### PR TITLE
2-digit year format for invoice and quote numbers

### DIFF
--- a/application/language/english/ip_lang.php
+++ b/application/language/english/ip_lang.php
@@ -94,6 +94,7 @@ $lang = array(
     'current_month'                                => 'Current month',
     'current_version'                              => 'Current Version',
     'current_year'                                 => 'Current year',
+    'current_yy'                                   => 'Current year (2-digit format)',
     'custom_field_form'                            => 'Custom Field Form',
     'custom_fields'                                => 'Custom Fields',
     'custom_title'                                 => 'Custom Title',

--- a/application/modules/invoice_groups/models/Mdl_invoice_groups.php
+++ b/application/modules/invoice_groups/models/Mdl_invoice_groups.php
@@ -93,6 +93,9 @@ class Mdl_Invoice_Groups extends Response_Model
                     case 'year':
                         $replace = date('Y');
                         break;
+                    case 'yy':
+                        $replace = date('y');
+                        break;
                     case 'month':
                         $replace = date('m');
                         break;

--- a/application/modules/invoice_groups/views/form.php
+++ b/application/modules/invoice_groups/views/form.php
@@ -63,6 +63,7 @@
             <div class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
                 <a href="#" class="text-tag" data-tag="{{{id}}}"><?php echo trans('id'); ?></a><br>
                 <a href="#" class="text-tag" data-tag="{{{year}}}"><?php echo trans('current_year'); ?></a><br>
+                <a href="#" class="text-tag" data-tag="{{{yy}}}"><?php echo trans('current_yy'); ?></a><br>
                 <a href="#" class="text-tag" data-tag="{{{month}}}"><?php echo trans('current_month'); ?></a><br>
                 <a href="#" class="text-tag" data-tag="{{{day}}}"><?php echo trans('current_day'); ?></a><br>
             </div>


### PR DESCRIPTION
This allows invoice groups to use a two digit year format
like {{{yy}}}} in the invoice numbers.
This way in 2017 an invoice number may contain >>17<<.

Closes IP-488