### PR TITLE
[IP-531] Return to the application current language

### DIFF
--- a/application/helpers/pdf_helper.php
+++ b/application/helpers/pdf_helper.php
@@ -35,7 +35,7 @@ function generate_invoice_pdf($invoice_id, $stream = true, $invoice_template = n
     $invoice = $CI->mdl_invoices->get_by_id($invoice_id);
     $invoice = $CI->mdl_invoices->get_payments($invoice);
 
-    // Override language with system language
+    // Override system language with client language
     set_language($invoice->client_language);
 
     if (!$invoice_template) {

--- a/application/helpers/trans_helper.php
+++ b/application/helpers/trans_helper.php
@@ -25,10 +25,19 @@ function trans($line, $id = '', $default = null)
 
     // Fall back to default language if the current language has no translated string
     if (empty($lang_string)) {
-        // Load the default language
+        // Save the current application language (code borrowed from Base_Controller.php)
+        $current_language = $CI->session->userdata('user_language');
+
+        if (empty($current_language) || $current_language == 'system') {
+            $current_language = get_setting('default_language');
+        }
+
+        // Load the default language and translate the string
         set_language('english');
         $lang_string = $CI->lang->line($line);
-        reset_language();
+
+        // Restore the application language to its previous setting
+        set_language($current_language);
     }
 
     // Fall back to the $line value if the default language has no translation either
@@ -65,27 +74,6 @@ function set_language($language)
     $CI->lang->load('form_validation', $new_language);
     $CI->lang->load('custom', $new_language);
     $CI->lang->load('gateway', $new_language);
-}
-
-/**
- * Reset the langauge to the default one
- *
- * @return void
- */
-function reset_language()
-{
-    // Clear the current loaded language
-    $CI =& get_instance();
-    $CI->lang->is_loaded = array();
-    $CI->lang->language = array();
-
-    // Reset to the default language
-    $default_lang = isset($CI->mdl_settings) ? $CI->mdl_settings->setting('default_language') : 'english';
-
-    $CI->lang->load('ip', $default_lang);
-    $CI->lang->load('form_validation', $default_lang);
-    $CI->lang->load('custom', $default_lang);
-    $CI->lang->load('gateway', $default_lang);
 }
 
 /**


### PR DESCRIPTION
Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request. 
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.
  
Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature 
  * [ ] New Feature

     New Feature

When translating a string not available in the current application language, (1) save the current language setting before switching to the default system-language to translate the string, and (2) once the string has been translated, restore the application to its original language setting.

I have tested the fix without errors in a multilingual setup, with 3 different non-English languages for the system, user and client:

- all strings have been properly translated in the first language which included them according to the hierarchy: user language, system language and English; and
- quote and invoice pdf files have been created in the client-language.
