### PR TITLE
Switch to trans() in partial_item_table

### DIFF
--- a/application/helpers/pdf_helper.php
+++ b/application/helpers/pdf_helper.php
@@ -161,7 +161,9 @@ function generate_invoice_sumex($invoice_id, $stream = true, $client = false){
     unlink($tempCopy);
 
     if($stream){
-      return $pdf->Output();
+      header("Content-Type", "application/pdf");
+      $pdf->Output($filename.'.pdf', 'I');
+      return;
     }
 
     $filePath = UPLOADS_FOLDER . 'temp/' . $filename . '.pdf';

--- a/application/modules/invoices/views/partial_item_table.php
+++ b/application/modules/invoices/views/partial_item_table.php
@@ -285,7 +285,7 @@
                     <?php echo trans('add_product'); ?>
                 </a>
                 <a href="#" class="btn_add_task btn btn-sm btn-default">
-                    <i class="fa fa-database"></i> <?php echo lang('add_task'); ?>
+                    <i class="fa fa-database"></i> <?php echo trans('add_task'); ?>
                 </a>
             <?php } ?>
         </div>


### PR DESCRIPTION
- Switch to trans() in partial_item_table: This way if the text isn't translated in another language it still appears in English
- Set a more descriptive filename: Sumex Invoices now when generated have a more descriptive name like `Invoice_INV-20170218_196bb16d.pdf` (instead of `doc.pdf`)