### PR TITLE
Bugfix: create new client in create invoice/quote modal

### DIFF
--- a/application/modules/invoices/views/modal_create_invoice.php
+++ b/application/modules/invoices/views/modal_create_invoice.php
@@ -8,7 +8,7 @@
         });
 
         $().ready(function () {
-            $("[name='client_name']").select2();
+            $("[name='client_name']").select2({tags: true});
         });
 
         // Creates the invoice

--- a/application/modules/quotes/views/modal_create_quote.php
+++ b/application/modules/quotes/views/modal_create_quote.php
@@ -8,7 +8,7 @@
         });
 
         $().ready(function () {
-            $("[name='client_name']").select2();
+            $("[name='client_name']").select2({tags: true});
             $("#client_name").focus();
         });
 


### PR DESCRIPTION
Hi all, today I upgraded a large edited version of InvoicePlane that I use personally and was at v1.4.4. 
Now I'm at v1.4.10 and I can't create new clients from the modal views for creating invoices or quotes. 

I see the history of the file and noted that you upgraded select2 to 4.x. 

So, if I'm not wrong, the issue is present since the commit [3d168a3](https://github.com/InvoicePlane/InvoicePlane/commit/3d168a395d7cd975c565a6347fcd7219b3ba7542#diff-1f5a04c026eaf82cdfeeb022e0c03138), so since the release tagged v1.4.5 (tested on my fork).

I also tested your demo on web site and it is also affected, so it doesn't appear to be an error in my hacks.

The files affected are:

* application/modules/invoices/views/modal_create_invoice.php
* application/modules/quotes/views/modal_create_quote.php

Here the pull request that fix the issue

Bye
Aleskandro