### PR TITLE
Do not send invoices/quotes when clicking the cancel button

### DIFF
--- a/application/modules/mailer/controllers/mailer.php
+++ b/application/modules/mailer/controllers/mailer.php
@@ -94,7 +94,12 @@ class Mailer extends Admin_Controller {
 
     public function send_invoice($invoice_id)
     {
-        if (!$this->mailer_configured) return;
+    	if ($this->input->post('btn_cancel'))
+    	{
+    		redirect('invoices');
+    	}
+    	
+    	if (!$this->mailer_configured) return;
 
         $from             = array($this->input->post('from_email'),
                                   $this->input->post('from_name'));
@@ -118,6 +123,11 @@ class Mailer extends Admin_Controller {
 
     public function send_quote($quote_id)
     {
+    	if ($this->input->post('btn_cancel'))
+    	{
+    		redirect('quotes');
+    	}
+    	
         if (!$this->mailer_configured) return;
 
         $from         = array($this->input->post('from_email'),


### PR DESCRIPTION
Fixes issue #140 "Invoice is sent even if you cancel the email form". Now the button clicked in the email form is checked, and when if the cancel button was clicked the user is sent back to the list of invoices or quotes.