### PR TITLE
Fix invoice creation for clients who have apostrophes in their names.

### DIFF
--- a/application/modules/invoices/views/modal_create_invoice.php
+++ b/application/modules/invoices/views/modal_create_invoice.php
@@ -62,7 +62,7 @@
                 <select name="client_name" id="client_name" class="form-control" autofocus="autofocus">
                     <?php
                     foreach ($clients as $client) {
-                        echo "<option value='" . htmlspecialchars($client->client_name) . "' ";
+                        echo "<option value=\"" . htmlspecialchars($client->client_name) . "\" ";
                         if ($client_name == $client->client_name) echo 'selected';
                         echo ">" . htmlspecialchars($client->client_name) . "</option>";
                     }

--- a/application/modules/quotes/views/modal_create_quote.php
+++ b/application/modules/quotes/views/modal_create_quote.php
@@ -59,7 +59,7 @@
                 <select name="client_name" id="client_name" class="form-control" autofocus="autofocus">
                     <?php
                     foreach ($clients as $client) {
-                        echo "<option value='" . htmlspecialchars($client->client_name) . "' ";
+                        echo "<option value=\"" . htmlspecialchars($client->client_name) . "\" ";
                         if ($client_name == $client->client_name) echo 'selected';
                         echo ">" . htmlspecialchars($client->client_name) . "</option>";
                     }


### PR DESCRIPTION
When creating a quote or invoice for a client who has an apostrophe in
their name, it created malformed HTML for the client select list because
it used single quotes in the option value attribute. This commit changes
it to use double quotes.