### PR TITLE
fix loading stripe for websites not using clean urls (#883)

### DIFF
--- a/application/modules/guest/views/payment_information.php
+++ b/application/modules/guest/views/payment_information.php
@@ -266,7 +266,7 @@
             $("#fullpage-loader").fadeIn(200);
             $('#standard-card-form').hide();
             $('#ajax-card-form').show();
-            $('#ajax-card-form').load('<?php echo base_url(); ?>guest/payment_information/stripe');
+            $('#ajax-card-form').load('<?php echo site_url('guest/payment_information/stripe');?>');
         }
         else if($('#gateway-select').select2('data')[0].id === "none")
         {


### PR DESCRIPTION
## Description
known issue was not completely solved in beta version. Stripe library is now loaded by passing a php script instead of injecting js directly. IP must therefore use site_url variable instead of base_url.

## Related Issue
#883 

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request. (#883)
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
