### PR TITLE
Allow client custom fields to be used in invoice group identifiers (IP-553)

### DIFF
--- a/application/modules/invoice_groups/controllers/invoice_groups.php
+++ b/application/modules/invoice_groups/controllers/invoice_groups.php
@@ -60,6 +60,10 @@ class Invoice_Groups extends Admin_Controller
         $pdf_invoice_templates = $this->mdl_templates->get_invoice_templates('pdf');
         $this->layout->set('pdf_invoice_templates', $pdf_invoice_templates);
 
+        $this->load->model('custom_fields/mdl_custom_fields');
+        $client_custom_fields = $this->mdl_custom_fields->by_table('ip_client_custom')->get()->result();
+        $this->layout->set('client_custom_fields', $client_custom_fields);
+
         $this->layout->buffer('content', 'invoice_groups/form');
         $this->layout->render();
     }

--- a/application/modules/invoice_groups/views/form.php
+++ b/application/modules/invoice_groups/views/form.php
@@ -83,6 +83,10 @@
                 <a href="#" class="text-tag" data-tag="{{{year}}}"><?php echo lang('current_year'); ?></a><br>
                 <a href="#" class="text-tag" data-tag="{{{month}}}"><?php echo lang('current_month'); ?></a><br>
                 <a href="#" class="text-tag" data-tag="{{{day}}}"><?php echo lang('current_day'); ?></a><br>
+
+                <?php foreach ($client_custom_fields as $field) { ?>
+                    <a href="#" class="text-tag" data-tag="{{{client:<?php echo $field->custom_field_label; ?>}}}"><?php echo $field->custom_field_label; ?></a><br>
+                <?php } ?>
             </div>
         </div>
     </div>

--- a/application/modules/invoices/controllers/cron.php
+++ b/application/modules/invoices/controllers/cron.php
@@ -44,7 +44,7 @@ class Cron extends Base_Controller
                     'invoice_date_due' => $this->mdl_invoices->get_date_due($invoice_recurring->recur_next_date, $invoice_recurring->recur_invoices_due_after),
                     'invoice_group_id' => $invoice->invoice_group_id,
                     'user_id' => $invoice->user_id,
-                    'invoice_number' => $this->mdl_invoices->get_invoice_number($invoice->invoice_group_id),
+                    'invoice_number' => $this->mdl_invoices->get_invoice_number($invoice->invoice_group_id, $invoice->client_id),
                     'invoice_url_key' => $this->mdl_invoices->get_url_key(),
                     'invoice_terms' => $invoice->invoice_terms
                 );

--- a/application/modules/invoices/models/mdl_invoices.php
+++ b/application/modules/invoices/models/mdl_invoices.php
@@ -305,7 +305,7 @@ class Mdl_Invoices extends Response_Model
 
         $db_array['invoice_date_created'] = date_to_mysql($db_array['invoice_date_created']);
         $db_array['invoice_date_due'] = $this->get_date_due($db_array['invoice_date_created']);
-        $db_array['invoice_number'] = $this->get_invoice_number($db_array['invoice_group_id']);
+        $db_array['invoice_number'] = $this->get_invoice_number($db_array['invoice_group_id'], $db_array['client_id']);
         $db_array['invoice_terms'] = $this->mdl_settings->setting('default_invoice_terms');
 
         if (!isset($db_array['invoice_status_id'])) {
@@ -318,10 +318,10 @@ class Mdl_Invoices extends Response_Model
         return $db_array;
     }
 
-    public function get_invoice_number($invoice_group_id)
+    public function get_invoice_number($invoice_group_id, $client_id)
     {
         $this->load->model('invoice_groups/mdl_invoice_groups');
-        return $this->mdl_invoice_groups->generate_invoice_number($invoice_group_id);
+        return $this->mdl_invoice_groups->generate_invoice_number($invoice_group_id, $client_id);
     }
 
     public function get_date_due($invoice_date_created, $invoices_due_after = null)

--- a/application/modules/quotes/models/mdl_quotes.php
+++ b/application/modules/quotes/models/mdl_quotes.php
@@ -251,7 +251,7 @@ class Mdl_Quotes extends Response_Model
 
         $db_array['quote_date_created'] = date_to_mysql($db_array['quote_date_created']);
         $db_array['quote_date_expires'] = $this->get_date_due($db_array['quote_date_created']);
-        $db_array['quote_number'] = $this->get_quote_number($db_array['invoice_group_id']);
+        $db_array['quote_number'] = $this->get_quote_number($db_array['invoice_group_id'], $db_array['client_id']);
         $db_array['notes'] = $this->mdl_settings->setting('default_quote_notes');
 
         if (!isset($db_array['quote_status_id'])) {
@@ -264,10 +264,10 @@ class Mdl_Quotes extends Response_Model
         return $db_array;
     }
 
-    public function get_quote_number($invoice_group_id)
+    public function get_quote_number($invoice_group_id, $client_id)
     {
         $this->load->model('invoice_groups/mdl_invoice_groups');
-        return $this->mdl_invoice_groups->generate_invoice_number($invoice_group_id);
+        return $this->mdl_invoice_groups->generate_invoice_number($invoice_group_id, $client_id);
     }
 
     public function get_date_due($quote_date_created)


### PR DESCRIPTION
My preferred invoice format is ABC-123, where ABC is a code specific to
the client and 123 is the incrementing ID for that client. To do this, I
had to make a new invoice group for each client and statically set that
client's code in the identifier. This change allows me to set the client
code using a custom field and use a single invoice group for all my
clients.

An example format string for this is {{{client:Invoice prefix}}} where
"Invoice prefix" is the label of the custom field.

This also works for quotes.
