### PR TITLE
[IP-624] - Use default function valid_email() of CI

### DIFF
--- a/application/modules/users/models/Mdl_users.php
+++ b/application/modules/users/models/Mdl_users.php
@@ -55,7 +55,7 @@ class Mdl_Users extends Response_Model
             'user_email' => array(
                 'field' => 'user_email',
                 'label' => trans('email'),
-                'rules' => 'required|callback_validate_email|is_unique[ip_users.user_email]'
+                'rules' => 'required|valid_email|is_unique[ip_users.user_email]'
             ),
             'user_name' => array(
                 'field' => 'user_name',
@@ -147,7 +147,7 @@ class Mdl_Users extends Response_Model
             'user_email' => array(
                 'field' => 'user_email',
                 'label' => trans('email'),
-                'rules' => 'required|callback_validate_email'
+                'rules' => 'required|valid_email'
             ),
             'user_name' => array(
                 'field' => 'user_name',
@@ -234,14 +234,6 @@ class Mdl_Users extends Response_Model
         );
     }
 
-    /**
-     * @param string $str
-     * @return bool
-     */
-    public function validate_email($str)
-    {
-        return filter_var($str, FILTER_VALIDATE_EMAIL) ? true : false;
-    }
 
     /**
      * @return array


### PR DESCRIPTION
https://development.invoiceplane.com/browse/IP-624

It was using a custom function which had the same check than CI's default one without any error message which produces an error (https://gyazo.com/dcc16f474a781db09141eba1a301f538) 

I've tested with 

> mark@github.design

And it works perfectly, it was accepted (as it seems the old function of CI2 didn't accept new TLD's)


