### PR TITLE
fix real path for windows

### DIFF
--- a/application/modules/guest/controllers/Get.php
+++ b/application/modules/guest/controllers/Get.php
@@ -17,10 +17,10 @@ class Get extends Base_Controller
 {
     public function attachment($filename)
     {
-        $path = UPLOADS_FOLDER . 'customer_files/';
+        $path = UPLOADS_FOLDER . 'customer_files'.DIRECTORY_SEPARATOR;
         $filePath = $path . $filename;
 
-        if (strpos(realpath($filePath), realpath($path)) !== 0) {
+        if (strpos(realpath($filePath), $path) !== 0) {
             header("Status: 403 Forbidden");
             echo '<h1>Forbidden</h1>';
             exit;

--- a/application/modules/guest/controllers/Get.php
+++ b/application/modules/guest/controllers/Get.php
@@ -20,7 +20,7 @@ class Get extends Base_Controller
         $path = UPLOADS_FOLDER . 'customer_files/';
         $filePath = $path . $filename;
 
-        if (strpos(realpath($filePath), $path) !== 0) {
+        if (strpos(realpath($filePath), realpath($path)) !== 0) {
             header("Status: 403 Forbidden");
             echo '<h1>Forbidden</h1>';
             exit;

--- a/index.php
+++ b/index.php
@@ -311,9 +311,9 @@ if ( ! isset($view_folder[0]) && is_dir(APPPATH.'views'.DIRECTORY_SEPARATOR))
 
 define('VIEWPATH', $view_folder.DIRECTORY_SEPARATOR);
 
-define('UPLOADS_FOLDER', FCPATH . 'uploads/');
+define('UPLOADS_FOLDER', FCPATH . 'uploads'.DIRECTORY_SEPARATOR);
 
-define('THEME_FOLDER', FCPATH . 'assets/');
+define('THEME_FOLDER', FCPATH . 'assets'.DIRECTORY_SEPARATOR);
 
 define('IPCONFIG_FILE', FCPATH . 'ipconfig.php');
 


### PR DESCRIPTION
It miss the realpath function for the customer files folder so the condition was not met on Windows 

> C:\wamp64\www\invoiceplane\uploads/customer_files

instead of 

> C:\wamp64\www\invoiceplane\uploads\customer_files


Be careful ! I didn't test it on a Linux server only on my Windows be sure to test it before merge it 
To see if it works just go on a guest invoice URL with an attachment and try to download it.


