### PR TITLE
Fix Payment Method Select

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ adminer.php
 /nbproject
 /.php_cs.cache
 /doc
+.history

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ adminer.php
 /nbproject
 /.php_cs.cache
 /doc
-.history

--- a/application/modules/payments/views/form.php
+++ b/application/modules/payments/views/form.php
@@ -8,7 +8,7 @@
         $invoice_id.change(function () {
             var invoice_identifier = "invoice" + $('#invoice_id').val();
             $('#payment_amount').val(amounts[invoice_identifier].replace("&nbsp;", " "));
-            $('#payment_method_id').find('option[value="' + invoice_payment_methods[invoice_identifier] + '"]').prop('selected', true);
+            $('#payment_method_id').val(invoice_payment_methods[invoice_identifier]).trigger('change');
 
             if (invoice_payment_methods[invoice_identifier] != 0) {
                 $('.payment-method-wrapper').append("<input type='hidden' name='payment_method_id' id='payment-method-id-hidden' class='hidden' value='" + invoice_payment_methods[invoice_identifier] + "'>");


### PR DESCRIPTION
When a payment method exists on the invoice, the select is disabled with the wrong option selected.  Set the select value and trigger a change so that select2 re-renders the selected value.


Pull Request Checklist

  * [X ] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request. 
  * [ ] I selected the corresponding branch.
  * [ ] I have rebased my changes on top of the corresponding branch.
  
Issue Type (Please check one or more)

  * [x ] Bugfix
  * [ ] Improvement of an existing Feature 
  * [ ] New Feature
