### PR TITLE
Fix invoice copy (and recurring)

### DIFF
--- a/application/modules/import/models/mdl_import.php
+++ b/application/modules/import/models/mdl_import.php
@@ -285,7 +285,7 @@ class Mdl_Import extends Response_Model
 
                 if (!$record_error) {
                     // No errors, go ahead and create the record
-                    $ids[] = $this->mdl_items->save($db_array['invoice_id'], NULL, $db_array);
+                    $ids[] = $this->mdl_items->save(NULL, $db_array);
                 }
             }
 

--- a/application/modules/invoices/models/mdl_invoices.php
+++ b/application/modules/invoices/models/mdl_invoices.php
@@ -234,7 +234,7 @@ class Mdl_Invoices extends Response_Model
                 'invoice_tax_rate_amount' => $invoice_tax_rate->invoice_tax_rate_amount
             );
 
-            $this->mdl_invoice_tax_rates->save($target_id, NULL, $db_array);
+            $this->mdl_invoice_tax_rates->save(NULL, $db_array);
         }
     }
 
@@ -273,7 +273,7 @@ class Mdl_Invoices extends Response_Model
                 'invoice_tax_rate_amount' => -$invoice_tax_rate->invoice_tax_rate_amount
             );
 
-            $this->mdl_invoice_tax_rates->save($target_id, NULL, $db_array);
+            $this->mdl_invoice_tax_rates->save(NULL, $db_array);
         }
     }
 

--- a/application/modules/invoices/models/mdl_invoices.php
+++ b/application/modules/invoices/models/mdl_invoices.php
@@ -221,7 +221,7 @@ class Mdl_Invoices extends Response_Model
                 'item_order' => $invoice_item->item_order
             );
 
-            $this->mdl_items->save($target_id, NULL, $db_array);
+            $this->mdl_items->save(NULL, $db_array);
         }
 
         $invoice_tax_rates = $this->mdl_invoice_tax_rates->where('invoice_id', $source_id)->get()->result();
@@ -260,7 +260,7 @@ class Mdl_Invoices extends Response_Model
                 'item_order' => $invoice_item->item_order
             );
 
-            $this->mdl_items->save($target_id, NULL, $db_array);
+            $this->mdl_items->save(NULL, $db_array);
         }
 
         $invoice_tax_rates = $this->mdl_invoice_tax_rates->where('invoice_id', $source_id)->get()->result();

--- a/application/modules/invoices/models/mdl_items.php
+++ b/application/modules/invoices/models/mdl_items.php
@@ -80,9 +80,9 @@ class Mdl_Items extends Response_Model
         $this->mdl_item_amounts->calculate($id);
 
         $this->load->model('invoices/mdl_invoice_amounts');
-        
-        if (isset($db_array->invoice_id)){
-            $this->mdl_invoice_amounts->calculate($db_array->invoice_id);
+
+        if (isset($db_array['invoice_id'])){
+            $this->mdl_invoice_amounts->calculate($db_array['invoice_id']);
         }
 
         return $id;

--- a/application/modules/quotes/controllers/ajax.php
+++ b/application/modules/quotes/controllers/ajax.php
@@ -325,7 +325,7 @@ class Ajax extends Admin_Controller
                     'item_order' => $quote_item->item_order
                 );
 
-                $this->mdl_items->save($invoice_id, NULL, $db_array);
+                $this->mdl_items->save(NULL, $db_array);
             }
 
             $quote_tax_rates = $this->mdl_quote_tax_rates->where('quote_id', $this->input->post('quote_id'))->get()->result();

--- a/application/modules/quotes/controllers/ajax.php
+++ b/application/modules/quotes/controllers/ajax.php
@@ -338,7 +338,7 @@ class Ajax extends Admin_Controller
                     'invoice_tax_rate_amount' => $quote_tax_rate->quote_tax_rate_amount
                 );
 
-                $this->mdl_invoice_tax_rates->save($invoice_id, NULL, $db_array);
+                $this->mdl_invoice_tax_rates->save(NULL, $db_array);
             }
 
             $response = array(

--- a/application/modules/quotes/models/mdl_quote_items.php
+++ b/application/modules/quotes/models/mdl_quote_items.php
@@ -81,8 +81,8 @@ class Mdl_Quote_Items extends Response_Model
 
         $this->load->model('quotes/mdl_quote_amounts');
 
-        if (isset($db_array->quote_id)){
-            $this->mdl_quote_amounts->calculate($db_array->quote_id);
+        if (isset($db_array['quote_id'])){
+            $this->mdl_quote_amounts->calculate($db_array['quote_id']);
         }
 
         return $id;

--- a/application/modules/quotes/models/mdl_quotes.php
+++ b/application/modules/quotes/models/mdl_quotes.php
@@ -227,7 +227,7 @@ class Mdl_Quotes extends Response_Model
                 'quote_tax_rate_amount' => $quote_tax_rate->quote_tax_rate_amount
             );
 
-            $this->mdl_quote_tax_rates->save($target_id, NULL, $db_array);
+            $this->mdl_quote_tax_rates->save(NULL, $db_array);
         }
     }
 

--- a/application/modules/quotes/models/mdl_quotes.php
+++ b/application/modules/quotes/models/mdl_quotes.php
@@ -214,7 +214,7 @@ class Mdl_Quotes extends Response_Model
                 'item_order' => $quote_item->item_order
             );
 
-            $this->mdl_quote_items->save($target_id, NULL, $db_array);
+            $this->mdl_quote_items->save(NULL, $db_array);
         }
 
         $quote_tax_rates = $this->mdl_quote_tax_rates->where('quote_id', $source_id)->get()->result();


### PR DESCRIPTION
I think the commit https://github.com/InvoicePlane/InvoicePlane/commit/de08ee0b4bd00e21a5a32e74b14fd1a1213967e0 broke both invoice copying and recurring invoices: When copying invoices in v1.4.5, the items don't get copied and recurring invoices are also missing the items.

This PR removes the first arguments of all calls to `mdl_items->save`, `mdl_invoice_tax_rates->save`, `mdl_quote_items->save` and `mdl_quote_tax_rates->save`.

It also removes the wrong object access to `invoice_id` and `quote_id` in `mdl_items.php` and `mdl_quote_items.php`.