### PR TITLE
Remove hardcoded euro symbol from Sales by Date

### DIFF
--- a/application/views/reports/sales_by_year.php
+++ b/application/views/reports/sales_by_year.php
@@ -53,7 +53,7 @@
 				<td style="border-bottom: none;text-align:center;"> <?php echo $result->VAT_ID; ?> </td>
 				<td style="border-bottom: none;text-align:center;" rowspan="<?php echo $numRows; ?>" valign="top"> <?php echo $result->Name; ?> </td>
 				<td style="border-bottom: none;text-align:center;"> <?php echo lang('annual'); ?> </td>
-				<td style="border-bottom: none;text-align:center;"> <?php echo format_currency($result->total_payment); echo" €"?> </td>
+				<td style="border-bottom: none;text-align:center;"> <?php echo format_currency($result->total_payment); ?> </td>
 			</tr>
 			
 			<?php


### PR DESCRIPTION
The Sales by Date report contains a hardcoded Euro symbol instead of relying on the format_currency function:
![screenshot from 2015-04-12 10 16 19](https://cloud.githubusercontent.com/assets/1688580/7104876/6a7a23ba-e0fd-11e4-80dc-e576d0c0caba.png)