### PR TITLE
IP-318

### DIFF
--- a/application/helpers/pdf_helper.php
+++ b/application/helpers/pdf_helper.php
@@ -38,7 +38,7 @@ function generate_invoice_pdf($invoice_id, $stream = TRUE, $invoice_template = N
     $data = array(
         'invoice' => $invoice,
         'invoice_tax_rates' => $CI->mdl_invoice_tax_rates->where('invoice_id', $invoice_id)->get()->result(),
-        'items' => $CI->mdl_items->where('invoice_id', $invoice_id)->get()->result(),
+		  'items' => $CI->mdl_items->get_items_and_replace_vars($invoice_id, $invoice->invoice_date_created),
         'payment_method' => $payment_method,
         'output_type' => 'pdf'
     );

--- a/application/modules/guest/controllers/view.php
+++ b/application/modules/guest/controllers/view.php
@@ -40,7 +40,7 @@ class View extends Base_Controller
 
             $data = array(
                 'invoice' => $invoice,
-                'items' => $this->mdl_items->where('invoice_id', $invoice->invoice_id)->get()->result(),
+					 'items' => $this->mdl_items->get_items_and_replace_vars($invoice->invoice_id),
                 'invoice_tax_rates' => $this->mdl_invoice_tax_rates->where('invoice_id', $invoice->invoice_id)->get()->result(),
                 'invoice_url_key' => $invoice_url_key,
                 'flash_message' => $this->session->flashdata('flash_message'),

--- a/application/modules/invoices/models/mdl_invoices.php
+++ b/application/modules/invoices/models/mdl_invoices.php
@@ -208,7 +208,7 @@ class Mdl_Invoices extends Response_Model
     {
         $this->load->model('invoices/mdl_items');
 
-        $invoice_items = $this->mdl_items->where('invoice_id', $source_id)->get()->result();
+		  $invoice_items = $this->mdl_items->where('invoice_id', $source_id)->get()->result();
 
         foreach ($invoice_items as $invoice_item) {
             $db_array = array(
@@ -247,7 +247,7 @@ class Mdl_Invoices extends Response_Model
     {
         $this->load->model('invoices/mdl_items');
 
-        $invoice_items = $this->mdl_items->where('invoice_id', $source_id)->get()->result();
+		  $invoice_items = $this->mdl_items->where('invoice_id', $source_id)->get()->result();
 
         foreach ($invoice_items as $invoice_item) {
             $db_array = array(

--- a/application/modules/invoices/models/mdl_items.php
+++ b/application/modules/invoices/models/mdl_items.php
@@ -28,6 +28,7 @@ class Mdl_Items extends Response_Model
 		 $query = $this->where('invoice_id', $invoice_id)->get();
 
 		 foreach($query->result() as $item) {
+			 $item->item_name = $this->parse_item($item->item_description, $invoice_date_created);
 			 $item->item_description = $this->parse_item($item->item_description, $invoice_date_created);
 			 $items[] = $item;
 		 }

--- a/application/modules/invoices/models/mdl_items.php
+++ b/application/modules/invoices/models/mdl_items.php
@@ -28,7 +28,7 @@ class Mdl_Items extends Response_Model
 		 $query = $this->where('invoice_id', $invoice_id)->get();
 
 		 foreach($query->result() as $item) {
-			 $item->item_name = $this->parse_item($item->item_description, $invoice_date_created);
+			 $item->item_name = $this->parse_item($item->item_name, $invoice_date_created);
 			 $item->item_description = $this->parse_item($item->item_description, $invoice_date_created);
 			 $items[] = $item;
 		 }

--- a/application/modules/invoices/models/mdl_items.php
+++ b/application/modules/invoices/models/mdl_items.php
@@ -22,6 +22,49 @@ class Mdl_Items extends Response_Model
     public $primary_key = 'ip_invoice_items.item_id';
     public $date_created_field = 'item_date_added';
 
+	 public function get_items_and_replace_vars($invoice_id, $invoice_date_created = 'now')
+	 {
+		 $items = array();
+		 $query = $this->where('invoice_id', $invoice_id)->get();
+
+		 foreach($query->result() as $item) {
+			 $item->item_description = $this->parse_item($item->item_description, $invoice_date_created);
+			 $items[] = $item;
+		 }
+		 return $items;
+	 }
+
+    private function parse_item($string, $invoice_date_created)
+    {
+        if (preg_match_all('/{{{(?<format>[yYmMdD])(?:(?<=[Yy])ear|(?<=[Mm])onth|(?<=[Dd])ay)(?:(?<operation>[-+])(?<amount>[1-9]+))?}}}/m', $string, $template_vars, PREG_SET_ORDER)) {
+			  try {
+				$formattedDate = new DateTime($invoice_date_created);
+			  }
+			  catch(Exception $e) { // If creating a date based on the invoice_date_created isn't possible, use current date
+				$formattedDate = new DateTime();
+			  }
+
+			  /* Calculate the date first, before starting replacing the variables */
+			  foreach($template_vars as $var) {
+				  if(!isset($var['operation'], $var['amount'])) continue;
+
+				  if($var['operation'] == '-') {
+					  $formattedDate->sub( new DateInterval('P' . $var['amount'] . strtoupper($var['format'])) );
+				  }
+				  else if($var['operation'] == '+') {
+					  $formattedDate->add( new DateInterval('P' . $var['amount'] . strtoupper($var['format'])) );
+				  }
+			  }
+
+			  /* Let's replace all variables */
+			  foreach($template_vars as $var) {
+				  $string = str_replace($var[0], $formattedDate->format($var['format']), $string);
+			  }
+        }
+
+        return $string;
+    }
+
     public function default_select()
     {
         $this->db->select('ip_invoice_item_amounts.*, ip_invoice_items.*, item_tax_rates.tax_rate_percent AS item_tax_rate_percent');


### PR DESCRIPTION
Added support for variables in item name/description.

Concept is based on marneu's idea: https://github.com/InvoicePlane/InvoicePlane/pull/260#issuecomment-122764367
https://community.invoiceplane.com/t/make-recurring-invoices-more-flexible-with-vars-like-month/1261

Supported variables:
- {{{(Y|y)ear}}}
- {{{(M|m)onth}}}
- {{{(D|d)ay}}}

You can add years/months/days to a variable.
For example, let's say the invoice creation date is 1-Jan-2015.

Your product description is "Hosting until {{month+2}}}-{{{Year+1}}}"
This will become: "Hosting until 03-2016"

The date is always based on the invoice_created_date, so the output stays always the same no matter when the PDF is generated.