### PR TITLE
Make product.* available in quotes

### DIFF
--- a/application/modules/quotes/models/Mdl_quote_items.php
+++ b/application/modules/quotes/models/Mdl_quote_items.php
@@ -24,7 +24,8 @@ class Mdl_Quote_Items extends Response_Model
 
     public function default_select()
     {
-        $this->db->select('ip_quote_item_amounts.*, ip_quote_items.*, item_tax_rates.tax_rate_percent AS item_tax_rate_percent');
+        $this->db->select('ip_quote_item_amounts.*, ip_products.*, ip_quote_items.*,
+            item_tax_rates.tax_rate_percent AS item_tax_rate_percent');
     }
 
     public function default_order_by()
@@ -36,6 +37,7 @@ class Mdl_Quote_Items extends Response_Model
     {
         $this->db->join('ip_quote_item_amounts', 'ip_quote_item_amounts.item_id = ip_quote_items.item_id', 'left');
         $this->db->join('ip_tax_rates AS item_tax_rates', 'item_tax_rates.tax_rate_id = ip_quote_items.item_tax_rate_id', 'left');
+        $this->db->join('ip_products', 'ip_products.product_id = ip_quote_items.item_product_id', 'left');
     }
 
     /**
@@ -48,6 +50,11 @@ class Mdl_Quote_Items extends Response_Model
                 'field' => 'quote_id',
                 'label' => trans('quote'),
                 'rules' => 'required',
+            ],
+            'item_sku' => [
+                'field' => 'item_sku',
+                'label' => trans('item_sku'),
+                'rules' => 'required|unique',
             ],
             'item_name' => [
                 'field' => 'item_name',


### PR DESCRIPTION
Make $item->product values available in quotes (just as they are in invoices) as announced in the forum https://community.invoiceplane.com/t/topic/9188

Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request. (Issues are deactivated?)
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.
  
Issue Type (Please check one or more)

  * [ ] Bugfix
  * [x] Improvement of an existing Feature 
  * [ ] New Feature
