### PR TITLE
IP-447 - Added Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.gitignore
+CONTRIBUTING.md
+Dockerfile
+license.txt
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM php:5.6-apache
+
+# Install and enable PHP extensions
+# https://wiki.invoiceplane.com/en/1.0/getting-started/requirements
+RUN \
+  apt-get update && apt-get install -y \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libmcrypt-dev \
+    libpng12-dev \
+    librecode-dev \
+    libxml2-dev \
+  && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+  && docker-php-ext-install -j$(nproc) gd mcrypt mysqli recode xmlrpc
+
+# Copy InvoicePlane into public directory
+COPY . /var/www/html
+
+# Enable .htaccess, set permissions, and enable Apache mod_rewrite
+RUN mv /var/www/html/htaccess /var/www/html/.htaccess \
+  && chown -R www-data:www-data /var/www/html \
+  && a2enmod rewrite


### PR DESCRIPTION
I have spent days now struggling with existing Docker images. Searching for InvoicePlane errors like "white screen after database connection" has been very unhelpful. Please merge this to help any poor souls like me in the future.

We should also get an official InvoicePlane image up on Docker Hub. I can help with that if you'd like.

This has a few advantages this has over [the existing images](https://hub.docker.com/search/?isAutomated=0&isOfficial=0&page=1&pullCount=0&q=InvoicePlane&starCount=0).

* **It's simple.** There is nothing complex about this image. It exposes port 80 by default, runs Apache in the foreground automatically, and makes no assumptions about what directories you want to mount.
* **It's based on the official PHP base image.** Other existing images use custom base images that don't work very well and makes maintenance difficult. Here we can rely on the maintainers of the PHP image.
* **It's easy to run.** `docker-compose` isn't required, the server is built into the image, and adding a database is done the usual way by spinning up a MySQL/Mariadb container and linking it.
* **It works with [Dokku](dokku.viewdocs.io/dokku/)**, and probably any other PaaS that can accept Dockerfiles.

# How to use this image
(Derived from [OwnCloud Docker readme](https://hub.docker.com/_/owncloud/))
## Start InvoicePlane
Until this is on Docker Hub, you'll have to build invoiceplane/invoiceplane yourself locally
```
$ docker run -d -p 80:80 invoiceplane/invoiceplane
```

For a MySQL database you can link an database container, e.g. `--link my-mysql:mysql`, and then use mysql as the database host on setup.

## Persistent data
All data beyond what lives in the database (file uploads, etc) is stored within the default volume `/var/www/html`.

You can use 2 volumes, as shown below.

* `-v /<mydatalocation>/config:/var/www/html/application/config`
* `-v /<mydatalocation>/uploads:/var/www/html/uploads`