### PR TITLE
Introducing variables in item description

### DIFF
--- a/application/helpers/pdf_helper.php
+++ b/application/helpers/pdf_helper.php
@@ -38,7 +38,7 @@ function generate_invoice_pdf($invoice_id, $stream = TRUE, $invoice_template = N
     $data = array(
         'invoice' => $invoice,
         'invoice_tax_rates' => $CI->mdl_invoice_tax_rates->where('invoice_id', $invoice_id)->get()->result(),
-        'items' => $CI->mdl_items->where('invoice_id', $invoice_id)->get()->result(),
+        'items' => $CI->mdl_items->get_items_and_replace_vars($invoice_id),
         'payment_method' => $payment_method,
         'output_type' => 'pdf'
     );

--- a/application/modules/guest/controllers/invoices.php
+++ b/application/modules/guest/controllers/invoices.php
@@ -74,7 +74,7 @@ class Invoices extends Guest_Controller
         $this->layout->set(
             array(
                 'invoice' => $invoice,
-                'items' => $this->mdl_items->where('invoice_id', $invoice_id)->get()->result(),
+                'items' => $this->mdl_items->get_items_and_replace_vars($invoice_id),
                 'invoice_tax_rates' => $this->mdl_invoice_tax_rates->where('invoice_id', $invoice_id)->get()->result(),
                 'invoice_id' => $invoice_id
             )

--- a/application/modules/guest/controllers/view.php
+++ b/application/modules/guest/controllers/view.php
@@ -40,7 +40,7 @@ class View extends Base_Controller
 
             $data = array(
                 'invoice' => $invoice,
-                'items' => $this->mdl_items->where('invoice_id', $invoice->invoice_id)->get()->result(),
+                'items' => $this->mdl_items->get_items_and_replace_vars($invoice->invoice_id),
                 'invoice_tax_rates' => $this->mdl_invoice_tax_rates->where('invoice_id', $invoice->invoice_id)->get()->result(),
                 'invoice_url_key' => $invoice_url_key,
                 'flash_message' => $this->session->flashdata('flash_message'),

--- a/application/modules/invoices/controllers/invoices.php
+++ b/application/modules/invoices/controllers/invoices.php
@@ -142,7 +142,7 @@ class Invoices extends Admin_Controller
         $this->layout->set(
             array(
                 'invoice' => $invoice,
-                'items' => $this->mdl_items->where('invoice_id', $invoice_id)->get()->result(),
+                'items' => $this->mdl_items->get_items_and_replace_vars($invoice_id),
                 'invoice_id' => $invoice_id,
                 'tax_rates' => $this->mdl_tax_rates->get()->result(),
                 'invoice_tax_rates' => $this->mdl_invoice_tax_rates->where('invoice_id', $invoice_id)->get()->result(),

--- a/application/modules/invoices/controllers/invoices.php
+++ b/application/modules/invoices/controllers/invoices.php
@@ -142,7 +142,7 @@ class Invoices extends Admin_Controller
         $this->layout->set(
             array(
                 'invoice' => $invoice,
-                'items' => $this->mdl_items->get_items_and_replace_vars($invoice_id),
+                'items' => $this->mdl_items->where('invoice_id', $invoice_id)->get()->result(),
                 'invoice_id' => $invoice_id,
                 'tax_rates' => $this->mdl_tax_rates->get()->result(),
                 'invoice_tax_rates' => $this->mdl_invoice_tax_rates->where('invoice_id', $invoice_id)->get()->result(),

--- a/application/modules/invoices/models/mdl_invoices.php
+++ b/application/modules/invoices/models/mdl_invoices.php
@@ -208,7 +208,7 @@ class Mdl_Invoices extends Response_Model
     {
         $this->load->model('invoices/mdl_items');
 
-        $invoice_items = $this->mdl_items->where('invoice_id', $source_id)->get()->result();
+        $invoice_items = $this->mdl_items->get_items_and_replace_vars($source_id);
 
         foreach ($invoice_items as $invoice_item) {
             $db_array = array(
@@ -247,7 +247,7 @@ class Mdl_Invoices extends Response_Model
     {
         $this->load->model('invoices/mdl_items');
 
-        $invoice_items = $this->mdl_items->where('invoice_id', $source_id)->get()->result();
+        $invoice_items = $this->mdl_items->get_items_and_replace_vars($source_id);
 
         foreach ($invoice_items as $invoice_item) {
             $db_array = array(

--- a/application/modules/invoices/models/mdl_items.php
+++ b/application/modules/invoices/models/mdl_items.php
@@ -28,11 +28,30 @@ class Mdl_Items extends Response_Model
 		 $query = $this->where('invoice_id', $invoice_id)->get();
 
 		 foreach($query->result() as $item) {
-			 $item->item_description = str_replace('{{{nextYear}}}', date('Y') + 1, $item->item_description);
+			 $item->item_description = $this->parse_item($item->item_description);
 			 $items[] = $item;
 		 }
 		 return $items;
 	 }
+
+    private function parse_item($string)
+    {
+        if (preg_match_all('/{{{([^{|}]*)}}}/', $string, $template_vars)) {
+            foreach ($template_vars[1] as $var) {
+                switch ($var) {
+                    case 'nextYear':
+                        $replace = date('Y') + 1;
+                        break;
+                    default:
+                        $replace = '';
+                }
+
+                $string = str_replace('{{{' . $var . '}}}', $replace, $string);
+            }
+        }
+
+        return $string;
+    }
 
     public function default_select()
     {

--- a/application/modules/invoices/models/mdl_items.php
+++ b/application/modules/invoices/models/mdl_items.php
@@ -22,6 +22,18 @@ class Mdl_Items extends Response_Model
     public $primary_key = 'ip_invoice_items.item_id';
     public $date_created_field = 'item_date_added';
 
+	 public function get_items_and_replace_vars($invoice_id)
+	 {
+		 $items = array();
+		 $query = $this->where('invoice_id', $invoice_id)->get();
+
+		 foreach($query->result() as $item) {
+			 $item->item_description = str_replace('{{{nextYear}}}', date('Y') + 1, $item->item_description);
+			 $items[] = $item;
+		 }
+		 return $items;
+	 }
+
     public function default_select()
     {
         $this->db->select('ip_invoice_item_amounts.*, ip_invoice_items.*, item_tax_rates.tax_rate_percent AS item_tax_rate_percent');


### PR DESCRIPTION
This is my first pull request on GitHub, so bare with me if I'm making mistakes :)
I checked the code if you have a common code for replace variables, but couldn't find one.
Tried to replace variables like the other modules do.

Supported variables:
- Only {{{nextYear}}} is supported

This could be handy for recurring invoices.
For example: <i>Hosting of example.com until August <b>{{{nextYear}}</b></i>
Every year the recurring invoice will contain a item with a description for the next year.

Future variables could be:
- {{{nextWeek}}}
- {{{nextMonth}}}