### PR TITLE
Fixes relative link of the 'overdue invoices' dashboard panel.

### DIFF
--- a/application/modules/dashboard/views/index.php
+++ b/application/modules/dashboard/views/index.php
@@ -103,9 +103,7 @@
                 }
                 ?>
                 <div class="panel panel-danger panel-heading">
-                    <a href="/invoices/status/overdue" class="text-danger">
-                        <i class="fa fa-external-link"></i> <?php echo lang('overdue_invoices'); ?>
-                    </a>
+                    <?php echo anchor('invoices/status/overdue', '<i class="fa fa-external-link"></i> '.lang('overdue_invoices'), 'class="text-danger"'); ?>
                     <span class="pull-right text-danger">
                         <?php echo format_currency($overdue_invoices_total); ?>
                     </span>


### PR DESCRIPTION
The link was broken if IP was run from a subdirectory of the domain (e.g. http://example.com/ip/).
Now it uses the `anchor` function that properly appends the url prefix to the link.

I hope this is the right branch since I couldn't find a `hotfix` branch for patch releases.