### PR TITLE
Update Log.php

### DIFF
--- a/system/libraries/Log.php
+++ b/system/libraries/Log.php
@@ -37,6 +37,8 @@ class CI_Log {
 	 */
 	public function __construct()
 	{
+		// you should ask for it on the setup
+		date_default_timezone_set('Europe/Berlin');
 		$config =& get_config();
 
 		$this->_log_path = ($config['log_path'] != '') ? $config['log_path'] : APPPATH.'logs/';


### PR DESCRIPTION
To prevent getting errors like this:

A PHP Error was encountered
Severity: Warning

Message: date(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone.

Filename: libraries/Log.php