### PR TITLE
fix logo upload image width/height proportions

### DIFF
--- a/assets/default/sass/_upload.scss
+++ b/assets/default/sass/_upload.scss
@@ -40,8 +40,8 @@ div.table .file-row:nth-child(odd) {
     display: none;
 }
 img{
-    width:80px;
-    height: 80px;
+    max-width: 80px;
+    max-height: 80px;
 }
 /* Hide the start and cancel buttons and show the delete button */
 


### PR DESCRIPTION
No matter how the proportions of the logo were, it was always displayed as fixed 80x80px - this looked distorted if the logo is e.g. 200x40px.