### PR TITLE
[IP-886]: login_log fields length correction

### DIFF
--- a/application/modules/setup/sql/035_1.5.12.sql
+++ b/application/modules/setup/sql/035_1.5.12.sql
@@ -1,5 +1,5 @@
 CREATE TABLE `ip_login_log` (
-    `login_name` varchar(255),
+    `login_name` varchar(100),
     `log_count` int DEFAULT 0,
     `log_create_timestamp` datetime,
     PRIMARY KEY (login_name)


### PR DESCRIPTION
the length of the field by varchar(100) is enough (since login table uses the same length) and provides additional security. Closes #886 

Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request. (#886)
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.
  
Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature 
  * [ ] New Feature
