### PR TITLE
Prevent information disclosure in PHPmailer

### DIFF
--- a/application/modules/mailer/helpers/phpmailer_helper.php
+++ b/application/modules/mailer/helpers/phpmailer_helper.php
@@ -38,6 +38,10 @@ function phpmail_send(
     $mail = new \PHPMailer\PHPMailer\PHPMailer();
     $mail->CharSet = 'UTF-8';
     $mail->isHTML();
+    // Remove unnecessary information disclosure
+    if (!IP_DEBUG) {
+        $mail->XMailer = null;
+    }
 
     switch (get_setting('email_send_method')) {
         case 'smtp':


### PR DESCRIPTION
PHPmailer class by default adds 'x-mailer' email header that does nothing but disclosing the version and platform used to send the email
`X-Mailer: PHPMailer 6.1.5 (https://github.com/PHPMailer/PHPMailer)`

<!--
Please check the following steps to submit your pull request. If you have any questions please read the contribution guide available at https://go.invoiceplane.com/contribguide or join the community forums or the Slack channel.
You can check items by changing `[ ]` to `[x]`.
If you can't check all checklist items please add `[WIP]` in front of your title.
Remove this first paragraph but please keep the following checklist even if it's incomplete. Pull requests without the checklist will be rejected.
-->

Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request. 
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.
  
Issue Type (Please check one or more)

  * [ ] Bugfix
  * [x] Improvement of an existing Feature 
  * [ ] New Feature
