### PR TITLE
[IP-543] - HTML mail templates not working

### DIFF
--- a/assets/core/js/scripts.js
+++ b/assets/core/js/scripts.js
@@ -46,7 +46,7 @@ function inject_email_template(template_fields, email_template) {
         // if key is in template_fields, apply value to form field
         if (val && template_fields.indexOf(key) > -1) {
             if (key === 'body') {
-                $("#" + key).html(val);
+                $("#" + key).text(val);
             } else {
                 $("#" + key).val(val);
             }


### PR DESCRIPTION
> jQuery.html() treats the string as HTML, jQuery.text() treats the content as text.

That's why the template was not displayed but interpreted.

