### PR TITLE
Add simple plain text body to email

### DIFF
--- a/application/modules/mailer/helpers/phpmailer_helper.php
+++ b/application/modules/mailer/helpers/phpmailer_helper.php
@@ -69,6 +69,7 @@ function phpmail_send(
 
     $mail->Subject = $subject;
     $mail->Body = $message;
+    $mail->AltBody = $mail->normalizeBreaks($mail->html2text($message));
 
 
     if (is_array($from)) {


### PR DESCRIPTION
Improve spam scores by including plain text email body