### PR TITLE
[IP-728] Display payment form if there are custom fields

### DIFF
--- a/application/modules/invoices/controllers/Ajax.php
+++ b/application/modules/invoices/controllers/Ajax.php
@@ -1,5 +1,7 @@
 <?php
-if (!defined('BASEPATH')) exit('No direct script access allowed');
+if (!defined('BASEPATH')) {
+    exit('No direct script access allowed');
+}
 
 /*
  * InvoicePlane

--- a/application/modules/invoices/controllers/Invoices.php
+++ b/application/modules/invoices/controllers/Invoices.php
@@ -1,7 +1,5 @@
 <?php
-if (!defined('BASEPATH')) {
-    exit('No direct script access allowed');
-}
+if (!defined('BASEPATH')) exit('No direct script access allowed');
 
 /*
  * InvoicePlane
@@ -182,6 +180,10 @@ class Invoices extends Admin_Controller
             }
         }
 
+        // Check whether there are payment custom fields
+        $payment_cf = $this->mdl_custom_fields->by_table('ip_payment_custom')->get();
+        $payment_cf_exist = ($payment_cf->num_rows() > 0) ? "yes" : "no";
+
         $this->layout->set(
             [
                 'invoice' => $invoice,
@@ -199,6 +201,7 @@ class Invoices extends Admin_Controller
                     'decimal_point' => get_setting('decimal_point'),
                 ],
                 'invoice_statuses' => $this->mdl_invoices->statuses(),
+                'payment_cf_exist' => $payment_cf_exist,
             ]
         );
 

--- a/application/modules/invoices/controllers/Invoices.php
+++ b/application/modules/invoices/controllers/Invoices.php
@@ -1,5 +1,7 @@
 <?php
-if (!defined('BASEPATH')) exit('No direct script access allowed');
+if (!defined('BASEPATH')) {
+    exit('No direct script access allowed');
+}
 
 /*
  * InvoicePlane

--- a/application/modules/invoices/views/view.php
+++ b/application/modules/invoices/views/view.php
@@ -224,7 +224,8 @@ if ($this->config->item('disable_read_only') == true) {
                         <a href="#" class="invoice-add-payment"
                            data-invoice-id="<?php echo $invoice_id; ?>"
                            data-invoice-balance="<?php echo $invoice->invoice_balance; ?>"
-                           data-invoice-payment-method="<?php echo $invoice->payment_method; ?>">
+                           data-invoice-payment-method="<?php echo $invoice->payment_method; ?>"
+                           data-payment-cf-exist="<?php echo $payment_cf_exist; ?>">
                             <i class="fa fa-credit-card fa-margin"></i>
                             <?php _trans('enter_payment'); ?>
                         </a>

--- a/application/modules/layout/views/includes/head.php
+++ b/application/modules/layout/views/includes/head.php
@@ -87,13 +87,15 @@
         });
 
         $(document).on('click', '.invoice-add-payment', function () {
-            invoice_id = $(this).data('invoice-id');
-            invoice_balance = $(this).data('invoice-balance');
-            invoice_payment_method = $(this).data('invoice-payment-method');
+            var invoice_id = $(this).data('invoice-id');
+            var invoice_balance = $(this).data('invoice-balance');
+            var invoice_payment_method = $(this).data('invoice-payment-method');
+            var payment_cf_exist =  $(this).data('payment-cf-exist');
             $('#modal-placeholder').load("<?php echo site_url('payments/ajax/modal_add_payment'); ?>", {
                 invoice_id: invoice_id,
                 invoice_balance: invoice_balance,
-                invoice_payment_method: invoice_payment_method
+                invoice_payment_method: invoice_payment_method,
+                payment_cf_exist: payment_cf_exist
             });
         });
 

--- a/application/modules/payments/controllers/Ajax.php
+++ b/application/modules/payments/controllers/Ajax.php
@@ -22,10 +22,11 @@ class Ajax extends Admin_Controller
         $this->load->model('payments/mdl_payments');
 
         if ($this->mdl_payments->run_validation()) {
-            $this->mdl_payments->save();
+            $payment_id = $this->mdl_payments->save();
 
             $response = array(
-                'success' => 1
+                'success' => 1,
+                'payment_id' => $payment_id
             );
         } else {
             $this->load->helper('json_error');
@@ -43,12 +44,14 @@ class Ajax extends Admin_Controller
         $this->load->module('layout');
         $this->load->model('payments/mdl_payments');
         $this->load->model('payment_methods/mdl_payment_methods');
+        $this->load->model('custom_fields/mdl_payment_custom');
 
         $data = array(
             'payment_methods' => $this->mdl_payment_methods->get()->result(),
             'invoice_id' => $this->input->post('invoice_id'),
             'invoice_balance' => $this->input->post('invoice_balance'),
-            'invoice_payment_method' => $this->input->post('invoice_payment_method')
+            'invoice_payment_method' => $this->input->post('invoice_payment_method'),
+            'payment_cf_exist' => $this->input->post('payment_cf_exist')
         );
 
         $this->layout->load_view('payments/modal_add_payment', $data);

--- a/application/modules/payments/views/modal_add_payment.php
+++ b/application/modules/payments/views/modal_add_payment.php
@@ -28,7 +28,7 @@
 						    window.location = "<?php echo site_url('payments/form'); ?>/" + response.payment_id;
 						}
 						else {
-                            // There are no payment custom fields, return to payments view
+                            // There are no payment custom fields, return to invoice view
 							window.location = "<?php echo $_SERVER['HTTP_REFERER']; ?>";
 						}
                     }

--- a/application/modules/payments/views/modal_add_payment.php
+++ b/application/modules/payments/views/modal_add_payment.php
@@ -22,14 +22,23 @@
                     var response = JSON.parse(data);
                     if (response.success === 1) {
                         // The validation was successful and payment was added
-                        window.location = "<?php echo $_SERVER['HTTP_REFERER']; ?>";
+                        if ($('#payment_cf_exist').val() === 'yes') {
+                            // There are payment custom fields, display the payment form
+                            // to allow completing the custom fields
+						    window.location = "<?php echo site_url('payments/form'); ?>/" + response.payment_id;
+						}
+						else {
+                            // There are no payment custom fields, return to payments view
+							window.location = "<?php echo $_SERVER['HTTP_REFERER']; ?>";
+						}
                     }
                     else {
                         // The validation was not successful
                         $('.control-group').removeClass('has-error');
                         for (var key in response.validation_errors) {
-                            $('#' + key).parent().parent().addClass('has-error');
-
+                            if(response.validation_errors.hasOwnProperty(key)) {
+                                $('#' + key).parent().parent().addClass('has-error');
+                            }
                         }
                     }
                 });
@@ -109,6 +118,11 @@
                         <textarea name="payment_note" id="payment_note" class="form-control"></textarea>
                     </div>
                 </div>
+
+                <!-- Add a hidden input field to pass whether payment custom fields have been create -->
+                <input type="hidden" name="payment_cf_exist" id="payment_cf_exist"
+                    value="<?php echo $payment_cf_exist; ?>">
+
             </form>
         </div>
 


### PR DESCRIPTION
Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request. 
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.
  
Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature 
  * [ ] New Feature

When creating an invoice payment through the modal window "Enter Payment" and clicking the [save] button, if there are payment custom fields take the user to the payment form so that (s)he can fill them before saving the payment, Otherwise, return to the invoice form.
