### PR TITLE
IP-109: Added suport for having a custom template for each invoice group

### DIFF
--- a/application/helpers/pdf_helper.php
+++ b/application/helpers/pdf_helper.php
@@ -27,8 +27,16 @@ function generate_invoice_pdf($invoice_id, $stream = true, $invoice_template = n
     $CI->load->model('mdl_settings');
     $CI->load->model('payment_methods/mdl_payment_methods');
     $CI->load->library('encrypt');
+    $CI->load->model('invoice_groups/mdl_invoice_groups');
+    $CI->load->helper('country');
 
     $invoice = $CI->mdl_invoices->get_by_id($invoice_id);
+
+    if (!$invoice_template) {
+        $invoice_group = $CI->mdl_invoice_groups->get_by_id($invoice->invoice_group_id);
+        $invoice_template = $invoice_group->invoice_group_pdf_template;
+    }
+
     if (!$invoice_template) {
         $CI->load->helper('template');
         $invoice_template = select_pdf_invoice_template($invoice);

--- a/application/modules/invoice_groups/controllers/invoice_groups.php
+++ b/application/modules/invoice_groups/controllers/invoice_groups.php
@@ -56,6 +56,10 @@ class Invoice_Groups extends Admin_Controller
             $this->mdl_invoice_groups->set_form_value('invoice_group_next_id', 1);
         }
 
+        $this->load->model('invoices/mdl_templates');
+        $pdf_invoice_templates = $this->mdl_templates->get_invoice_templates('pdf');
+        $this->layout->set('pdf_invoice_templates', $pdf_invoice_templates);
+
         $this->layout->buffer('content', 'invoice_groups/form');
         $this->layout->render();
     }

--- a/application/modules/invoice_groups/models/mdl_invoice_groups.php
+++ b/application/modules/invoice_groups/models/mdl_invoice_groups.php
@@ -54,7 +54,10 @@ class Mdl_Invoice_Groups extends Response_Model
                 'field' => 'invoice_group_left_pad',
                 'label' => lang('left_pad'),
                 'rules' => 'required'
-            )
+            ),
+            'invoice_group_pdf_template' => array(
+                'field' => 'invoice_group_pdf_template',
+                'label' => lang('default_pdf_template')            )
         );
     }
 

--- a/application/modules/invoice_groups/views/form.php
+++ b/application/modules/invoice_groups/views/form.php
@@ -51,6 +51,24 @@
                        value="<?php echo $this->mdl_invoice_groups->form_value('invoice_group_left_pad'); ?>">
             </div>
         </div>
+
+        <div class="form-group">
+            <div class="col-xs-12 col-sm-3 col-lg-2 text-right text-left-xs">
+                <label for="invoice_group_pdf_template" class="control-label">
+                    <?php echo lang('default_pdf_template'); ?>
+                </label>
+            </div>
+            <div class="col-xs-12 col-sm-8 col-lg-8">
+                <select name="invoice_group_pdf_template" id="invoice_group_pdf_template" class="input-sm form-control">
+                    <option value=""></option>
+                    <?php foreach ($pdf_invoice_templates as $invoice_template) { ?>
+                        <option value="<?php echo $invoice_template; ?>"
+                                <?php if ($this->mdl_invoice_groups->form_value('invoice_group_pdf_template') == $invoice_template) { ?>selected="selected"<?php } ?>><?php echo $invoice_template; ?></option>
+                    <?php } ?>
+                </select>
+            </div>
+        </div>
+
         <br>
 
         <div class="row">

--- a/application/modules/setup/sql/017_1.4.4-nextRelease.sql
+++ b/application/modules/setup/sql/017_1.4.4-nextRelease.sql
@@ -1,0 +1,2 @@
+#Adding suport for custom templates for each invoice group
+ALTER TABLE ip_invoice_groups ADD COLUMN invoice_group_pdf_template varchar(255);


### PR DESCRIPTION
This commit adds a extra select in invoice groups for choosing a custom default template. In case there is no template selected everything works as before.

This allows us having different templates for different kinds of documents (proforma/delivery note/...)

There is a small change in database (see application/modules/setup/sql/017_1.4.4-nextRelease.sql). I didn't know where to put this change so rename this file as you like.

PD: This is a reborn of pull request #333