### PR TITLE
Added missing by_product() method

### DIFF
--- a/application/modules/products/models/mdl_products.php
+++ b/application/modules/products/models/mdl_products.php
@@ -34,7 +34,7 @@ class Mdl_Products extends Response_Model {
     public function default_join()
     {
         $this->db->join('ip_families', 'ip_families.family_id = ip_products.family_id', 'left');
-        $this->db->join('ip_tax_rates', 'ip_tax_rates.tax_rate_id = ip_products.tax_rate_id', 'left');
+        //$this->db->join('ip_tax_rates', 'ip_tax_rates.tax_rate_id = ip_products.tax_rate_id', 'left');
     }
 
 	public function by_product($match)

--- a/application/modules/products/models/mdl_products.php
+++ b/application/modules/products/models/mdl_products.php
@@ -37,6 +37,13 @@ class Mdl_Products extends Response_Model {
         $this->db->join('ip_tax_rates', 'ip_tax_rates.tax_rate_id = ip_products.tax_rate_id', 'left');
     }
 
+	public function by_product($match)
+	{
+		$this->db->like('product_sku', $match);
+		$this->db->or_like('product_name', $match); 
+		$this->db->or_like('product_description', $match); 
+	}
+	
     public function validation_rules()
     {
         return array(
@@ -53,7 +60,7 @@ class Mdl_Products extends Response_Model {
             'product_description' => array(
                 'field' => 'product_description',
                 'label' => lang('product_description'),
-                'rules' => 'required'
+                'rules' => ''
             ),
             'product_price' => array(
                 'field' => 'product_price',
@@ -63,7 +70,7 @@ class Mdl_Products extends Response_Model {
             'purchase_price' => array(
                 'field' => 'purchase_price',
                 'label' => lang('purchase_price'),
-                'rules' => 'required'
+                'rules' => ''
             ),
             'family_id' => array(
                 'field' => 'family_id',

--- a/application/modules/products/views/modal_product_lookups.php
+++ b/application/modules/products/views/modal_product_lookups.php
@@ -105,6 +105,7 @@
             <div class="table-responsive">
                 <table id="products_table" class="table table-bordered table-striped">
                     <tr>
+                        <th>&nbsp;</th>
                         <th><?php echo lang('product_sku'); ?></th>
                         <th><?php echo lang('family_name'); ?></th>
                         <th><?php echo lang('product_name'); ?></th>
@@ -116,6 +117,8 @@
                             <td class="text-left">
                                 <input type="checkbox" name="product_ids[]"
                                        value="<?php echo $product->product_id; ?>">
+                            </td>
+                            <td nowrap class="text-left">
                                 <b><?php echo $product->product_sku; ?></b>
                             </td>
                             <td>

--- a/application/modules/products/views/modal_product_lookups.php
+++ b/application/modules/products/views/modal_product_lookups.php
@@ -21,7 +21,7 @@
 
                 for(var key in items) {
                     if ($('#item_table tr:last input[name=item_name]').val() !== '') {
-                        $('#new_item').clone().appendTo('#item_table').removeAttr('id').addClass('item').show();
+						$('#new_row').clone().appendTo('#item_table').removeAttr('id').addClass('item').show();
                     }
                     $('#item_table tr:last input[name=item_name]').val(items[key].product_name);
                     $('#item_table tr:last textarea[name=item_description]').val(items[key].product_description);
@@ -30,6 +30,7 @@
                     $('#item_table tr:last select[name=item_tax_rate_id]').val(items[key].tax_rate_id);
 
                     $('#modal-choose-items').modal('hide');
+					console.log(items[key].tax_rate_id);
                 }
             });
         });


### PR DESCRIPTION
Fixed IP-175
- removed default_join for tax rates
- fixed new row id from products modal

Fix for IP-176:
 - moved checkbox to a new column …

Fix for IP-177:
 - added missing by_product() method in mdl_products
 - product_description is no longer required
 - purchase_price is no longer required