### PR TITLE
€ symbol, quarter (small correction)

### DIFF
--- a/application/views/reports/sales_by_year.php
+++ b/application/views/reports/sales_by_year.php
@@ -69,12 +69,12 @@
 			 	 <tr>
 				 	<td style="border-bottom: none;">&nbsp;</td>
 			 		<td style="border-bottom: none;text-align:center;"><?php 
-			 		 if($quarter=="t1") echo lang('Q1')."-".$year;
-			 		 else if($quarter=="t2") echo lang('Q2')."-".$year;
-			 		 else if($quarter=="t3") echo lang('Q3')."-".$year;
-			 		 else if($quarter=="t4") echo lang('Q4')."-".$year;
+			 		 if($quarter=="t1") echo lang('Q1')."/".$year;
+			 		 else if($quarter=="t2") echo lang('Q2')."/".$year;
+			 		 else if($quarter=="t3") echo lang('Q3')."/".$year;
+			 		 else if($quarter=="t4") echo lang('Q4')."/".$year;
 			 		?></td>
-			 		<td style="border-bottom: none;text-align:center;"><?php if($value>0){echo format_currency($value); echo " €";} ?>></td>
+			 		<td style="border-bottom: none;text-align:center;"><?php if($value>0){echo format_currency($value);} ?></td>
 			 	</tr>
 			 	
 			 <?php 


### PR DESCRIPTION
Not need to add € symbol when using format_currency function. 

Quarter could be written with space or slash (but no hyphen). See http://financial-dictionary.thefreedictionary.com/quarter. I prefer slash, because of it menas "of" (like 1st quarter of year...) more than space.