### PR TITLE
[IP-620] - Invoice name with space results in corrupted in archive page

### DIFF
--- a/application/modules/invoices/controllers/Invoices.php
+++ b/application/modules/invoices/controllers/Invoices.php
@@ -107,6 +107,7 @@ class Invoices extends Admin_Controller
      */
     public function download($invoice)
     {
+        $invoice = urldecode($invoice);
         header('Content-type: application/pdf');
         header('Content-Disposition: attachment; filename="' . $invoice . '"');
         readfile('./uploads/archive/' . $invoice);

--- a/application/modules/invoices/controllers/Invoices.php
+++ b/application/modules/invoices/controllers/Invoices.php
@@ -107,10 +107,9 @@ class Invoices extends Admin_Controller
      */
     public function download($invoice)
     {
-        $invoice = urldecode($invoice);
         header('Content-type: application/pdf');
-        header('Content-Disposition: attachment; filename="' . $invoice . '"');
-        readfile('./uploads/archive/' . $invoice);
+        header('Content-Disposition: attachment; filename="' . urldecode($invoice) . '"');
+        readfile('./uploads/archive/' . urldecode($invoice));
     }
 
     /**


### PR DESCRIPTION
https://development.invoiceplane.com/browse/IP-620

If you want to download archives with space inside the name, it result in a corrupted file as it transforms space with `%20`.
It needs to have urldecode inside the `header` and `read_file` function to work properly and download without being corrupted.
