### PR TITLE
Fixed syntax error in clients form

### DIFF
--- a/application/modules/clients/views/form.php
+++ b/application/modules/clients/views/form.php
@@ -196,7 +196,6 @@
 
                                 <div class="controls">
                                     <?php switch ($custom_field->custom_field_type) : ?>
-
 <?php case 'ip_fieldtype_input': ?>
                                             <input type="text" class="form-control"
                                                    name="custom[<?php echo $custom_field->custom_field_column; ?>]"


### PR DESCRIPTION
If you're using switches with colons, you're not allowed to keep a space between the switch and the case.
This will cause syntax errors, like these:
PHP Parse error: syntax error, unexpected '', expecting endswitch (T_ENDSWITCH) or case (T_CASE) or default (T_DEFAULT) in form.php on line 200

See http://php.net/manual/en/control-structures.alternative-syntax.php