### PR TITLE
Suggestion: replaced header menu bar username / company text with icon

### DIFF
--- a/application/modules/layout/views/layout.php
+++ b/application/modules/layout/views/layout.php
@@ -275,13 +275,21 @@
                 </li>
                 <li>
                     <a href="<?php echo site_url('users/form/' .
-                        $this->session->userdata('user_id')); ?>">
-                        <?php
+                        $this->session->userdata('user_id')); ?>"
+                        class="tip icon" data-placement="bottom"
+                        data-original-title="<?php
                         print($this->session->userdata('user_name'));
                         if ($this->session->userdata('user_company')) {
                             print(" (" . $this->session->userdata('user_company') . ")");
                         }
-                        ?>
+                        ?>">
+                        <i class="fa fa-user-circle-o"></i>
+                        <span class="visible-xs">&nbsp;<?php
+                        print($this->session->userdata('user_name'));
+                        if ($this->session->userdata('user_company')) {
+                            print(" (" . $this->session->userdata('user_company') . ")");
+                        }
+                        ?></span>
                     </a>
                 </li>
                 <li>


### PR DESCRIPTION
Benefits:
- More consistent design.
- Less ’noise’.
- If user and company name is long, it breaks onto a new line at
certain screen sizes, this should be more compact and stop that in most
cases.

[Original Header](http://pasteboard.co/xk6c2Nvig.png)
[New Header](http://pasteboard.co/xk6UGa9to.png)
[New Header Mobile](http://pasteboard.co/xk7pYIeWZ.png)