### PR TITLE
Fix wrong VAT and tax ID in PDF templates.

### DIFF
--- a/application/views/invoice_templates/pdf/blue.php
+++ b/application/views/invoice_templates/pdf/blue.php
@@ -139,10 +139,10 @@
                             </h3>
                             <p class="text-right">
                                 <?php if ($invoice->user_vat_id) {
-                                    echo lang('vat_id_short') . ': ' . $invoice->client_vat_id . '<br/>';
+                                    echo lang('vat_id_short') . ': ' . $invoice->user_vat_id . '<br/>';
                                 } ?>
                                 <?php if ($invoice->user_tax_code) {
-                                    echo lang('tax_code_short') . ': ' . $invoice->client_tax_code . '<br/>';
+                                    echo lang('tax_code_short') . ': ' . $invoice->user_tax_code . '<br/>';
                                 } ?>
                                 <?php if ($invoice->user_address_1) {
                                     echo $invoice->user_address_1 . '<br/>';

--- a/application/views/invoice_templates/pdf/default-overdue.php
+++ b/application/views/invoice_templates/pdf/default-overdue.php
@@ -141,10 +141,10 @@
                             </h3>
                             <p class="text-right">
                                 <?php if ($invoice->user_vat_id) {
-                                    echo lang('vat_id_short') . ': ' . $invoice->client_vat_id . '<br/>';
+                                    echo lang('vat_id_short') . ': ' . $invoice->user_vat_id . '<br/>';
                                 } ?>
                                 <?php if ($invoice->user_tax_code) {
-                                    echo lang('tax_code_short') . ': ' . $invoice->client_tax_code . '<br/>';
+                                    echo lang('tax_code_short') . ': ' . $invoice->user_tax_code . '<br/>';
                                 } ?>
                                 <?php if ($invoice->user_address_1) {
                                     echo $invoice->user_address_1 . '<br/>';

--- a/application/views/invoice_templates/pdf/default-paid.php
+++ b/application/views/invoice_templates/pdf/default-paid.php
@@ -141,10 +141,10 @@
                             </h3>
                             <p class="text-right">
                                 <?php if ($invoice->user_vat_id) {
-                                    echo lang('vat_id_short') . ': ' . $invoice->client_vat_id . '<br/>';
+                                    echo lang('vat_id_short') . ': ' . $invoice->user_vat_id . '<br/>';
                                 } ?>
                                 <?php if ($invoice->user_tax_code) {
-                                    echo lang('tax_code_short') . ': ' . $invoice->client_tax_code . '<br/>';
+                                    echo lang('tax_code_short') . ': ' . $invoice->user_tax_code . '<br/>';
                                 } ?>
                                 <?php if ($invoice->user_address_1) {
                                     echo $invoice->user_address_1 . '<br/>';

--- a/application/views/invoice_templates/pdf/default.php
+++ b/application/views/invoice_templates/pdf/default.php
@@ -139,10 +139,10 @@
                             </h3>
                             <p class="text-right">
                                 <?php if ($invoice->user_vat_id) {
-                                    echo lang('vat_id_short') . ': ' . $invoice->client_vat_id . '<br/>';
+                                    echo lang('vat_id_short') . ': ' . $invoice->user_vat_id . '<br/>';
                                 } ?>
                                 <?php if ($invoice->user_tax_code) {
-                                    echo lang('tax_code_short') . ': ' . $invoice->client_tax_code . '<br/>';
+                                    echo lang('tax_code_short') . ': ' . $invoice->user_tax_code . '<br/>';
                                 } ?>
                                 <?php if ($invoice->user_address_1) {
                                     echo $invoice->user_address_1 . '<br/>';

--- a/application/views/invoice_templates/pdf/green.php
+++ b/application/views/invoice_templates/pdf/green.php
@@ -139,10 +139,10 @@
                             </h3>
                             <p class="text-right">
                                 <?php if ($invoice->user_vat_id) {
-                                    echo lang('vat_id_short') . ': ' . $invoice->client_vat_id . '<br/>';
+                                    echo lang('vat_id_short') . ': ' . $invoice->user_vat_id . '<br/>';
                                 } ?>
                                 <?php if ($invoice->user_tax_code) {
-                                    echo lang('tax_code_short') . ': ' . $invoice->client_tax_code . '<br/>';
+                                    echo lang('tax_code_short') . ': ' . $invoice->user_tax_code . '<br/>';
                                 } ?>
                                 <?php if ($invoice->user_address_1) {
                                     echo $invoice->user_address_1 . '<br/>';

--- a/application/views/invoice_templates/pdf/red.php
+++ b/application/views/invoice_templates/pdf/red.php
@@ -139,10 +139,10 @@
                             </h3>
                             <p class="text-right">
                                 <?php if ($invoice->user_vat_id) {
-                                    echo lang('vat_id_short') . ': ' . $invoice->client_vat_id . '<br/>';
+                                    echo lang('vat_id_short') . ': ' . $invoice->user_vat_id . '<br/>';
                                 } ?>
                                 <?php if ($invoice->user_tax_code) {
-                                    echo lang('tax_code_short') . ': ' . $invoice->client_tax_code . '<br/>';
+                                    echo lang('tax_code_short') . ': ' . $invoice->user_tax_code . '<br/>';
                                 } ?>
                                 <?php if ($invoice->user_address_1) {
                                     echo $invoice->user_address_1 . '<br/>';


### PR DESCRIPTION
Instead of the user's VAT and tax IDs, the ones for the client were used.
