### PR TITLE
Fix issues with missing timezone

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -91,7 +91,7 @@ $config['charset'] = 'UTF-8';
 | setting this variable to TRUE (boolean).  See the user guide for details.
 |
 */
-$config['enable_hooks'] = FALSE;
+$config['enable_hooks'] = TRUE;
 
 
 /*

--- a/application/config/hooks.php
+++ b/application/config/hooks.php
@@ -9,7 +9,12 @@
 |	http://codeigniter.com/user_guide/general/hooks.html
 |
 */
-
+$hook['pre_controller'] = array(
+	'class'    => 'SetTimezoneClass',
+    'function' => 'setTimezone',
+    'filename' => 'SetTimezoneClass.php',
+    'filepath' => 'hooks'
+);
 
 
 /* End of file hooks.php */

--- a/application/hooks/SetTimezoneClass.php
+++ b/application/hooks/SetTimezoneClass.php
@@ -1,0 +1,7 @@
+<?php 
+class  SetTimezoneClass {
+	public function setTimezone()
+	{
+		date_default_timezone_set(date_default_timezone_get());
+	}
+}

--- a/application/language/english/ip_lang.php
+++ b/application/language/english/ip_lang.php
@@ -431,3 +431,7 @@ $lang['updatecheck_failed'] = 'Updatecheck failed! Check your network connection
 $lang['no_updates_available'] = 'No updates available.';
 
 $lang['please_enable_js'] = 'Please enable Javascript to use InvoicePlane';
+
+$lang['php_timezone_fail'] = 'There seems to be no timezone configured. Please check date.timezone in your php configuration. Otherwise <strong>%s</strong> will be selected.';
+$lang['php_timezone_success'] = 'A valid timezone is configured.';
+$lang['warning'] = 'Warning';

--- a/application/modules/setup/controllers/setup.php
+++ b/application/modules/setup/controllers/setup.php
@@ -339,11 +339,28 @@ class Setup extends MX_Controller {
                 'message' => sprintf(lang('php_version_fail'), $php_installed, $php_required),
                 'success' => 0
             );
+        } 
+        else 
+        {
+            $checks[] = array(
+                'message' => lang('php_version_success'),
+                'success' => 1
+            );
+        }
+
+        if (!ini_get('date.timezone'))
+        {
+            #$this->errors += 1;
+
+            $checks[] = array(
+                'message' => sprintf(lang('php_timezone_fail'), date_default_timezone_get()),
+                'warning' => 1
+            );
         }
         else
         {
             $checks[] = array(
-                'message' => lang('php_version_success'),
+                'message' => lang('php_timezone_success'),
                 'success' => 1
             );
         }

--- a/application/modules/setup/views/prerequisites.php
+++ b/application/modules/setup/views/prerequisites.php
@@ -14,6 +14,8 @@
                 <?php foreach ($basics as $basic) { ?>
                     <?php if ($basic['success']) { ?>
                     <p><span class="label label-success"><?php echo lang('success'); ?></span> <?php echo $basic['message']; ?></p>
+                    <?php } elseif($basic['warning']) { ?>
+                    <p><span class="label label-warning"><?php echo lang('warning'); ?></span> <?php echo $basic['message']; ?></p>
                     <?php } else { ?>
                     <p><span class="label label-danger"><?php echo lang('failure'); ?></span> <?php echo $basic['message']; ?></p>
                     <?php } ?>


### PR DESCRIPTION
fixes #32 and #154

During setup a warning is displayed if there is no date.timezone. It is still possible to continue setup without changing the settings

The hook is executed before the application controllers and sets date_default_timezone_set to date_default_timezone_get which returns UTC if there is no timezone set in ini, via ini_set or in server configuration (available to php). With ENVIRONMENT set to production a warning still appears in log.

![2015-01-16_18-44-45](https://cloud.githubusercontent.com/assets/4281150/5781551/f74208f4-9db3-11e4-8f9a-db8c9512c31f.png)

![2015-01-16_18-45-24](https://cloud.githubusercontent.com/assets/4281150/5781557/062292d0-9db4-11e4-8d2c-11c805ca2809.png)