### PR TITLE
Error in total discount calculation

### DIFF
--- a/application/modules/invoices/controllers/invoices.php
+++ b/application/modules/invoices/controllers/invoices.php
@@ -99,8 +99,8 @@ class Invoices extends Admin_Controller
     public function download($invoice)
     {
         header('Content-type: application/pdf');
-        header('Content-Disposition: attachment; filename="' . $invoice . '"');
-        readfile('./uploads/archive/' . $invoice);
+        header('Content-Disposition: attachment; filename='.basename($invoice));
+        readfile('./uploads/archive/' . urldecode(basename($invoice)));
     }
 
     public function view($invoice_id)


### PR DESCRIPTION
Hello,

I added a code to display the discount in templates of quotes and invoices, but the calculation of the total discount is wrong and I'm not able to fix this error (I tried many many times to fix it).

**The discount should be calculated before all taxes**, or an user should be able to choose whether to apply it before or after.

I can share my edited file that shows the discount in templates, but before it should be fixed.

I think that this error is in the following files: *mdl_invoice_amounts.php* and *mdl_quote_amounts.php*

The issue is in 

```public function calculate_invoice_taxes```
and/or
```public function calculate_quote_taxes```

because it calculate amount without the total discount and in

```public function calculate_discount```

because it is calculated after "taxes function" with the total item + taxes and not only with the total item.

I hope this is the correct way to post a problem here. Thank you in advance!

