### PR TITLE
Escape client name for PDF generation (Only in Zugferd invoices)

### DIFF
--- a/application/libraries/ZugferdXml.php
+++ b/application/libraries/ZugferdXml.php
@@ -140,7 +140,7 @@ class ZugferdXml
     protected function xmlBuyerTradeParty($index = '', $item = '')
     {
         $node = $this->doc->createElement('ram:BuyerTradeParty');
-        $node->appendChild($this->doc->createElement('ram:Name', $this->invoice->client_name));
+        $node->appendChild($this->doc->createElement('ram:Name', htmlsc($this->invoice->client_name)));
 
         // PostalTradeAddress
         $addressNode = $this->doc->createElement('ram:PostalTradeAddress');


### PR DESCRIPTION
This PR fixes the issue #809. If the client name has an & in their name, it would break PDF generation otherwise.

Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request. 
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.
  
Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature 
  * [ ] New Feature
