### PR TITLE
IP-360 - Implemented mPDF template file

### DIFF
--- a/application/helpers/mpdf_helper.php
+++ b/application/helpers/mpdf_helper.php
@@ -17,16 +17,15 @@ if (!defined('BASEPATH')) {
  * 
  */
 
-function pdf_create($html, $filename, $stream = true, $password = null, $isInvoice = null, $isGuest = null)
+function pdf_create($html, $filename, $stream = true, $password = null, $isInvoice = null, $isGuest = null, $baseTemplate = null)
 {
     require_once(APPPATH . 'helpers/mpdf/mpdf.php');
 
     $mpdf = new mPDF();
 
-    $base_template = './uploads/pdf_base.pdf';
-    if (file_exists($base_template)) {
+    if (!empty($baseTemplate) && file_exists('./uploads/'.$baseTemplate)) {
         $mpdf->SetImportUse();
-        $mpdf->SetSourceFile($base_template);
+        $mpdf->SetSourceFile('./uploads/'.$baseTemplate);
         $base = $mpdf->ImportPage(1);
         $mpdf->SetPageTemplate($base);
     }

--- a/application/helpers/mpdf_helper.php
+++ b/application/helpers/mpdf_helper.php
@@ -22,6 +22,15 @@ function pdf_create($html, $filename, $stream = true, $password = null, $isInvoi
     require_once(APPPATH . 'helpers/mpdf/mpdf.php');
 
     $mpdf = new mPDF();
+
+    $base_template = './uploads/pdf_base.pdf';
+    if (file_exists($base_template)) {
+        $mpdf->SetImportUse();
+        $mpdf->SetSourceFile($base_template);
+        $base = $mpdf->ImportPage(1);
+        $mpdf->SetPageTemplate($base);
+    }
+
     $mpdf->useAdobeCJK = true;
     $mpdf->SetAutoFont();
     $mpdf->SetProtection(array('copy', 'print'), $password, $password);

--- a/application/helpers/pdf_helper.php
+++ b/application/helpers/pdf_helper.php
@@ -24,6 +24,7 @@ function generate_invoice_pdf($invoice_id, $stream = true, $invoice_template = n
     $CI->load->model('invoices/mdl_invoices');
     $CI->load->model('invoices/mdl_items');
     $CI->load->model('invoices/mdl_invoice_tax_rates');
+    $CI->load->model('mdl_settings');
     $CI->load->model('payment_methods/mdl_payment_methods');
     $CI->load->library('encrypt');
 
@@ -50,13 +51,14 @@ function generate_invoice_pdf($invoice_id, $stream = true, $invoice_template = n
 
     $CI->load->helper('mpdf');
     return pdf_create($html, lang('invoice') . '_' . str_replace(array('\\', '/'), '_', $invoice->invoice_number),
-        $stream, $invoice->invoice_password, 1, $isGuest);
+        $stream, $invoice->invoice_password, 1, $isGuest, $CI->mdl_settings->setting('invoice_background'));
 }
 
 function generate_quote_pdf($quote_id, $stream = true, $quote_template = null)
 {
     $CI = &get_instance();
 
+    $CI->load->model('mdl_settings');
     $CI->load->model('quotes/mdl_quotes');
     $CI->load->model('quotes/mdl_quote_items');
     $CI->load->model('quotes/mdl_quote_tax_rates');
@@ -79,5 +81,5 @@ function generate_quote_pdf($quote_id, $stream = true, $quote_template = null)
     $CI->load->helper('mpdf');
 
     return pdf_create($html, lang('quote') . '_' . str_replace(array('\\', '/'), '_', $quote->quote_number), $stream,
-        $quote->quote_password);
+        $quote->quote_password, null, null, $CI->mdl_settings->setting('invoice_background'));
 }

--- a/application/language/english/ip_lang.php
+++ b/application/language/english/ip_lang.php
@@ -212,6 +212,7 @@ $lang = array(
     'invoice_aging_above_30'                       => 'Above 30 Days',
     'invoice_already_paid'                         => 'This invoice was already paid.',
     'invoice_archive'                              => 'Invoice archive',
+	'invoice_background'                           => 'Invoice Background PDF',
     'invoice_count'                                => 'Invoice Count',
     'invoice_date'                                 => 'Invoice Date',
     'invoice_deletion_forbidden'                   => 'Deleting invoices is forbidden. Please contact the administrator or consult the documentation.',

--- a/application/modules/settings/controllers/settings.php
+++ b/application/modules/settings/controllers/settings.php
@@ -115,6 +115,26 @@ class Settings extends Admin_Controller
                 $this->mdl_settings->save('login_logo', $upload_data['file_name']);
             }
 
+            $upload_pdf_config = array(
+                'upload_path' => './uploads/',
+                'allowed_types' => 'pdf',
+                'max_size' => '9999',
+            );
+
+            // Check for invoice background (pdf template) upload
+            if ($_FILES['invoice_background']['name']) {
+                $this->load->library('upload', $upload_pdf_config);
+
+                if (!$this->upload->do_upload('invoice_background')) {
+                    $this->session->set_flashdata('alert_error', $this->upload->display_errors());
+                    redirect('settings');
+                }
+
+                $upload_data = $this->upload->data();
+
+                $this->mdl_settings->save('invoice_background', $upload_data['file_name']);
+            }
+
             $this->session->set_flashdata('alert_success', lang('settings_successfully_saved'));
 
             redirect('settings');
@@ -185,6 +205,18 @@ class Settings extends Admin_Controller
         $this->mdl_settings->save($type . '_logo', '');
 
         $this->session->set_flashdata('alert_success', lang($type . '_logo_removed'));
+
+        redirect('settings');
+    }
+
+    public function remove_background()
+    {
+        // Maybe merge this with remove_logo and rename is to a more generic function
+        unlink('./uploads/' . $this->mdl_settings->setting('invoice_background'));
+
+        $this->mdl_settings->save('invoice_background', '');
+
+        $this->session->set_flashdata('alert_success', lang('invoice_background_removed'));
 
         redirect('settings');
     }

--- a/application/modules/settings/views/partial_settings_invoices.php
+++ b/application/modules/settings/views/partial_settings_invoices.php
@@ -113,6 +113,17 @@
     </div>
 
     <div class="form-group">
+        <label class="control-label">
+            <?php echo lang('invoice_background'); ?>
+        </label>
+        <?php if ($this->mdl_settings->setting('invoice_background')) { ?><br>
+            <?php echo $this->mdl_settings->setting('invoice_background'); ?><br>
+            <?php echo anchor('settings/remove_background', 'Remove Background'); ?><br>
+        <?php } ?>
+        <input type="file" name="invoice_background" size="40" class="input-sm form-control"/>
+    </div>
+
+    <div class="form-group">
         <hr/>
         <h4><?php echo lang('invoice_template'); ?></h4>
     </div>


### PR DESCRIPTION
When is was designing the invoice PDF template I wanted to use my company's corporate identity to style the invoice. Redesigning this in HTML is a real pain in the ass, while a simple PDF file could fix the problem. This pull request implements the [mPDF template feature](http://mpdf1.com/manual/index.php?tid=349) (not to be confused with the InvoicePlane templating system). To use it, save a template PDF file to `uploads/pdf_base.pdf`. Make sure the body background-color is set to `none`. Normalize.css defaults to white, which while overlay the template.