### PR TITLE
Use country key instead of country value for user-country setting

### DIFF
--- a/application/modules/mailer/controllers/mailer.php
+++ b/application/modules/mailer/controllers/mailer.php
@@ -94,7 +94,12 @@ class Mailer extends Admin_Controller {
 
     public function send_invoice($invoice_id)
     {
-        if (!$this->mailer_configured) return;
+    	if ($this->input->post('btn_cancel'))
+    	{
+    		redirect('invoices');
+    	}
+    	
+    	if (!$this->mailer_configured) return;
 
         $from             = array($this->input->post('from_email'),
                                   $this->input->post('from_name'));
@@ -118,6 +123,11 @@ class Mailer extends Admin_Controller {
 
     public function send_quote($quote_id)
     {
+    	if ($this->input->post('btn_cancel'))
+    	{
+    		redirect('quotes');
+    	}
+    	
         if (!$this->mailer_configured) return;
 
         $from         = array($this->input->post('from_email'),

--- a/application/modules/mailer/controllers/mailer.php
+++ b/application/modules/mailer/controllers/mailer.php
@@ -94,12 +94,7 @@ class Mailer extends Admin_Controller {
 
     public function send_invoice($invoice_id)
     {
-    	if ($this->input->post('btn_cancel'))
-    	{
-    		redirect('invoices');
-    	}
-    	
-    	if (!$this->mailer_configured) return;
+        if (!$this->mailer_configured) return;
 
         $from             = array($this->input->post('from_email'),
                                   $this->input->post('from_name'));
@@ -123,11 +118,6 @@ class Mailer extends Admin_Controller {
 
     public function send_quote($quote_id)
     {
-    	if ($this->input->post('btn_cancel'))
-    	{
-    		redirect('quotes');
-    	}
-    	
         if (!$this->mailer_configured) return;
 
         $from         = array($this->input->post('from_email'),

--- a/application/modules/settings/views/partial_settings_general.php
+++ b/application/modules/settings/views/partial_settings_general.php
@@ -88,7 +88,7 @@
             <select name="settings[default_country]" class="input-sm form-control">
                 <option></option>
                 <?php foreach ($countries as $cldr => $country) { ?>
-                    <option value="<?php echo $country; ?>" <?php if ($this->mdl_settings->setting('default_country') == $country) { ?>selected="selected"<?php } ?>><?php echo $country ?></option>
+                    <option value="<?php echo $cldr; ?>" <?php if ($this->mdl_settings->setting('default_country') == $cldr) { ?>selected="selected"<?php } ?>><?php echo $country ?></option>
                 <?php } ?>
             </select>
         </div>

--- a/application/modules/users/models/mdl_users.php
+++ b/application/modules/users/models/mdl_users.php
@@ -90,7 +90,9 @@ class Mdl_Users extends Response_Model {
                 'field' => 'user_zip'
             ),
             'user_country'   => array(
-                'field' => 'user_country'
+                'field' => 'user_country',
+            	'label' => lang('user_country'),
+            	'rules' => 'required'
             ),
             'user_phone'     => array(
                 'field' => 'user_phone'
@@ -147,7 +149,9 @@ class Mdl_Users extends Response_Model {
                 'field' => 'user_zip'
             ),
             'user_country'   => array(
-                'field' => 'user_country'
+                'field' => 'user_country',
+                'label' => lang('user_country'),
+                'rules' => 'required'                       		
             ),
             'user_phone'     => array(
                 'field' => 'user_phone'

--- a/application/modules/users/views/form.php
+++ b/application/modules/users/views/form.php
@@ -196,7 +196,7 @@
                             <select name="user_country" id="user_country" class="form-control">
                                 <option></option>
                                 <?php foreach ($countries as $cldr => $country) { ?>
-                                    <option value="<?php echo $country; ?>" <?php if ($selected_country == $country) { ?>selected="selected"<?php } ?>><?php echo $country ?></option>
+                                    <option value="<?php echo $cldr; ?>" <?php if ($selected_country == $cldr) { ?>selected="selected"<?php } ?>><?php echo $country ?></option>
                                 <?php } ?>
                             </select>
                         </div>


### PR DESCRIPTION
Use the country code ($cldr key in $countries array) in the forms when setting the country option and saving it to the database so that it is unaffected by changes to the application language.