### PR TITLE
IP-287 - “Create product” without a valid “Family” throws SQL/PHP error

### DIFF
--- a/application/modules/products/models/mdl_products.php
+++ b/application/modules/products/models/mdl_products.php
@@ -75,12 +75,12 @@ class Mdl_Products extends Response_Model
             'family_id' => array(
                 'field' => 'family_id',
                 'label' => lang('family'),
-                'rules' => ''
+                'rules' => 'numeric'
             ),
             'tax_rate_id' => array(
                 'field' => 'tax_rate_id',
                 'label' => lang('tax_rate'),
-                'rules' => ''
+                'rules' => 'numeric'
             ),
 
         );

--- a/application/modules/products/views/form.php
+++ b/application/modules/products/views/form.php
@@ -27,7 +27,7 @@
                         </div>
                         <div class="col-xs-12 col-sm-8 col-lg-8">
                             <select name="family_id" id="family_id" class="form-control">
-                                <option value=""><?php echo lang('select_family'); ?></option>
+                                <option value="0"><?php echo lang('select_family'); ?></option>
                                 <?php foreach ($families as $family) { ?>
                                     <option value="<?php echo $family->family_id; ?>"
                                             <?php if ($this->mdl_products->form_value('family_id') == $family->family_id) { ?>selected="selected"<?php } ?>><?php echo $family->family_name; ?></option>
@@ -86,7 +86,10 @@
                                 <?php foreach ($tax_rates as $tax_rate) { ?>
                                     <option value="<?php echo $tax_rate->tax_rate_id; ?>"
                                         <?php if ($this->mdl_products->form_value('tax_rate_id') == $tax_rate->tax_rate_id) { ?> selected="selected" <?php } ?>
-                                        ><?php echo $tax_rate->tax_rate_name; ?></option>
+                                        >
+                                        <?php echo $tax_rate->tax_rate_name
+                                            . ' (' . format_amount($tax_rate->tax_rate_percent) . '%)'; ?>
+                                    </option>
                                 <?php } ?>
                             </select>
                         </div>


### PR DESCRIPTION
Also optimized the tax rate displaying.