### PR TITLE
Added more effective search results on client names - IP-544

### DIFF
--- a/application/modules/clients/controllers/Ajax.php
+++ b/application/modules/clients/controllers/Ajax.php
@@ -37,9 +37,9 @@ class Ajax extends Admin_Controller
         $escapedQuery = str_replace("%", "", $escapedQuery);
         $clients = $this->mdl_clients
             ->where('client_active', 1)
-            ->having('client_name LIKE \'' . $escapedQuery . '%\'')
-            ->or_having('client_surname LIKE \'' . $escapedQuery . '%\'')
-            ->or_having('client_fullname LIKE \'' . $escapedQuery . '%\'')
+            ->having('client_name LIKE \'%' . $escapedQuery . '%\'')
+            ->or_having('client_surname LIKE \'%' . $escapedQuery . '%\'')
+            ->or_having('client_fullname LIKE \'%' . $escapedQuery . '%\'')
             ->order_by('client_name')
             ->get()
             ->result();


### PR DESCRIPTION
Ajax type-ahead for client names would'nt return results if you started typing "ohn" or "hn" while searching for a client named "John Doe" for example.
It now does.

https://community.invoiceplane.com/t/topic/4471/3