### PR TITLE
[IP-745] Reorder tax line in invoice & quote views

### DIFF
--- a/application/modules/invoices/views/partial_item_table.php
+++ b/application/modules/invoices/views/partial_item_table.php
@@ -342,16 +342,16 @@
                             <form method="post"
                                 action="<?php echo site_url('invoices/delete_invoice_tax/' . $invoice->invoice_id . '/' . $invoice_tax_rate->invoice_tax_rate_id) ?>">
                                 <?php _csrf_field(); ?>
-                                <span class="amount">
-                                    <?php echo format_currency($invoice_tax_rate->invoice_tax_rate_amount); ?>
-                                </span>
-                                <span class="text-muted">
-                                    <?php echo htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' ' . format_amount($invoice_tax_rate->invoice_tax_rate_percent) ?>
-                                </span>
                                 <button type="submit" class="btn btn-xs btn-link"
                                         onclick="return confirm('<?php _trans('delete_tax_warning'); ?>');">
                                     <i class="fa fa-trash-o"></i>
                                 </button>
+                                <span class="text-muted">
+                                    <?php echo htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' ' . format_amount($invoice_tax_rate->invoice_tax_rate_percent) . '%' ?>
+                                </span>
+                                <span class="amount">
+                                    <?php echo format_currency($invoice_tax_rate->invoice_tax_rate_amount); ?>
+                                </span>
                             </form>
                         <?php }
                     } else {

--- a/application/modules/quotes/views/partial_item_table.php
+++ b/application/modules/quotes/views/partial_item_table.php
@@ -256,16 +256,16 @@
                             <form method="POST" class="form-inline"
                                   action="<?php echo site_url('quotes/delete_quote_tax/' . $quote->quote_id . '/' . $quote_tax_rate->quote_tax_rate_id) ?>">
                                 <?php _csrf_field(); ?>
-                                <span class="amount">
-                                    <?php echo format_currency($quote_tax_rate->quote_tax_rate_amount); ?>
-                                </span>
-                                <span class="text-muted">
-                                    <?php echo htmlsc($quote_tax_rate->quote_tax_rate_name) . ' ' . format_amount($quote_tax_rate->quote_tax_rate_percent) ?>
-                                </span>
                                 <button type="submit" class="btn btn-xs btn-link"
                                         onclick="return confirm('<?php _trans('delete_tax_warning'); ?>');">
                                     <i class="fa fa-trash-o"></i>
                                 </button>
+                                <span class="text-muted">
+                                    <?php echo htmlsc($quote_tax_rate->quote_tax_rate_name) . ' ' . format_amount($quote_tax_rate->quote_tax_rate_percent) . '%' ?>
+                                </span>
+                                <span class="amount">
+                                    <?php echo format_currency($quote_tax_rate->quote_tax_rate_amount); ?>
+                                </span>
                             </form>
                         <?php }
                     } else {


### PR DESCRIPTION
Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request. 
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.
  
Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature 
  * [ ] New Feature

Reorder the elements in the tax line in invoice & quote views to display the amount at the right end of the line as in:  [trash-icon] US Std 7,00% 28,00€
