### PR TITLE
fix download link

### DIFF
--- a/application/views/invoice_templates/public/InvoicePlane_Web.php
+++ b/application/views/invoice_templates/public/InvoicePlane_Web.php
@@ -272,7 +272,7 @@
                                     <tr class="attachments">
                                         <td><?php echo $attachment['name']; ?></td>
                                         <td>
-                                            <a href="<?php echo base_url('/guest/get/attachment/' . $attachment['fullname']); ?>"
+                                            <a href="<?php echo site_url('guest/get/attachment/' . $attachment['fullname']); ?>"
                                                class="btn btn-primary btn-sm">
                                                 <i class="fa fa-download"></i> <?php echo trans('download') ?>
                                             </a>

--- a/application/views/quote_templates/public/InvoicePlane_Web.php
+++ b/application/views/quote_templates/public/InvoicePlane_Web.php
@@ -249,7 +249,7 @@
                                         <tr class="attachments">
                                             <td><?php echo $attachment['name']; ?></td>
                                             <td>
-                                                <a href="<?php echo base_url('/guest/get/attachment/' . $attachment['fullname']); ?>"
+                                                <a href="<?php echo site_url('guest/get/attachment/' . $attachment['fullname']); ?>"
                                                    class="btn btn-primary btn-sm">
                                                     <i class="fa fa-download"></i> <?php _trans('download') ?>
                                                 </a>


### PR DESCRIPTION
I don't know why it was setup like that as it attends to go in a controller to generate the file and not download with a direct link.
So I've changed it to site_url() to also get index.php if not removed (otherwise it produces a 404 not found)

(Follow this topic : https://community.invoiceplane.com/t/topic/5194/5 it can have a link) 