### PR TITLE
CSS improvement: icons on same line as text in rest. menu

### DIFF
--- a/assets/default/sass/style.scss
+++ b/assets/default/sass/style.scss
@@ -1111,6 +1111,13 @@ legend, .install-step h2 {
         margin-top: 7px;
     }
 
+    // put icons on same line as text
+    .navbar-nav {
+        .visible-xs {
+            display: inline-block !important;
+        }
+    }
+
 }
 
 // Styles for very small devices (< xs)
@@ -1120,9 +1127,6 @@ legend, .install-step h2 {
         margin: 7px 0;
         .dropdown .dropdown-menu {
             background: #555;
-        }
-        .visible-xs {
-            display: inline-block !important;
         }
     }
 


### PR DESCRIPTION
Moved the css to a wider media query so they are on the same line the whole time the mobile menu is active, previously it only occurred at the smaller size.

[Tablet menu without fix](http://pasteboard.co/y7VURAlU5.png)
[Tablet menu with fix](http://pasteboard.co/y7WGmReS4.png)