### PR TITLE
Make it possible to delete projects

### DIFF
--- a/application/modules/tasks/models/Mdl_tasks.php
+++ b/application/modules/tasks/models/Mdl_tasks.php
@@ -263,7 +263,7 @@ class Mdl_Tasks extends Response_Model
             ->get();
 
         foreach ($query->result() as $task) {
-            parent::save($task->task_id, array('task_project_id' => null));
+            parent::save($task->task_id, array('project_id' => null));
         }
     }
 }


### PR DESCRIPTION
Due to a wrong database column it was not possible to delete projects.

This is now fixed.