### PR TITLE
IP-412 - ZUGFeRD PDF invoices

### DIFF
--- a/application/helpers/mpdf/includes/functions.php
+++ b/application/helpers/mpdf/includes/functions.php
@@ -78,6 +78,11 @@ function _fgets (&$h, $force=false) {
 	return $s;
 }
 
+function pdfFormattedDate($date){
+  $z = date('O'); // +0200
+  $offset = substr($z,0,3)."'".substr($z,3,2)."'"; // +02'00'
+  return date('YmdHis', $date) . $offset;
+}
 
 // For PHP4 compatability
 if(!function_exists('str_ireplace')) {

--- a/application/helpers/mpdf_helper.php
+++ b/application/helpers/mpdf_helper.php
@@ -5,7 +5,7 @@ if (!defined('BASEPATH'))
 
 /*
  * InvoicePlane
- * 
+ *
  * A free and open source web based invoicing system
  *
  * @package		InvoicePlane
@@ -13,10 +13,10 @@ if (!defined('BASEPATH'))
  * @copyright	Copyright (c) 2012 - 2015 InvoicePlane.com
  * @license		https://invoiceplane.com/license.txt
  * @link		https://invoiceplane.com
- * 
+ *
  */
 
-function pdf_create($html, $filename, $stream = true, $password = null, $isInvoice = null, $isGuest = null)
+function pdf_create($html, $filename, $stream = true, $password = null, $isInvoice = null, $isGuest = null, $zugferd_invoice = false, $associatedFiles = null)
 {
     require_once(APPPATH . 'helpers/mpdf/mpdf.php');
 
@@ -24,9 +24,18 @@ function pdf_create($html, $filename, $stream = true, $password = null, $isInvoi
     $mpdf->useAdobeCJK = true;
     $mpdf->SetAutoFont();
 
-    // Avoid setting protection when password is blank/empty
-    if (!empty($password)) {
-        $mpdf->SetProtection(array('copy', 'print'), $password, $password);
+    if ($zugferd_invoice) {
+        $CI = &get_instance();
+        $CI->load->helper('zugferd');
+        $mpdf->PDFA = true;
+        $mpdf->PDFAauto = true;
+        $mpdf->SetAdditionalRdf(zugferd_rdf());
+        $mpdf->SetAssociatedFiles($associatedFiles);
+    } else {
+        // Avoid setting protection when password is blank/empty
+        if (!empty($password)) {
+            $mpdf->SetProtection(array('copy', 'print'), $password, $password);
+        }
     }
 
     if (!(is_dir('./uploads/archive/') || is_link('./uploads/archive/'))) {

--- a/application/helpers/zugferd_helper.php
+++ b/application/helpers/zugferd_helper.php
@@ -1,0 +1,38 @@
+<?php
+
+if (!defined('BASEPATH'))
+    exit('No direct script access allowed');
+
+/*
+ * InvoicePlane
+ *
+ * A free and open source web based invoicing system
+ *
+ * @package		InvoicePlane
+ * @author		Kovah (www.kovah.de)
+ * @copyright	Copyright (c) 2012 - 2015 InvoicePlane.com
+ * @license		https://invoiceplane.com/license.txt
+ * @link		https://invoiceplane.com
+ *
+ */
+
+function generate_invoice_zugferd_xml_temp_file($invoice, $items){
+    $CI = &get_instance();
+    $CI->load->helper('file');
+
+    $path = './uploads/temp/invoice_' . $invoice->invoice_id . '_zugferd.xml';
+    $zugferdXml = $CI->load->library('ZugferdXml', array('invoice' => $invoice, 'items' => $items));
+
+    write_file($path, $zugferdXml->xml());
+    return $path;
+}
+
+function zugferd_rdf(){
+    $s  = '<rdf:Description rdf:about="" xmlns:zf="urn:ferd:pdfa:CrossIndustryDocument:invoice:1p0#">'."\n";
+    $s .= '  <zf:DocumentType>INVOICE</zf:DocumentType>'."\n";
+    $s .= '  <zf:DocumentFileName>ZUGFeRD-invoice.xml</zf:DocumentFileName>'."\n";
+    $s .= '  <zf:Version>1.0</zf:Version>'."\n";
+    $s .= '  <zf:ConformanceLevel>COMFORT</zf:ConformanceLevel>'."\n";
+    $s .= '</rdf:Description>'."\n";
+    return $s;
+}

--- a/application/language/english/ip_lang.php
+++ b/application/language/english/ip_lang.php
@@ -79,6 +79,7 @@ $lang = array(
     'credit_invoice_details'                       => 'Credit invoice details',
     'credit_invoice_for_invoice'                   => 'Credit invoice for invoice',
     'cron_key'                                     => 'CRON Key',
+    'currency_code'                                => 'Currency Code',
     'currency_symbol'                              => 'Currency Symbol',
     'currency_symbol_placement'                    => 'Currency Symbol Placement',
     'current_day'                                  => 'Current day',

--- a/application/libraries/ZugferdXml.php
+++ b/application/libraries/ZugferdXml.php
@@ -1,0 +1,294 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+class ZugferdXml {
+    var $invoice;
+    var $doc;
+    var $root;
+
+    public function ZugferdXml($params){
+        $CI = &get_instance();
+        $this->invoice = $params['invoice'];
+        $this->items = $params['items'];
+        $this->currencyCode = $CI->mdl_settings->setting('currency_code');
+    }
+
+    public function xml(){
+        $this->doc = new DOMDocument('1.0', 'UTF-8');
+        $this->doc->formatOutput = true;
+
+        $this->root = $this->xmlRoot();
+        $this->root->appendChild($this->xmlSpecifiedExchangedDocumentContext());
+        $this->root->appendChild($this->xmlHeaderExchangedDocument());
+        $this->root->appendChild($this->xmlSpecifiedSupplyChainTradeTransaction());
+
+        $this->doc->appendChild($this->root);
+        return $this->doc->saveXML();
+    }
+
+    protected function xmlRoot(){
+        $node = $this->doc->createElement('rsm:CrossIndustryDocument');
+        $node->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        $node->setAttribute('xmlns:rsm', 'urn:ferd:CrossIndustryDocument:invoice:1p0');
+        $node->setAttribute('xmlns:ram', 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12');
+        $node->setAttribute('xmlns:udt', 'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15');
+        return $node;
+    }
+
+    protected function xmlSpecifiedExchangedDocumentContext(){
+        $node = $this->doc->createElement('rsm:SpecifiedExchangedDocumentContext');
+        $guidelineNode = $this->doc->createElement('ram:GuidelineSpecifiedDocumentContextParameter');
+        $guidelineNode->appendChild($this->doc->createElement('ram:ID', 'urn:ferd:CrossIndustryDocument:invoice:1p0:basic'));
+        $node->appendChild($guidelineNode);
+        return $node;
+    }
+
+    protected function xmlHeaderExchangedDocument(){
+        $node = $this->doc->createElement('rsm:HeaderExchangedDocument');
+
+        $node->appendChild($this->doc->createElement('ram:ID', $this->invoice->invoice_number));
+        $node->appendChild($this->doc->createElement('ram:Name', lang('invoice')));
+        $node->appendChild($this->doc->createElement('ram:TypeCode', 380));
+
+        // IssueDateTime
+        $dateNode = $this->doc->createElement('ram:IssueDateTime');
+        $dateNode->appendChild($this->dateElement($this->invoice->invoice_date_created));
+        $node->appendChild($dateNode);
+
+        // IncludedNote
+        $noteNode = $this->doc->createElement('ram:IncludedNote');
+        $noteNode->appendChild($this->doc->createElement('ram:Content', $this->invoice->invoice_terms));
+        $node->appendChild($noteNode);
+
+        return $node;
+    }
+
+    protected function xmlSpecifiedSupplyChainTradeTransaction(){
+        $node = $this->doc->createElement('rsm:SpecifiedSupplyChainTradeTransaction');
+        $node->appendChild($this->xmlApplicableSupplyChainTradeAgreement());
+        $node->appendChild($this->xmlApplicableSupplyChainTradeDelivery());
+        $node->appendChild($this->xmlApplicableSupplyChainTradeSettlement());
+        foreach ($this->items as $index => $item) {
+            $node->appendChild($this->xmlIncludedSupplyChainTradeLineItem($index + 1, $item));
+        }
+        return $node;
+    }
+
+    protected function xmlApplicableSupplyChainTradeAgreement(){
+        $node = $this->doc->createElement('ram:ApplicableSupplyChainTradeAgreement');
+        $node->appendChild($this->xmlSellerTradeParty());
+        $node->appendChild($this->xmlBuyerTradeParty());
+        return $node;
+    }
+
+    protected function xmlApplicableSupplyChainTradeDelivery(){
+        $node = $this->doc->createElement('ram:ApplicableSupplyChainTradeDelivery');
+
+        // ActualDeliverySupplyChainEvent
+        $eventNode = $this->doc->createElement('ram:ActualDeliverySupplyChainEvent');
+        $dateNode = $this->doc->createElement('ram:OccurrenceDateTime');
+        $dateNode->appendChild($this->dateElement($this->invoice->invoice_date_created));
+        $eventNode->appendChild($dateNode);
+
+        $node->appendChild($eventNode);
+        return $node;
+    }
+
+    protected function xmlApplicableSupplyChainTradeSettlement(){
+        $node = $this->doc->createElement('ram:ApplicableSupplyChainTradeSettlement');
+
+        $node->appendChild($this->doc->createElement('ram:PaymentReference', $this->invoice->invoice_number));
+        $node->appendChild($this->doc->createElement('ram:InvoiceCurrencyCode', $this->currencyCode));
+
+        // taxes
+        foreach ($this->itemsSubtotalGroupedByTaxPercent() as $percent=>$subtotal) {
+            $node->appendChild($this->xmlApplicableTradeTax($percent, $subtotal));
+        }
+
+        // sums
+        $node->appendChild($this->xmlSpecifiedTradeSettlementMonetarySummation());
+
+        return $node;
+    }
+
+    protected function xmlIncludedSupplyChainTradeLineItem($lineNumber, $item){
+        $node = $this->doc->createElement('ram:IncludedSupplyChainTradeLineItem');
+
+        // AssociatedDocumentLineDocument
+        $lineNode = $this->doc->createElement('ram:AssociatedDocumentLineDocument');
+        $lineNode->appendChild($this->doc->createElement('ram:LineID', $lineNumber));
+        $node->appendChild($lineNode);
+
+        // SpecifiedSupplyChainTradeAgreement
+        $node->appendChild($this->xmlSpecifiedSupplyChainTradeAgreement($item));
+
+        // SpecifiedSupplyChainTradeDelivery
+        $deliveyNode = $this->doc->createElement('ram:SpecifiedSupplyChainTradeDelivery');
+        $deliveyNode->appendChild($this->quantityElement('ram:BilledQuantity', $item->item_quantity));
+        $node->appendChild($deliveyNode);
+
+        // SpecifiedSupplyChainTradeSettlement
+        $node->appendChild($this->xmlSpecifiedSupplyChainTradeSettlement($item));
+
+        // SpecifiedTradeProduct
+        $tradeNode = $this->doc->createElement('ram:SpecifiedTradeProduct');
+        $tradeNode->appendChild($this->doc->createElement('ram:Name', $item->item_name . "\n" . $item->item_description));
+        $node->appendChild($tradeNode);
+
+        return $node;
+    }
+
+    protected function xmlSellerTradeParty($index, $item){
+        $node = $this->doc->createElement('ram:SellerTradeParty');
+        $node->appendChild($this->doc->createElement('ram:Name', $this->invoice->user_name));
+
+        // PostalTradeAddress
+        $addressNode = $this->doc->createElement('ram:PostalTradeAddress');
+        $addressNode->appendChild($this->doc->createElement('ram:PostcodeCode', $this->invoice->user_zip));
+        $addressNode->appendChild($this->doc->createElement('ram:LineOne', $this->invoice->user_address_1));
+        $addressNode->appendChild($this->doc->createElement('ram:LineTwo', $this->invoice->user_address_2));
+        $addressNode->appendChild($this->doc->createElement('ram:CityName', $this->invoice->user_city));
+        $addressNode->appendChild($this->doc->createElement('ram:CountryID', $this->invoice->user_country));
+
+        $node->appendChild($addressNode);
+        return $node;
+    }
+
+    protected function xmlBuyerTradeParty($index, $item){
+        $node = $this->doc->createElement('ram:BuyerTradeParty');
+        $node->appendChild($this->doc->createElement('ram:Name', $this->invoice->client_name));
+
+        // PostalTradeAddress
+        $addressNode = $this->doc->createElement('ram:PostalTradeAddress');
+        $addressNode->appendChild($this->doc->createElement('ram:PostcodeCode', $this->invoice->client_zip));
+        $addressNode->appendChild($this->doc->createElement('ram:LineOne', $this->invoice->client_address_1));
+        $addressNode->appendChild($this->doc->createElement('ram:LineTwo', $this->invoice->client_address_2));
+        $addressNode->appendChild($this->doc->createElement('ram:CityName', $this->invoice->client_city));
+        $addressNode->appendChild($this->doc->createElement('ram:CountryID', $this->invoice->client_country));
+        $node->appendChild($addressNode);
+
+        // SpecifiedTaxRegistration
+        $node->appendChild($this->xmlSpecifiedTaxRegistration('VA', $this->invoice->client_vat_id));
+        $node->appendChild($this->xmlSpecifiedTaxRegistration('FC', $this->invoice->client_tax_code));
+
+        return $node;
+    }
+
+    protected function xmlSpecifiedTaxRegistration($schemeID, $content){
+        $node = $this->doc->createElement('ram:SpecifiedTaxRegistration');
+        $el = $this->doc->createElement('ram:ID', $content);
+        $el->setAttribute('schemeID', $schemeID);
+        $node->appendChild($el);
+        return $node;
+    }
+
+    protected function xmlApplicableTradeTax($percent, $subtotal){
+        $node = $this->doc->createElement('ram:ApplicableTradeTax');
+        $node->appendChild($this->currencyElement('ram:CalculatedAmount', $subtotal * $percent / 100));
+        $node->appendChild($this->doc->createElement('ram:TypeCode', 'VAT'));
+        $node->appendChild($this->currencyElement('ram:BasisAmount', $subtotal));
+        $node->appendChild($this->doc->createElement('ram:CategoryCode', 'S'));
+        $node->appendChild($this->doc->createElement('ram:ApplicablePercent', $percent));
+        return $node;
+    }
+
+    protected function xmlSpecifiedTradeSettlementMonetarySummation(){
+        $node = $this->doc->createElement('ram:SpecifiedTradeSettlementMonetarySummation');
+        $node->appendChild($this->currencyElement('ram:LineTotalAmount', $this->invoice->invoice_item_subtotal));
+        $node->appendChild($this->currencyElement('ram:ChargeTotalAmount', 0));
+        $node->appendChild($this->currencyElement('ram:AllowanceTotalAmount', 0));
+        $node->appendChild($this->currencyElement('ram:TaxBasisTotalAmount', $this->invoice->invoice_item_subtotal));
+        $node->appendChild($this->currencyElement('ram:TaxTotalAmount', $this->invoice->invoice_item_tax_total));
+        $node->appendChild($this->currencyElement('ram:GrandTotalAmount', $this->invoice->invoice_total));
+        $node->appendChild($this->currencyElement('ram:TotalPrepaidAmount', $this->invoice->invoice_paid));
+        $node->appendChild($this->currencyElement('ram:DuePayableAmount', $this->invoice->invoice_balance));
+        return $node;
+    }
+
+    protected function xmlSpecifiedSupplyChainTradeAgreement($item) {
+        $node = $this->doc->createElement('ram:SpecifiedSupplyChainTradeAgreement');
+
+        // GrossPriceProductTradePrice
+        $grossPriceNode = $this->doc->createElement('ram:GrossPriceProductTradePrice');
+        $grossPriceNode->appendChild($this->currencyElement('ram:ChargeAmount', $item->item_price, 4));
+        $node->appendChild($grossPriceNode);
+
+        // NetPriceProductTradePrice
+        $netPriceNode = $this->doc->createElement('ram:NetPriceProductTradePrice');
+        $netPriceNode->appendChild($this->currencyElement('ram:ChargeAmount', $item->item_price, 4));
+        $node->appendChild($netPriceNode);
+
+        return $node;
+     }
+
+    protected function xmlSpecifiedSupplyChainTradeSettlement($item) {
+        $node = $this->doc->createElement('ram:SpecifiedSupplyChainTradeSettlement');
+
+        // ApplicableTradeTax
+        if ($item->item_tax_rate_percent > 0) {
+            $taxNode = $this->doc->createElement('ram:ApplicableTradeTax');
+            $taxNode->appendChild($this->doc->createElement('ram:TypeCode', 'VAT'));
+            $taxNode->appendChild($this->doc->createElement('ram:ApplicablePercent', $item->item_tax_rate_percent));
+            $node->appendChild($taxNode);
+        }
+
+        // SpecifiedTradeSettlementMonetarySummation
+        $sumNode = $this->doc->createElement('ram:SpecifiedTradeSettlementMonetarySummation');
+        $sumNode->appendChild($this->currencyElement('ram:LineTotalAmount', $item->item_subtotal));
+        $node->appendChild($sumNode);
+
+        return $node;
+     }
+
+    // ===========================================================================
+    // elements helpers
+    // ===========================================================================
+
+    protected function currencyElement($name, $amount, $nb_decimals = 2){
+        $el = $this->doc->createElement($name, $this->zugferdFormattedFloat($amount, $nb_decimals));
+        $el->setAttribute('currencyID', $this->currencyCode);
+        return $el;
+    }
+
+    protected function quantityElement($name, $quantity){
+        $el = $this->doc->createElement($name, $this->zugferdFormattedFloat($quantity, 4));
+        $el->setAttribute('unitCode', 'C62');
+        return $el;
+    }
+
+    protected function dateElement($date){
+        $el = $this->doc->createElement('udt:DateTimeString', $this->zugferdFormattedDate($date));
+        $el->setAttribute('format', 102);
+        return $el;
+    }
+
+    // ===========================================================================
+    // helpers
+    // ===========================================================================
+
+    function zugferdFormattedDate($date)
+    {
+        if ($date && $date <> '0000-00-00') {
+            $date = DateTime::createFromFormat('Y-m-d', $date);
+            return $date->format('Ymd');
+        }
+        return '';
+    }
+
+    function zugferdFormattedFloat($amount, $nb_decimals = 2)
+    {
+        return number_format((float)$amount, $nb_decimals);
+    }
+
+    function itemsSubtotalGroupedByTaxPercent(){
+        $result = [];
+        foreach ($this->items as $item) {
+            if ($item->item_tax_rate_percent == 0) continue;
+
+            if (!isset($result[$item->item_tax_rate_percent])) {
+                $result[$item->item_tax_rate_percent] = 0;
+            }
+            $result[$item->item_tax_rate_percent] += $item->item_subtotal;
+        }
+        return $result;
+    }
+}

--- a/application/modules/invoices/controllers/invoices.php
+++ b/application/modules/invoices/controllers/invoices.php
@@ -5,7 +5,7 @@ if (!defined('BASEPATH'))
 
 /*
  * InvoicePlane
- * 
+ *
  * A free and open source web based invoicing system
  *
  * @package		InvoicePlane
@@ -13,7 +13,7 @@ if (!defined('BASEPATH'))
  * @copyright	Copyright (c) 2012 - 2015 InvoicePlane.com
  * @license		https://invoiceplane.com/license.txt
  * @link		https://invoiceplane.com
- * 
+ *
  */
 
 class Invoices extends Admin_Controller
@@ -206,7 +206,20 @@ class Invoices extends Admin_Controller
             $this->mdl_invoices->mark_sent($invoice_id);
         }
 
-        generate_invoice_pdf($invoice_id, $stream, $invoice_template);
+        $include_zugferd_xml = $this->input->get('include_zugferd_xml') == 'true';
+        generate_invoice_pdf($invoice_id, $stream, $invoice_template, NULL, $include_zugferd_xml);
+    }
+
+    public function generate_zugferd_xml($invoice_id)
+    {
+        $this->load->model('invoices/mdl_items');
+        $this->load->library('ZugferdXml', array(
+            'invoice' => $this->mdl_invoices->get_by_id($invoice_id),
+            'items' => $this->mdl_items->where('invoice_id', $invoice_id)->get()->result()
+        ));
+
+        $this->output->set_content_type('text/xml');
+        $this->output->set_output($this->zugferdxml->xml());
     }
 
     public function delete_invoice_tax($invoice_id, $invoice_tax_rate_id)

--- a/application/modules/invoices/models/mdl_items.php
+++ b/application/modules/invoices/models/mdl_items.php
@@ -24,7 +24,9 @@ class Mdl_Items extends Response_Model
 
     public function default_select()
     {
-        $this->db->select('ip_invoice_item_amounts.*, ip_invoice_items.*, item_tax_rates.tax_rate_percent AS item_tax_rate_percent');
+        $this->db->select('ip_invoice_item_amounts.*, ip_invoice_items.*,
+            item_tax_rates.tax_rate_percent AS item_tax_rate_percent,
+            item_tax_rates.tax_rate_name AS item_tax_rate_name');
     }
 
     public function default_order_by()

--- a/application/modules/settings/views/partial_settings_general.php
+++ b/application/modules/settings/views/partial_settings_general.php
@@ -175,6 +175,18 @@
         </div>
     </div>
 
+    <div class="row">
+        <div class="col-xs-12 col-md-6">
+            <div class="form-group">
+                <label class="control-label">
+                    <?php echo lang('currency_code'); ?>
+                </label>
+                <input type="text" name="settings[currency_code]" class="input-sm form-control"
+                       value="<?php echo $this->mdl_settings->setting('currency_code'); ?>">
+            </div>
+        </div>
+    </div>
+
     <hr/>
     <h4><?php echo lang('dashboard'); ?></h4>
     <br/>


### PR DESCRIPTION
This PR enables creation of ZUGFeRD Invoices in InvoicePlane. A good technical description of the format is available on http://www.pdflib.com/knowledge-base/pdfa/zugferd-invoices.

Two routes are concerned in IP:
- GET XML standalone via ```invoices/generate_zugferd_xml/{invoice_id}```
- GET XML embedded in the PDF via ```invoices/generate_pdf/{invoice_id}?include_zugferd_xml=true```

Note: 
- ZUGFeRD requires an ISO currency code: I've added it in the system settings, like the actual "currency symbol" https://github.com/InvoicePlane/InvoicePlane/commit/50c8ddbe4e84eb25c2b83ce278e902a67eac45c7

- ZUGFeRD requires PDF/A-3: I've adapted mPDF library here, but the same code is in a PR on mPDF: https://github.com/mpdf/mpdf/pull/130

Don't hesitate to ask for modifications, i'll be glad to help!