### PR TITLE
Fix: Inserting email template

### DIFF
--- a/assets/core/js/scripts.js
+++ b/assets/core/js/scripts.js
@@ -46,7 +46,7 @@ function inject_email_template(template_fields, email_template) {
         // if key is in template_fields, apply value to form field
         if (val && template_fields.indexOf(key) > -1) {
             if (key === 'body') {
-                $("#" + key).html(val);
+                $("#" + key).val(val);
             } else if (key === 'pdf_template') {
                 $("#" + key).val(val).trigger('change');
             } else {

--- a/assets/core/js/scripts.js
+++ b/assets/core/js/scripts.js
@@ -45,9 +45,7 @@ function inject_email_template(template_fields, email_template) {
         key = key.replace("email_template_", "");
         // if key is in template_fields, apply value to form field
         if (val && template_fields.indexOf(key) > -1) {
-            if (key === 'body') {
-                $("#" + key).val(val);
-            } else if (key === 'pdf_template') {
+            if (key === 'pdf_template') {
                 $("#" + key).val(val).trigger('change');
             } else {
                 $("#" + key).val(val);


### PR DESCRIPTION
## Description
When selecting an email template on the 'send invoice' page, it won't get inserted into the textarea. val() instead of html() has to be used here.

## Motivation and Context
Fixes the above mentioned issue.

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request.
  * [ ] I selected the corresponding branch.
  * [ ] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
