### PR TITLE
IP-104 - Custom fields are not copied when Invoice is duplicated

### DIFF
--- a/application/modules/invoices/models/mdl_invoices.php
+++ b/application/modules/invoices/models/mdl_invoices.php
@@ -237,6 +237,14 @@ class Mdl_Invoices extends Response_Model
 
             $this->mdl_invoice_tax_rates->save($target_id, null, $db_array);
         }
+
+        $this->load->model('custom_fields/mdl_invoice_custom');
+        $db_array = $this->mdl_invoice_custom->where('invoice_id', $source_id)->get()->row_array();
+        if (count($db_array) > 2) {
+            unset($db_array['invoice_custom_id']);
+            $db_array['invoice_id'] = $target_id;
+            $this->mdl_invoice_custom->save_custom($target_id, $db_array);
+        }
     }
 
     /**
@@ -275,6 +283,14 @@ class Mdl_Invoices extends Response_Model
             );
 
             $this->mdl_invoice_tax_rates->save($target_id, null, $db_array);
+        }
+
+        $this->load->model('custom_fields/mdl_invoice_custom');
+        $db_array = $this->mdl_invoice_custom->where('invoice_id', $source_id)->get()->row_array();
+        if (count($db_array) > 2) {
+            unset($db_array['invoice_custom_id']);
+            $db_array['invoice_id'] = $target_id;
+            $this->mdl_invoice_custom->save_custom($target_id, $db_array);
         }
     }
 

--- a/application/modules/quotes/models/mdl_quotes.php
+++ b/application/modules/quotes/models/mdl_quotes.php
@@ -230,6 +230,14 @@ class Mdl_Quotes extends Response_Model
 
             $this->mdl_quote_tax_rates->save($target_id, null, $db_array);
         }
+
+        $this->load->model('custom_fields/mdl_quote_custom');
+        $db_array = $this->mdl_quote_custom->where('quote_id', $source_id)->get()->row_array();
+        if (count($db_array) > 2) {
+            unset($db_array['quote_custom_id']);
+            $db_array['quote_id'] = $target_id;
+            $this->mdl_quote_custom->save_custom($target_id, $db_array);
+        }
     }
 
     public function db_array()


### PR DESCRIPTION
When a invoice or quote is duplicated, from now on the custom fields will be copied along with it. The `copy_invoice()` method is also used for the recurring invoice cron, therefore recurring invoices also get the custom fields of their parent.