### PR TITLE
Fix: Email PDF attachement now global

### DIFF
--- a/application/modules/settings/views/partial_settings_email.php
+++ b/application/modules/settings/views/partial_settings_email.php
@@ -110,20 +110,20 @@
                     <?php if ($this->mdl_settings->setting('smtp_security') == 'tls') { ?>selected="selected"<?php } ?>><?php echo lang('smtp_tls'); ?></option>
         </select>
     </div>
+</div>
 
-    <div class="form-group">
-        <label for="settings[email_pdf_attachment]">
-            <?php echo lang('email_pdf_attachment'); ?>
-        </label>
-        <select name="settings[email_pdf_attachment]" class="input-sm form-control">
-            <option value="0"
-                    <?php if (!$this->mdl_settings->setting('email_pdf_attachment')) { ?>selected="selected"<?php } ?>>
-                <?php echo lang('no'); ?>
-            </option>
-            <option value="1"
-                    <?php if ($this->mdl_settings->setting('email_pdf_attachment')) { ?>selected="selected"<?php } ?>>
-                <?php echo lang('yes'); ?>
-            </option>
-        </select>
-    </div>
+<div class="form-group">
+    <label for="settings[email_pdf_attachment]">
+        <?php echo lang('email_pdf_attachment'); ?>
+    </label>
+    <select name="settings[email_pdf_attachment]" class="input-sm form-control">
+        <option value="0"
+                <?php if (!$this->mdl_settings->setting('email_pdf_attachment')) { ?>selected="selected"<?php } ?>>
+            <?php echo lang('no'); ?>
+        </option>
+        <option value="1"
+                <?php if ($this->mdl_settings->setting('email_pdf_attachment')) { ?>selected="selected"<?php } ?>>
+            <?php echo lang('yes'); ?>
+        </option>
+    </select>
 </div>


### PR DESCRIPTION
Moved email pdf attachment setting (HTML) out of SMTP tab/section and made it a global email setting. The setting already applies to all email methods (in the backend), its just that it was tucked away in the SMTP tab on the frontend.

I've tested this and the setting applies to phpmail, sendmail, and smtp.