### PR TITLE
[IP-737] Configure mPDF to include non-Latin characters

### DIFF
--- a/application/helpers/mpdf_helper.php
+++ b/application/helpers/mpdf_helper.php
@@ -51,6 +51,10 @@ function pdf_create(
     // mPDF configuration
     $mpdf->useAdobeCJK = true;
     $mpdf->autoScriptToLang = true;
+    $mpdf->autoLangToFont = true;
+    $mpdf->autoVietnamese = true;
+    $mpdf->autoArabic = true;
+    $mpdf->autoLangToFont = true;
 
     if (IP_DEBUG) {
         // Enable image error logging


### PR DESCRIPTION
Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request. 
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.
  
Issue Type (Please check one or more)

  * [ ] Bugfix
  * [x] Improvement of an existing Feature 
  * [ ] New Feature

Configure mPDF to include non-Latin characters in PDF files so that IP supports languages using the Cyrillic alphabet, the Arabic alphabet (aka Arabic abjad), the CJK ideographs (aka CJK characters or CJK pictograms), etc.

NOTE: InvoicePlane does not include all required font files and they must be downloaded from the mPDF web site or from third party repositories. That information will be added to the FAQ.
