### PR TITLE
Updated 404 Page

### DIFF
--- a/application/errors/error_404.php
+++ b/application/errors/error_404.php
@@ -1,62 +1,69 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<title>404 Page Not Found</title>
-<style type="text/css">
-
-::selection{ background-color: #E13300; color: white; }
-::moz-selection{ background-color: #E13300; color: white; }
-::webkit-selection{ background-color: #E13300; color: white; }
-
-body {
-	background-color: #fff;
-	margin: 40px;
-	font: 13px/20px normal Helvetica, Arial, sans-serif;
-	color: #4F5155;
-}
-
-a {
-	color: #003399;
-	background-color: transparent;
-	font-weight: normal;
-}
-
-h1 {
-	color: #444;
-	background-color: transparent;
-	border-bottom: 1px solid #D0D0D0;
-	font-size: 19px;
-	font-weight: normal;
-	margin: 0 0 14px 0;
-	padding: 14px 15px 10px 15px;
-}
-
-code {
-	font-family: Consolas, Monaco, Courier New, Courier, monospace;
-	font-size: 12px;
-	background-color: #f9f9f9;
-	border: 1px solid #D0D0D0;
-	color: #002166;
-	display: block;
-	margin: 14px 0 14px 0;
-	padding: 12px 10px 12px 10px;
-}
-
-#container {
-	margin: 10px;
-	border: 1px solid #D0D0D0;
-	-webkit-box-shadow: 0 0 8px #D0D0D0;
-}
-
-p {
-	margin: 12px 15px 12px 15px;
-}
-</style>
-</head>
-<body>
-	<div id="container">
-		<h1><?php echo $heading; ?></h1>
-		<?php echo $message; ?>
-	</div>
-</body>
+    <head>
+        <meta charset="utf-8">
+        <title>Page Not Found - InvoicePlane</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style type="text/css">
+            
+            * {
+                line-height: 1.2;
+                margin: 0;
+            }
+            
+            html {
+                color: #777;
+                display: table;
+                font-family: sans-serif;
+                height: 100%;
+                text-align: center;
+                width: 100%;
+            }
+            
+            body {
+                display: table-cell;
+                vertical-align: middle;
+                margin: 2em auto;
+            }
+            
+            h1 {
+                color: #333;
+                font-size: 2em;
+                font-weight: 400;
+            }
+            
+            p {
+                margin: 0 auto;
+                width: 280px;
+            }
+            
+            code {
+            	font-family: Consolas, Monaco, Courier New, Courier, monospace;
+            	background-color: #f9f9f9;
+            	border: 1px solid #eee;
+            	color: #555;
+            	display: inline-block;
+            	margin: 1em;
+            	padding: .5em .75em;
+            	border-radius: 6px;
+            }
+            
+            @media only screen and (max-width: 280px) {
+            
+                body, p {
+                    width: 95%;
+                }
+            
+                h1 {
+                    font-size: 1.5em;
+                    margin: 0 0 0.3em;
+                }
+            
+            }
+        </style>
+    </head>
+    <body>
+        <h1><?php echo $heading; ?></h1>
+        <?php echo $message; ?>
+    </body>
 </html>


### PR DESCRIPTION
An updated 404 error page. Cleaner, simpler with no container.
- Now responsive + viewport set.
- Removed ‘404’ from the page title. No need for this, users just need
to know that the page was not found. The number is a side note.
- Added ‘InvoicePlane’ to the title, so that the user knows its apart
of the InvoicePlane environment.
- Updated the ‘code’ element styling to be a bit simpler. I wasn’t sure
if this was actually needed, as I only see ‘p’ tags coming through.