### PR TITLE
Suggestion: "data-original-title" to "title" attribute

### DIFF
--- a/application/modules/layout/views/layout.php
+++ b/application/modules/layout/views/layout.php
@@ -244,7 +244,7 @@
             <ul class="nav navbar-nav navbar-right">
                 <li>
                     <a href="http://docs.invoiceplane.com/" target="_blank"
-                       class="tip icon" data-original-title="<?php echo trans('documentation'); ?>"
+                       class="tip icon" title="<?php echo trans('documentation'); ?>"
                        data-placement="bottom">
                         <i class="fa fa-question-circle"></i>
                         <span class="visible-xs">&nbsp;<?php echo trans('documentation'); ?></span>
@@ -253,7 +253,7 @@
 
                 <li class="dropdown">
                     <a href="#" class="tip icon dropdown-toggle" data-toggle="dropdown"
-                       data-original-title="<?php echo trans('settings'); ?>"
+                       title="<?php echo trans('settings'); ?>"
                        data-placement="bottom">
                         <i class="fa fa-cogs"></i>
                         <span class="visible-xs">&nbsp;<?php echo trans('settings'); ?></span>
@@ -288,7 +288,7 @@
                 <li>
                     <a href="<?php echo site_url('sessions/logout'); ?>"
                        class="tip icon logout" data-placement="bottom"
-                       data-original-title="<?php echo trans('logout'); ?>">
+                       title="<?php echo trans('logout'); ?>">
                         <i class="fa fa-power-off"></i>
                         <span class="visible-xs">&nbsp;<?php echo trans('logout'); ?></span>
                     </a>

--- a/application/modules/layout/views/layout_guest.php
+++ b/application/modules/layout/views/layout_guest.php
@@ -69,7 +69,7 @@
                 <li>
                     <a href="<?php echo site_url('sessions/logout'); ?>"
                        class="tip icon logout" data-placement="bottom"
-                       data-original-title="<?php echo trans('logout'); ?>">
+                       title="<?php echo trans('logout'); ?>">
                         <span class="visible-xs">&nbsp;<?php echo trans('logout'); ?></span>
                         <i class="fa fa-power-off"></i>
                     </a>


### PR DESCRIPTION
The script itself moves the `title` to `data-original-title`. That way
the `title` attribute can be a fallback when JS is not enabled. I
believe this is the "correct" way to use this plugin.

Not a biggie, just a suggestion.