### PR TITLE
Fix for output of Japanese font which was not displayed correctly

### DIFF
--- a/application/helpers/mpdf_helper.php
+++ b/application/helpers/mpdf_helper.php
@@ -51,6 +51,7 @@ function pdf_create(
     // mPDF configuration
     $mpdf->useAdobeCJK = true;
     $mpdf->autoScriptToLang = true;
+    $mpdf->autoLangToFont = true;
 
     if (IP_DEBUG) {
         // Enable image error logging


### PR DESCRIPTION
PDF出力した日本語フォントが正しく表示されていなかったので、設定を追加しました。