### PR TITLE
Added new functionality: Default payment mode for invoices

### DIFF
--- a/application/language/english/ip_lang.php
+++ b/application/language/english/ip_lang.php
@@ -95,6 +95,7 @@ $lang = array(
     'default_item_tax_rate' => 'Default Item Tax Rate',
     'default_list_limit' => 'Number of Items in Lists',
     'default_notes' => 'Default Notes',
+    'default_payment_mode' => 'Default payment form',
     'default_pdf_template' => 'Default PDF Template',
     'default_public_template' => 'Default Public Template',
     'default_quote_group' => 'Default Quote Group',

--- a/application/modules/invoices/models/mdl_invoices.php
+++ b/application/modules/invoices/models/mdl_invoices.php
@@ -286,6 +286,7 @@ class Mdl_Invoices extends Response_Model
         $db_array['invoice_date_due'] = $this->get_date_due($db_array['invoice_date_created']);
         $db_array['invoice_number'] = $this->get_invoice_number($db_array['invoice_group_id']);
         $db_array['invoice_terms'] = $this->mdl_settings->setting('default_invoice_terms');
+	$db_array['payment_method'] = $this->mdl_settings->setting('default_payment_mode');
 
         if (!isset($db_array['invoice_status_id'])) {
             $db_array['invoice_status_id'] = 1;

--- a/application/modules/settings/views/partial_settings_invoices.php
+++ b/application/modules/settings/views/partial_settings_invoices.php
@@ -42,6 +42,22 @@
     </div>
 
     <div class="form-group">
+        <label for="settings[default_payment_mode]" class="control-label">
+            <?php echo lang('default_payment_mode'); ?>
+        </label>
+       
+        <select name="settings[default_payment_mode]" id="payment_method" class="form-control input-sm">
+		   <option value=""><?php echo lang('select_payment_method');?></option> 
+		        <?php foreach ($payment_methods as $payment_method) { ?>
+		        <option <?php if($this->mdl_settings->setting('default_payment_mode') == $payment_method->payment_method_id) echo "selected" ?> 
+		        		value="<?php echo $payment_method->payment_method_id; ?>">
+		                <?php echo $payment_method->payment_method_name; ?>
+		        </option>
+		                <?php } ?>
+		 </select>
+    </div>
+
+    <div class="form-group">
         <label for="settings[default_invoice_terms]">
             <?php echo lang('default_terms'); ?>
         </label>


### PR DESCRIPTION
Now you can select a default payment mode only for invoices. When you create a new invoice, it will has the default payment mode set up.