### PR TITLE
Display type of email template in local language

### DIFF
--- a/application/modules/email_templates/views/form.php
+++ b/application/modules/email_templates/views/form.php
@@ -20,7 +20,7 @@
 
         <div class="form-group">
             <div class="col-xs-12 col-sm-2 text-right text-left-xs">
-                <label for="email_template_type" class="control-label"><?php echo "Type"; ?>: </label>
+                <label for="email_template_type" class="control-label"><?php echo lang('type'); ?>: </label>
             </div>
             <div class="col-xs-12 col-sm-6">
                 <label class="radio-inline">

--- a/application/modules/email_templates/views/index.php
+++ b/application/modules/email_templates/views/index.php
@@ -31,7 +31,7 @@
         <?php foreach ($email_templates as $email_template) { ?>
             <tr>
                 <td><?php echo $email_template->email_template_title; ?></td>
-                <td><?php echo $email_template->email_template_type; ?></td>
+                <td><?php echo lang($email_template->email_template_type); ?></td>
                 <td>
                     <div class="options btn-group">
                         <a class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" href="#"><i class="fa fa-cog"></i> <?php echo lang('options'); ?></a>


### PR DESCRIPTION
Minor fix to display in the local language: the label "type" in the email templates form, and the type of email template (invoice or quote) in the list of templates.
