### PR TITLE
IP-317 - Removed PayPal and Stripe from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,5 @@
 {
     "require": {
-        "omnipay/omnipay": "^2.3",
-        "omnipay/paypal": "^2.4",
-        "omnipay/stripe": "^2.2"
+        "omnipay/omnipay": "^2.3"
     }
 }


### PR DESCRIPTION
Removed PayPal and Stripe from composer.json as they are already included in omnipay/omnipay