### PR TITLE
[IP-652] - Paypal sandbox not working

### DIFF
--- a/application/modules/guest/controllers/Payment_handler.php
+++ b/application/modules/guest/controllers/Payment_handler.php
@@ -180,7 +180,7 @@ class Payment_Handler extends Base_Controller
             if (isset($gateway_settings[$key]) && $gateway_settings[$key]['type'] == 'password') {
                 $value = $this->crypt->decode($setting->setting_value);
             } elseif (isset($gateway_settings[$key]) && $gateway_settings[$key]['type'] == 'checkbox') {
-                $value = $setting->setting_value == 'on' ? true : false;
+                $value = $setting->setting_value == '1' ? true : false;
             } else {
                 $value = $setting->setting_value;
             }


### PR DESCRIPTION
Change the verification from "on" to "1" as it's saved with 0/1 in DB. So it needs to fit the actual settings to enter in the condition and use correctly the test mode.

https://development.invoiceplane.com/browse/IP-652
The fix has been tested (cf community post)

