### PR TITLE
Fix address formatting in PDF templates - IP-477

### DIFF
--- a/application/views/invoice_templates/pdf/InvoicePlane - overdue.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane - overdue.php
@@ -28,18 +28,18 @@
         if ($invoice->client_address_2) {
             echo '<div>' . $invoice->client_address_2 . '</div>';
         }
-        if ($invoice->client_city && $invoice->client_zip) {
-            echo '<div>' . $invoice->client_city . ' ' . $invoice->client_zip . '</div>';
-        } else {
+        if ($invoice->client_city || $invoice->client_state || $invoice->client_zip) {
+            echo '<div>';
             if ($invoice->client_city) {
-                echo '<div>' . $invoice->client_city . '</div>';
+                echo $invoice->client_city . ' ';
+            }
+            if ($invoice->client_state) {
+                echo $invoice->client_state . ' ';
             }
             if ($invoice->client_zip) {
-                echo '<div>' . $invoice->client_zip . '</div>';
+                echo $invoice->client_zip;
             }
-        }
-        if ($invoice->client_state) {
-            echo '<div>' . $invoice->client_state . '</div>';
+            echo '</div>';
         }
         if ($invoice->client_country) {
             echo '<div>' . get_country_name(trans('cldr'), $invoice->client_country) . '</div>';
@@ -66,18 +66,18 @@
         if ($invoice->user_address_2) {
             echo '<div>' . $invoice->user_address_2 . '</div>';
         }
-        if ($invoice->user_city && $invoice->user_zip) {
-            echo '<div>' . $invoice->user_city . ' ' . $invoice->user_zip . '</div>';
-        } else {
+        if ($invoice->user_city || $invoice->user_state || $invoice->user_zip) {
+            echo '<div>';
             if ($invoice->user_city) {
-                echo '<div>' . $invoice->user_city . '</div>';
+                echo $invoice->user_city . ' ';
+            }
+            if ($invoice->user_state) {
+                echo $invoice->user_state . ' ';
             }
             if ($invoice->user_zip) {
-                echo '<div>' . $invoice->user_zip . '</div>';
+                echo $invoice->user_zip;
             }
-        }
-        if ($invoice->user_state) {
-            echo '<div>' . $invoice->user_state . '</div>';
+            echo '</div>';
         }
         if ($invoice->user_country) {
             echo '<div>' . get_country_name(trans('cldr'), $invoice->user_country) . '</div>';

--- a/application/views/invoice_templates/pdf/InvoicePlane - paid.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane - paid.php
@@ -28,18 +28,18 @@
         if ($invoice->client_address_2) {
             echo '<div>' . $invoice->client_address_2 . '</div>';
         }
-        if ($invoice->client_city && $invoice->client_zip) {
-            echo '<div>' . $invoice->client_city . ' ' . $invoice->client_zip . '</div>';
-        } else {
+        if ($invoice->client_city || $invoice->client_state || $invoice->client_zip) {
+            echo '<div>';
             if ($invoice->client_city) {
-                echo '<div>' . $invoice->client_city . '</div>';
+                echo $invoice->client_city . ' ';
+            }
+            if ($invoice->client_state) {
+                echo $invoice->client_state . ' ';
             }
             if ($invoice->client_zip) {
-                echo '<div>' . $invoice->client_zip . '</div>';
+                echo $invoice->client_zip;
             }
-        }
-        if ($invoice->client_state) {
-            echo '<div>' . $invoice->client_state . '</div>';
+            echo '</div>';
         }
         if ($invoice->client_country) {
             echo '<div>' . get_country_name(trans('cldr'), $invoice->client_country) . '</div>';
@@ -66,18 +66,18 @@
         if ($invoice->user_address_2) {
             echo '<div>' . $invoice->user_address_2 . '</div>';
         }
-        if ($invoice->user_city && $invoice->user_zip) {
-            echo '<div>' . $invoice->user_city . ' ' . $invoice->user_zip . '</div>';
-        } else {
+        if ($invoice->user_city || $invoice->user_state || $invoice->user_zip) {
+            echo '<div>';
             if ($invoice->user_city) {
-                echo '<div>' . $invoice->user_city . '</div>';
+                echo $invoice->user_city . ' ';
+            }
+            if ($invoice->user_state) {
+                echo $invoice->user_state . ' ';
             }
             if ($invoice->user_zip) {
-                echo '<div>' . $invoice->user_zip . '</div>';
+                echo $invoice->user_zip;
             }
-        }
-        if ($invoice->user_state) {
-            echo '<div>' . $invoice->user_state . '</div>';
+            echo '</div>';
         }
         if ($invoice->user_country) {
             echo '<div>' . get_country_name(trans('cldr'), $invoice->user_country) . '</div>';

--- a/application/views/invoice_templates/pdf/InvoicePlane.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane.php
@@ -28,18 +28,18 @@
         if ($invoice->client_address_2) {
             echo '<div>' . $invoice->client_address_2 . '</div>';
         }
-        if ($invoice->client_city && $invoice->client_zip) {
-            echo '<div>' . $invoice->client_city . ' ' . $invoice->client_zip . '</div>';
-        } else {
+        if ($invoice->client_city || $invoice->client_state || $invoice->client_zip) {
+            echo '<div>';
             if ($invoice->client_city) {
-                echo '<div>' . $invoice->client_city . '</div>';
+                echo $invoice->client_city . ' ';
+            }
+            if ($invoice->client_state) {
+                echo $invoice->client_state . ' ';
             }
             if ($invoice->client_zip) {
-                echo '<div>' . $invoice->client_zip . '</div>';
+                echo $invoice->client_zip;
             }
-        }
-        if ($invoice->client_state) {
-            echo '<div>' . $invoice->client_state . '</div>';
+            echo '</div>';
         }
         if ($invoice->client_country) {
             echo '<div>' . get_country_name(trans('cldr'), $invoice->client_country) . '</div>';
@@ -66,18 +66,18 @@
         if ($invoice->user_address_2) {
             echo '<div>' . $invoice->user_address_2 . '</div>';
         }
-        if ($invoice->user_city && $invoice->user_zip) {
-            echo '<div>' . $invoice->user_city . ' ' . $invoice->user_zip . '</div>';
-        } else {
+        if ($invoice->user_city || $invoice->user_state || $invoice->user_zip) {
+            echo '<div>';
             if ($invoice->user_city) {
-                echo '<div>' . $invoice->user_city . '</div>';
+                echo $invoice->user_city . ' ';
+            }
+            if ($invoice->user_state) {
+                echo $invoice->user_state . ' ';
             }
             if ($invoice->user_zip) {
-                echo '<div>' . $invoice->user_zip . '</div>';
+                echo $invoice->user_zip;
             }
-        }
-        if ($invoice->user_state) {
-            echo '<div>' . $invoice->user_state . '</div>';
+            echo '</div>';
         }
         if ($invoice->user_country) {
             echo '<div>' . get_country_name(trans('cldr'), $invoice->user_country) . '</div>';

--- a/application/views/quote_templates/pdf/InvoicePlane.php
+++ b/application/views/quote_templates/pdf/InvoicePlane.php
@@ -28,15 +28,18 @@
         if ($quote->client_address_2) {
             echo '<div>' . $quote->client_address_2 . '</div>';
         }
-        if ($quote->client_city && $quote->client_zip) {
-            echo '<div>' . $quote->client_city . ' ' . $quote->client_zip . '</div>';
-        } else {
+        if ($quote->client_city || $quote->client_state || $quote->client_zip) {
+            echo '<div>';
             if ($quote->client_city) {
-                echo '<div>' . $quote->client_city . '</div>';
+                echo $quote->client_city . ' ';
+            }
+            if ($quote->client_state) {
+                echo $quote->client_state . ' ';
             }
             if ($quote->client_zip) {
-                echo '<div>' . $quote->client_zip . '</div>';
+                echo $quote->client_zip;
             }
+            echo '</div>';
         }
         if ($quote->client_state) {
             echo '<div>' . $quote->client_state . '</div>';
@@ -66,18 +69,18 @@
         if ($quote->user_address_2) {
             echo '<div>' . $quote->user_address_2 . '</div>';
         }
-        if ($quote->user_city && $quote->user_zip) {
-            echo '<div>' . $quote->user_city . ' ' . $quote->user_zip . '</div>';
-        } else {
+        if ($quote->user_city || $quote->user_state || $quote->user_zip) {
+            echo '<div>';
             if ($quote->user_city) {
-                echo '<div>' . $quote->user_city . '</div>';
+                echo $quote->user_city . ' ';
+            }
+            if ($quote->user_state) {
+                echo $quote->user_state . ' ';
             }
             if ($quote->user_zip) {
-                echo '<div>' . $quote->user_zip . '</div>';
+                echo $quote->user_zip;
             }
-        }
-        if ($quote->user_state) {
-            echo '<div>' . $quote->user_state . '</div>';
+            echo '</div>';
         }
         if ($quote->user_country) {
             echo '<div>' . get_country_name(trans('cldr'), $quote->user_country) . '</div>';


### PR DESCRIPTION
This PR changes the format of the client postal address in PDF templates.

Issue: [[IP-477] Nonstandard address format in templates](https://development.invoiceplane.com/browse/IP-477)

## Before

```
{{ Address 1 }}
{{ Address 2 }}
{{ City and/or ZIP Code }}
{{ State }}
```

## After [(Standard US Mail format](http://pe.usps.gov/text/pub28/28c2_001.htm#ep526236))

```
{{ Address 1 }}
{{ Address 2 }}
{{ City }} {{ State }} {{ ZIP Code }}
```