### PR TITLE
download link bug fix

### DIFF
--- a/application/modules/dashboard/views/index.php
+++ b/application/modules/dashboard/views/index.php
@@ -154,7 +154,7 @@
                                 </td>
                                 <td style="text-align: center;">
                                     <a href="<?php echo site_url('quotes/generate_pdf/' . $quote->quote_id); ?>"
-                                       title="<?php _trans('download_pdf'); ?>" target="_blank">
+                                       title="<?php _trans('download_pdf'); ?>">
                                         <i class="fa fa-file-pdf-o"></i>
                                     </a>
                                 </td>
@@ -228,12 +228,12 @@
                                 <td style="text-align: center;">
                                     <?php if ($invoice->sumex_id != null): ?>
                                         <a href="<?php echo site_url('invoices/generate_sumex_pdf/' . $invoice->invoice_id); ?>"
-                                           title="<?php _trans('download_pdf'); ?>" target="_blank">
+                                           title="<?php _trans('download_pdf'); ?>">
                                             <i class="fa fa-file-pdf-o"></i>
                                         </a>
                                     <?php else: ?>
                                         <a href="<?php echo site_url('invoices/generate_pdf/' . $invoice->invoice_id); ?>"
-                                           title="<?php _trans('download_pdf'); ?>" target="_blank">
+                                           title="<?php _trans('download_pdf'); ?>">
                                             <i class="fa fa-file-pdf-o"></i>
                                         </a>
                                     <?php endif; ?>

--- a/application/modules/upload/views/dropzone-quote-scripts.php
+++ b/application/modules/upload/views/dropzone-quote-scripts.php
@@ -68,11 +68,11 @@
                     var mockFile = {fullname: val.fullname, size: val.size, name: val.name};
 
                     thisDropzone.options.addedfile.call(thisDropzone, mockFile);
-                    createDownloadButton(mockFile, '<?php echo site_url('upload/get_file'); ?>/' + val.fullname);
+                    createDownloadButton(mockFile, '<?php echo site_url('upload/get_file/'); ?>' + val.fullname);
 
                     if (val.fullname.match(/\.(jpg|jpeg|png|gif)$/)) {
                         thisDropzone.options.thumbnail.call(thisDropzone, mockFile,
-                            '<?php echo site_url('upload/get_file'); ?>' + val.fullname);
+                            '<?php echo site_url('upload/get_file/'); ?>' + val.fullname);
                     } else {
                         thisDropzone.options.thumbnail.call(thisDropzone, mockFile,
                             '<?php echo site_url('assets/default/img/favicon.png'); ?>');
@@ -121,7 +121,7 @@
             downloadButtonList[$i].addEventListener("click", function (e) {
                 e.preventDefault();
                 e.stopPropagation();
-                window.open(fileUrl);
+                location.href = fileUrl;
                 return false;
             });
         }


### PR DESCRIPTION
- Fixed a bug where attached image files would point to a broken url and would not render (missing trailing slash).
- Changed `window.open` to `location.href` due to UX concerns.

On a side note: `$config['csrf_regenerate']` should be set to `false` within `/application/config/config.php` for the upload form to work properly. Otherwise you will not be able to upload consecutive files (csrf token 403 error).