### PR TITLE
[IP719]  Remove search box from Select2 dropdown lists when not needed

### DIFF
--- a/application/modules/clients/views/form.php
+++ b/application/modules/clients/views/form.php
@@ -260,7 +260,8 @@ $cv = $this->controller->view_data['custom_values'];
                             <label for="client_gender"><?php _trans('gender'); ?></label>
 
                             <div class="controls">
-                                <select name="client_gender" id="client_gender" class="form-control simple-select">
+                                <select name="client_gender" id="client_gender"
+                                	class="form-control simple-select" data-minimum-results-for-search="Infinity">
                                     <?php
                                     $genders = array(
                                         trans('gender_male'),

--- a/application/modules/invoices/views/modal_create_invoice.php
+++ b/application/modules/invoices/views/modal_create_invoice.php
@@ -113,7 +113,8 @@
 
             <div class="form-group">
                 <label for="invoice_group_id"><?php _trans('invoice_group'); ?></label>
-                <select name="invoice_group_id" id="invoice_group_id" class="form-control simple-select">
+                <select name="invoice_group_id" id="invoice_group_id"
+                	class="form-control simple-select" data-minimum-results-for-search="Infinity">
                     <?php foreach ($invoice_groups as $invoice_group) { ?>
                         <option value="<?php echo $invoice_group->invoice_group_id; ?>"
                                 <?php if (get_setting('default_invoice_group') == $invoice_group->invoice_group_id) { ?>selected="selected"<?php } ?>>

--- a/application/modules/invoices/views/view.php
+++ b/application/modules/invoices/views/view.php
@@ -417,7 +417,7 @@ if ($this->config->item('disable_read_only') == true) {
                                         } ?>
                                     </label>
                                     <select name="invoice_status_id" id="invoice_status_id"
-                                            class="form-control input-sm simple-select"
+                                            class="form-control input-sm simple-select" data-minimum-results-for-search="Infinity"
                                         <?php if ($invoice->is_read_only == 1 && $invoice->invoice_status_id == 4) {
                                             echo 'disabled="disabled"';
                                         } ?>>

--- a/application/modules/payments/views/form.php
+++ b/application/modules/payments/views/form.php
@@ -103,7 +103,8 @@
                            value="<?php echo $this->mdl_payments->form_value('payment_method_id'); ?>">
                 <?php } ?>
 
-                <select id="payment_method_id" name="payment_method_id" class="form-control simple-select"
+                <select id="payment_method_id" name="payment_method_id"
+                	class="form-control simple-select" data-minimum-results-for-search="Infinity"
                     <?php echo($this->mdl_payments->form_value('payment_method_id') ? 'disabled="disabled"' : ''); ?>>
 
                     <?php foreach ($payment_methods as $payment_method) { ?>

--- a/application/modules/quotes/views/modal_create_quote.php
+++ b/application/modules/quotes/views/modal_create_quote.php
@@ -107,7 +107,8 @@
 
             <div class="form-group">
                 <label for="invoice_group_id"><?php _trans('invoice_group'); ?>: </label>
-                <select name="invoice_group_id" id="invoice_group_id" class="form-control simple-select">
+                <select name="invoice_group_id" id="invoice_group_id"
+                	class="form-control simple-select" data-minimum-results-for-search="Infinity">
                     <?php foreach ($invoice_groups as $invoice_group) { ?>
                         <option value="<?php echo $invoice_group->invoice_group_id; ?>"
                             <?php check_select(get_setting('default_quote_group'), $invoice_group->invoice_group_id); ?>>

--- a/application/modules/quotes/views/view.php
+++ b/application/modules/quotes/views/view.php
@@ -315,7 +315,7 @@ $cv = $this->controller->view_data["custom_values"];
                                         <?php _trans('status'); ?>
                                     </label>
                                     <select name="quote_status_id" id="quote_status_id"
-                                            class="form-control input-sm simple-select">
+                                            class="form-control input-sm simple-select" data-minimum-results-for-search="Infinity">
                                         <?php foreach ($quote_statuses as $key => $status) { ?>
                                             <option value="<?php echo $key; ?>"
                                                     <?php if ($key == $quote->quote_status_id) { ?>selected="selected"

--- a/application/modules/settings/views/partial_settings_email.php
+++ b/application/modules/settings/views/partial_settings_email.php
@@ -34,7 +34,7 @@
                             <?php _trans('email_pdf_attachment'); ?>
                         </label>
                         <select name="settings[email_pdf_attachment]" id="settings[email_pdf_attachment]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="0"><?php _trans('no'); ?></option>
                             <option value="1" <?php check_select(get_setting('email_pdf_attachment'), '1'); ?>>
                                 <?php _trans('yes'); ?>
@@ -47,7 +47,7 @@
                             <?php _trans('email_send_method'); ?>
                         </label>
                         <select name="settings[email_send_method]" id="email_send_method"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <option value="phpmail" <?php check_select(get_setting('email_send_method'), 'phpmail'); ?>>
                                 <?php _trans('email_send_method_phpmail'); ?>

--- a/application/modules/settings/views/partial_settings_general.php
+++ b/application/modules/settings/views/partial_settings_general.php
@@ -41,7 +41,7 @@
                             <?php _trans('theme'); ?>
                         </label>
                         <select name="settings[system_theme]" id="settings[system_theme]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <?php foreach ($available_themes as $theme_key => $theme_name) { ?>
                                 <option value="<?php echo $theme_key; ?>" <?php check_select(get_setting('system_theme'), $theme_key); ?>>
                                     <?php echo $theme_name; ?>
@@ -59,7 +59,7 @@
                             <?php _trans('first_day_of_week'); ?>
                         </label>
                         <select name="settings[first_day_of_week]" id="settings[first_day_of_week]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <?php foreach ($first_days_of_weeks as $first_day_of_week_id => $first_day_of_week_name) { ?>
                                 <option value="<?php echo $first_day_of_week_id; ?>"
                                     <?php check_select(get_setting('first_day_of_week'), $first_day_of_week_id); ?>>
@@ -135,7 +135,7 @@
                             <?php _trans('currency_symbol_placement'); ?>
                         </label>
                         <select name="settings[currency_symbol_placement]" id="settings[currency_symbol_placement]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="before" <?php check_select(get_setting('currency_symbol_placement'), 'before'); ?>>
                                 <?php _trans('before_amount'); ?>
                             </option>
@@ -175,7 +175,7 @@
                             <?php _trans('tax_rate_decimal_places'); ?>
                         </label>
                         <select name="settings[tax_rate_decimal_places]" class="form-control simple-select"
-                                id="tax_rate_decimal_places">
+                                id="tax_rate_decimal_places" data-minimum-results-for-search="Infinity">
                             <option value="2" <?php check_select(get_setting('tax_rate_decimal_places'), '2'); ?>>
                                 2
                             </option>
@@ -241,7 +241,7 @@
                             <?php _trans('quote_overview_period'); ?>
                         </label>
                         <select name="settings[quote_overview_period]" id="settings[quote_overview_period]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="this-month" <?php check_select(get_setting('quote_overview_period'), 'this-month'); ?>>
                                 <?php _trans('this_month'); ?>
                             </option>
@@ -270,7 +270,7 @@
                             <?php _trans('invoice_overview_period'); ?>
                         </label>
                         <select name="settings[invoice_overview_period]" id="settings[invoice_overview_period]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="this-month" <?php check_select(get_setting('invoice_overview_period'), 'this-month'); ?>>
                                 <?php _trans('this_month'); ?>
                             </option>
@@ -301,7 +301,7 @@
                             <?php _trans('disable_quickactions'); ?>
                         </label>
                         <select name="settings[disable_quickactions]" class="form-control simple-select"
-                                id="disable_quickactions">
+                                id="disable_quickactions" data-minimum-results-for-search="Infinity">
                             <option value="0">
                                 <?php _trans('no'); ?>
                             </option>
@@ -329,7 +329,7 @@
                             <?php _trans('disable_sidebar'); ?>
                         </label>
                         <select name="settings[disable_sidebar]" class="form-control simple-select"
-                                id="disable_sidebar">
+                                id="disable_sidebar" data-minimum-results-for-search="Infinity">
                             <option value="0">
                                 <?php _trans('no'); ?>
                             </option>
@@ -360,7 +360,7 @@
                             <?php _trans('monospaced_font_for_amounts'); ?>
                         </label>
                         <select name="settings[monospace_amounts]" class="form-control simple-select"
-                                id="monospace_amounts">
+                                id="monospace_amounts" data-minimum-results-for-search="Infinity">
                             <option value="0"><?php _trans('no'); ?></option>
                             <option value="1" <?php check_select(get_setting('monospace_amounts'), '1'); ?>>
                                 <?php _trans('yes'); ?>
@@ -396,7 +396,7 @@
                             <?php _trans('open_reports_in_new_tab'); ?>
                         </label>
                         <select name="settings[reports_in_new_tab]" id="settings[reports_in_new_tab]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="0"><?php _trans('no'); ?></option>
                             <option value="1" <?php check_select(get_setting('reports_in_new_tab'), '1'); ?>>
                                 <?php _trans('yes'); ?>
@@ -425,7 +425,7 @@
                             <?php _trans('bcc_mails_to_admin'); ?>
                         </label>
                         <select name="settings[bcc_mails_to_admin]" id="settings[bcc_mails_to_admin]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="0"><?php _trans('no'); ?></option>
                             <option value="1" <?php check_select(get_setting('bcc_mails_to_admin'), '1'); ?>>
                                 <?php _trans('yes'); ?>

--- a/application/modules/settings/views/partial_settings_invoices.php
+++ b/application/modules/settings/views/partial_settings_invoices.php
@@ -14,7 +14,7 @@
                             <?php _trans('default_invoice_group'); ?>
                         </label>
                         <select name="settings[default_invoice_group]" id="settings[default_invoice_group]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php foreach ($invoice_groups as $invoice_group) { ?>
                                 <option value="<?php echo $invoice_group->invoice_group_id; ?>"
@@ -42,7 +42,7 @@
                             <?php _trans('default_payment_method'); ?>
                         </label>
                         <select name="settings[invoice_default_payment_method]" class="form-control simple-select"
-                                id="settings[invoice_default_payment_method]">
+                                id="settings[invoice_default_payment_method]" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php
                             foreach ($payment_methods as $payment_method) { ?>
@@ -67,7 +67,7 @@
                             <?php _trans('generate_invoice_number_for_draft'); ?>
                         </label>
                         <select name="settings[generate_invoice_number_for_draft]" class="form-control simple-select"
-                                id="settings[generate_invoice_number_for_draft]">
+                                id="settings[generate_invoice_number_for_draft]" data-minimum-results-for-search="Infinity">
                             <option value="0">
                                 <?php _trans('no'); ?>
                             </option>
@@ -97,7 +97,7 @@
                             <?php _trans('mark_invoices_sent_pdf'); ?>
                         </label>
                         <select name="settings[mark_invoices_sent_pdf]" id="settings[mark_invoices_sent_pdf]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="0">
                                 <?php _trans('no'); ?>
                             </option>
@@ -112,7 +112,7 @@
                             <?php _trans('pdf_watermark'); ?>
                         </label>
                         <select name="settings[pdf_watermark]" id="settings[pdf_watermark]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="0">
                                 <?php _trans('no'); ?>
                             </option>
@@ -136,7 +136,7 @@
                             <?php _trans('invoice_pdf_include_zugferd'); ?>
                         </label>
                         <select name="settings[include_zugferd]" id="settings[include_zugferd]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="0">
                                 <?php _trans('no'); ?>
                             </option>
@@ -184,7 +184,7 @@
                             <?php _trans('default_pdf_template'); ?>
                         </label>
                         <select name="settings[pdf_invoice_template]" id="settings[pdf_invoice_template]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php foreach ($pdf_invoice_templates as $invoice_template) { ?>
                                 <option value="<?php echo $invoice_template; ?>"
@@ -200,7 +200,7 @@
                             <?php _trans('pdf_template_paid'); ?>
                         </label>
                         <select name="settings[pdf_invoice_template_paid]" id="settings[pdf_invoice_template_paid]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php foreach ($pdf_invoice_templates as $invoice_template) { ?>
                                 <option value="<?php echo $invoice_template; ?>"
@@ -216,7 +216,7 @@
                             <?php _trans('pdf_template_overdue'); ?>
                         </label>
                         <select name="settings[pdf_invoice_template_overdue]" class="form-control simple-select"
-                                id="settings[pdf_invoice_template_overdue]">
+                                id="settings[pdf_invoice_template_overdue]" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php foreach ($pdf_invoice_templates as $invoice_template) { ?>
                                 <option value="<?php echo $invoice_template; ?>"
@@ -232,7 +232,7 @@
                             <?php _trans('default_public_template'); ?>
                         </label>
                         <select name="settings[public_invoice_template]" id="settings[public_invoice_template]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php foreach ($public_invoice_templates as $invoice_template) { ?>
                                 <option value="<?php echo $invoice_template; ?>"
@@ -251,7 +251,7 @@
                             <?php _trans('default_email_template'); ?>
                         </label>
                         <select name="settings[email_invoice_template]" id="settings[email_invoice_template]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php foreach ($email_templates_invoice as $email_template) { ?>
                                 <option value="<?php echo $email_template->email_template_id; ?>"
@@ -267,7 +267,7 @@
                             <?php _trans('email_template_paid'); ?>
                         </label>
                         <select name="settings[email_invoice_template_paid]" id="settings[email_invoice_template_paid]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php foreach ($email_templates_invoice as $email_template) { ?>
                                 <option value="<?php echo $email_template->email_template_id; ?>"
@@ -283,7 +283,7 @@
                             <?php _trans('email_template_overdue'); ?>
                         </label>
                         <select name="settings[email_invoice_template_overdue]" class="form-control simple-select"
-                                id="settings[email_invoice_template_overdue]">
+                                id="settings[email_invoice_template_overdue]" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php foreach ($email_templates_invoice as $email_template) { ?>
                                 <option value="<?php echo $email_template->email_template_id; ?>"
@@ -329,7 +329,7 @@
                             <?php _trans('automatic_email_on_recur'); ?>
                         </label>
                         <select name="settings[automatic_email_on_recur]" id="settings[automatic_email_on_recur]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="0">
                                 <?php _trans('no'); ?>
                             </option>
@@ -359,7 +359,7 @@
                             <?php _trans('set_to_read_only'); ?>
                         </label>
                         <select name="settings[read_only_toggle]" id="settings[read_only_toggle]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="2" <?php check_select(get_setting('read_only_toggle'), '2'); ?>>
                                 <?php _trans('sent'); ?>
                             </option>
@@ -390,7 +390,8 @@
                         <label for="settings[sumex]">
                             <?php _trans('invoice_sumex'); ?>
                         </label>
-                        <select name="settings[sumex]" id="settings[sumex]" class="form-control simple-select">
+                        <select name="settings[sumex]" id="settings[sumex]"
+                        	class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="0">
                                 <?php _trans('no'); ?>
                             </option>
@@ -406,7 +407,7 @@
                             <?php _trans('invoice_sumex_sliptype'); ?>
                         </label>
                         <select name="settings[sumex_sliptype]" id="settings[sumex_sliptype]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <?php
                             $slipTypes = array("esr9", "esrRed");
                             foreach ($slipTypes as $k => $v): ?>
@@ -440,7 +441,7 @@
                             <?php _trans('invoice_sumex_place'); ?>
                         </label>
                         <select name="settings[sumex_place]" id="settings[sumex_place]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <?php
                             $places = Sumex::PLACES;
                             foreach ($places as $k => $v): ?>

--- a/application/modules/settings/views/partial_settings_projects_tasks.php
+++ b/application/modules/settings/views/partial_settings_projects_tasks.php
@@ -14,7 +14,7 @@
                             <?php _trans('enable_projects'); ?>
                         </label>
                         <select name="settings[projects_enabled]" class="form-control simple-select"
-                                id="settings[projects_enabled]">
+                                id="settings[projects_enabled]" data-minimum-results-for-search="Infinity">
                             <option value="0">
                                 <?php _trans('no'); ?>
                             </option>

--- a/application/modules/settings/views/partial_settings_quotes.php
+++ b/application/modules/settings/views/partial_settings_quotes.php
@@ -23,7 +23,7 @@
                             <?php _trans('default_quote_group'); ?>
                         </label>
                         <select name="settings[default_quote_group]" id="settings[default_quote_group]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php foreach ($invoice_groups as $invoice_group) { ?>
                                 <option value="<?php echo $invoice_group->invoice_group_id; ?>"
@@ -39,7 +39,7 @@
                             <?php _trans('mark_quotes_sent_pdf'); ?>
                         </label>
                         <select name="settings[mark_quotes_sent_pdf]" id="settings[mark_quotes_sent_pdf]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value="0">
                                 <?php _trans('no'); ?>
                             </option>
@@ -73,7 +73,7 @@
                             <?php _trans('generate_quote_number_for_draft'); ?>
                         </label>
                         <select name="settings[generate_quote_number_for_draft]" class="form-control simple-select"
-                                id="settings[generate_quote_number_for_draft]">
+                                id="settings[generate_quote_number_for_draft]" data-minimum-results-for-search="Infinity">
                             <option value="0">
                                 <?php _trans('no'); ?>
                             </option>
@@ -103,7 +103,7 @@
                             <?php _trans('default_pdf_template'); ?>
                         </label>
                         <select name="settings[pdf_quote_template]" id="settings[pdf_quote_template]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php foreach ($pdf_quote_templates as $quote_template) { ?>
                                 <option value="<?php echo $quote_template; ?>"
@@ -119,7 +119,7 @@
                             <?php _trans('default_public_template'); ?>
                         </label>
                         <select name="settings[public_quote_template]" id="settings[public_quote_template]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php foreach ($public_quote_templates as $quote_template) { ?>
                                 <option value="<?php echo $quote_template; ?>"
@@ -138,7 +138,7 @@
                             <?php _trans('default_email_template'); ?>
                         </label>
                         <select name="settings[email_quote_template]" id="settings[email_quote_template]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <?php foreach ($email_templates_quote as $email_template) { ?>
                                 <option value="<?php echo $email_template->email_template_id; ?>"

--- a/application/modules/settings/views/partial_settings_taxes.php
+++ b/application/modules/settings/views/partial_settings_taxes.php
@@ -30,7 +30,7 @@
                             <?php _trans('default_invoice_tax_rate_placement'); ?>
                         </label>
                         <select name="settings[default_include_item_tax]" id="settings[default_include_item_tax]"
-                                class="form-control simple-select">
+                                class="form-control simple-select" data-minimum-results-for-search="Infinity">
                             <option value=""><?php _trans('none'); ?></option>
                             <option value="0" <?php check_select(get_setting('default_include_item_tax'), '0'); ?>>
                                 <?php _trans('apply_before_item_tax'); ?>

--- a/application/modules/tasks/views/form.php
+++ b/application/modules/tasks/views/form.php
@@ -90,7 +90,8 @@ if ($this->mdl_tasks->form_value('task_id') && $this->mdl_tasks->form_value('tas
 
                         <div class="form-group">
                             <label for="task_status"><?php _trans('status'); ?></label>
-                            <select name="task_status" id="task_status" class="form-control simple-select">
+                            <select name="task_status" id="task_status" 
+                            	class="form-control simple-select" data-minimum-results-for-search="Infinity">
                                 <?php foreach ($task_statuses as $key => $status) {
                                     if ($this->mdl_tasks->form_value('task_status') != 4 && $key == 4) {
                                         continue;


### PR DESCRIPTION
Pull Request Checklist

  * [X] My code follows the code formatting guidelines.
  * [X] I have an issue ID for this pull request. 
  * [X] I selected the corresponding branch.
  * [X] I have rebased my changes on top of the corresponding branch.
  
Issue Type (Please check one or more)

  * [ ] Bugfix
  * [X] Improvement of an existing Feature 
  * [ ] New Feature

Remove the search box from the Select2 dropdown lists when not needed. For instance, when there is a short number of options or options are hard coded (e.g. yes/no questions). Fixed by adding 'data-minimum-results-for-search="Infinity"' to the select tag as suggested in:

- https://stackoverflow.com/questions/17480040/select2-hiding-the-search-box (in particular, Aaron Hudon's answer)
- https://github.com/select2/select2/issues/3199
- https://github.com/select2/select2/issues/3189