### PR TITLE
Add (disabled) option to force HTTPS access

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,3 +4,7 @@ RewriteBase /
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule . index.php [L]
+
+# Enable the following if you want to force HTTPS access:
+#RewriteCond %{SERVER_PORT} 80
+#RewriteRule ^(.*)$ https://%{HTTP_HOST}/$1 [R,L]


### PR DESCRIPTION
It's much more convenient if you just need to remove some comment hashs.