### PR TITLE
Add quote information to invoices - IP-476

### DIFF
--- a/application/modules/invoices/models/mdl_invoices.php
+++ b/application/modules/invoices/models/mdl_invoices.php
@@ -54,6 +54,8 @@ class Mdl_Invoices extends Response_Model
             SQL_CALC_FOUND_ROWS ip_invoice_custom.*,
             ip_client_custom.*,
             ip_user_custom.*,
+            ip_quotes.*,
+            ip_quote_custom.*,
             ip_users.user_name,
 			ip_users.user_company,
 			ip_users.user_address_1,
@@ -97,6 +99,8 @@ class Mdl_Invoices extends Response_Model
         $this->db->join('ip_client_custom', 'ip_client_custom.client_id = ip_clients.client_id', 'left');
         $this->db->join('ip_user_custom', 'ip_user_custom.user_id = ip_users.user_id', 'left');
         $this->db->join('ip_invoice_custom', 'ip_invoice_custom.invoice_id = ip_invoices.invoice_id', 'left');
+        $this->db->join('ip_quotes', 'ip_quotes.invoice_id = ip_invoices.invoice_id', 'left');
+        $this->db->join('ip_quote_custom', 'ip_quotes.quote_id = ip_quote_custom.quote_id', 'left');
     }
 
     public function validation_rules()

--- a/application/views/invoice_templates/pdf/InvoicePlane.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane.php
@@ -219,14 +219,6 @@
         </tbody>
     </table>
 
-    <div>
-        <pre><?php print_r($quote); ?></pre>
-        <pre><?php print_r($invoice); ?></pre>
-        <pre><?php print_r($items); ?></pre>
-    </div>
-
-
-
 </main>
 
 <footer>

--- a/application/views/invoice_templates/pdf/InvoicePlane.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane.php
@@ -219,6 +219,14 @@
         </tbody>
     </table>
 
+    <div>
+        <pre><?php print_r($quote); ?></pre>
+        <pre><?php print_r($invoice); ?></pre>
+        <pre><?php print_r($items); ?></pre>
+    </div>
+
+
+
 </main>
 
 <footer>


### PR DESCRIPTION
The invoice templates can now use the information from quotes and custom quotes.

E.g. I am adding the contact person or the person who requested the quote.

Thus I can add the 
* quote_number,
* the requester and
* the contact person 
in the invoice template.

See https://community.invoiceplane.com/t/topic/3860/8

Please squash the PR.