### PR TITLE
Add non-html section to generated mail

### DIFF
--- a/application/modules/mailer/helpers/phpmailer_helper.php
+++ b/application/modules/mailer/helpers/phpmailer_helper.php
@@ -78,7 +78,8 @@ function phpmail_send($from, $to, $subject, $message, $attachment_path = null, $
     }
 
     $mail->Subject = $subject;
-    $mail->Body = $message;
+    $mail->Body = $mail->normalizeBreaks($message);
+    $mail->AltBody = $mail->normalizeBreaks($mail->html2text($message));
 
 
     if (is_array($from)) {


### PR DESCRIPTION
Many mail analyzers classify a mail as being spam if it only provides a HTML-body. This change adds a text-body too, and normalizes the breaks (feel free to remove the normalizeBreaks-calls if not desired).