### PR TITLE
Load invoice and quote id from item in database

### DIFF
--- a/application/modules/invoices/models/mdl_items.php
+++ b/application/modules/invoices/models/mdl_items.php
@@ -79,11 +79,13 @@ class Mdl_Items extends Response_Model
         $this->load->model('invoices/mdl_item_amounts');
         $this->mdl_item_amounts->calculate($id);
 
+        // Get the invoice id so we can recalculate invoice amounts
+        $item = $this->get_by_id($id);
+        $invoice_id = $item->invoice_id;
+
+        // Recalculate invoice amounts
         $this->load->model('invoices/mdl_invoice_amounts');
-        
-        if (isset($db_array->invoice_id)){
-            $this->mdl_invoice_amounts->calculate($db_array->invoice_id);
-        }
+        $this->mdl_invoice_amounts->calculate($invoice_id);
 
         return $id;
     }

--- a/application/modules/quotes/models/mdl_quote_items.php
+++ b/application/modules/quotes/models/mdl_quote_items.php
@@ -79,11 +79,13 @@ class Mdl_Quote_Items extends Response_Model
         $this->load->model('quotes/mdl_quote_item_amounts');
         $this->mdl_quote_item_amounts->calculate($id);
 
-        $this->load->model('quotes/mdl_quote_amounts');
+        // Get the quote id so we can recalculate quote amounts
+        $item = $this->get_by_id($id);
+        $quote_id = $item->quote_id;
 
-        if (isset($db_array->quote_id)){
-            $this->mdl_quote_amounts->calculate($db_array->quote_id);
-        }
+        // Recalculate quote amounts
+        $this->load->model('quotes/mdl_quote_amounts');
+        $this->mdl_quote_amounts->calculate($quote_id);
 
         return $id;
     }


### PR DESCRIPTION
Commit https://github.com/InvoicePlane/InvoicePlane/commit/56422bd863b68d220c4f087330280a0e18889135 fixed the saving of invoices and quotes again, however when copying an invoice or a quote the total of the copied invoice or quote would be wrong as `$db_array` would be an array in that case.

This PR fixes the calculation of the total while copying and also works for saving.