### PR TITLE
IP-895: Option to Initiate Terms When Sending Invoice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ adminer.php
 /nbproject
 /.php_cs.cache
 /doc
+*.bak

--- a/application/language/english/ip_lang.php
+++ b/application/language/english/ip_lang.php
@@ -332,6 +332,7 @@ $lang = array(
     'no_overdue_invoices'                          => 'No overdue Invoices',
     'no_quotes_requiring_approval'                 => 'There are no quotes requiring approval.',
     'no_updates_available'                         => 'No updates available.',
+		'no_update_invoice_due_date_mail'							 => 'Disable the change of invoice date and due date before emailing',
     'none'                                         => 'None',
     'note'                                         => 'Note',
     'notes'                                        => 'Notes',

--- a/application/modules/invoices/models/Mdl_invoices.php
+++ b/application/modules/invoices/models/Mdl_invoices.php
@@ -582,4 +582,39 @@ class Mdl_Invoices extends Response_Model
         }
     }
 
+    /**
+     * Update the invoice date and due date
+     * @param $invoice_id
+     */
+    public function update_invoice_due_dates($invoice_id)
+    {
+        $invoice = $this->get_by_id($invoice_id);
+        
+        if (!empty($invoice)) {
+						$invoice_date_created = date_to_mysql(date(date_format_setting()));          
+            $this->db->where('invoice_id', $invoice_id);
+            $this->db->set('invoice_date_created', $invoice_date_created);
+            $this->db->set('invoice_date_due', $this->get_date_due($invoice_date_created));            
+            $this->db->update('ip_invoices');
+        }
+    }
+
+    /**
+	 * Reset the invoice and due date to there former values 
+     * @param $invoice_id
+	 * @param $org_invoice_date
+	 * @param $org_due_date
+     */
+    public function reset_invoice_due_dates($invoice_id, $org_invoice_date, $org_due_date)
+    {
+        $invoice = $this->get_by_id($invoice_id);
+        
+        if (!empty($invoice)) {        
+            $this->db->where('invoice_id', $invoice_id);
+            $this->db->set('invoice_date_created', $org_invoice_date);
+            $this->db->set('invoice_date_due', $org_due_date);            
+            $this->db->update('ip_invoices');
+        }
+    }
+
 }

--- a/application/modules/settings/views/partial_settings_invoices.php
+++ b/application/modules/settings/views/partial_settings_invoices.php
@@ -372,6 +372,25 @@
                         </div>
 
                     </div>
+
+					<!-- Disable the update of invoice date and due date before emailing! -->
+                    <div class="col-xs-12 col-md-6">                    
+                    <div class="form-group">
+                            <label for="settings[no_update_invoice_due_date_mail]">
+                                <?php _trans('no_update_invoice_due_date_mail'); ?>
+                            </label>
+                            <select name="settings[no_update_invoice_due_date_mail]" class="form-control simple-select"
+                                id="settings[no_update_invoice_due_date_mail]" data-minimum-results-for-search="Infinity">
+                                <option value="0">
+                                    <?php _trans('no'); ?>
+                                </option>
+                                <option value="1" <?php check_select(get_setting('no_update_invoice_due_date_mail'), '1'); ?>>
+                                    <?php _trans('yes'); ?>
+                                </option>
+                            </select>
+                        </div>
+                    </div>
+
                 </div>
 
             </div>

--- a/application/modules/settings/views/partial_settings_invoices.php
+++ b/application/modules/settings/views/partial_settings_invoices.php
@@ -373,17 +373,17 @@
 
                     </div>
 
-					<!-- Disable the update of invoice date and due date before emailing! -->
+                    <!-- Disable the update of invoice date and due date before emailing! -->
                     <div class="col-xs-12 col-md-6">                    
-                    <div class="form-group">
+                        <div class="form-group">
                             <label for="settings[no_update_invoice_due_date_mail]">
                                 <?php _trans('no_update_invoice_due_date_mail'); ?>
                             </label>
                             <select name="settings[no_update_invoice_due_date_mail]" class="form-control simple-select"
                                 id="settings[no_update_invoice_due_date_mail]" data-minimum-results-for-search="Infinity">
-                                <option value="0">
+                                <option value="0" <?php check_select(get_setting('no_update_invoice_due_date_mail'), '0'); ?>>
                                     <?php _trans('no'); ?>
-                                </option>
+                                </option>                                
                                 <option value="1" <?php check_select(get_setting('no_update_invoice_due_date_mail'), '1'); ?>>
                                     <?php _trans('yes'); ?>
                                 </option>


### PR DESCRIPTION
See #924 --> must reopen it to re-revert

## Description
As indicated in the problem (#895), when sending the invoice, the invoice date and due date are not changed. 
Those details are retained as set when the invoice is created, even if changes are made in the period (days, weeks) thereafter. 
My solution will always "by default" change the invoice date to the current date and also recalculate the due date, **IF the setting** _**[Disable the change of invoice date and due date before emailing]**_ **is NOT activated BEFORE SENDING THE EMAIL!** 
So if the setting is **active** then the invoice date and due date are NOT changed.

## Related Issue
<!--- Please make sure there's an accomanying issue in the issues list -->
#895 
<!--- Please try and link to an accompanying thread on the forums, if there is one -->

## Motivation and Context
<!--- Why would you like this change? Does it solve a provlem or is it an improvement? -->
For me, this is a problem/rectification that needs to be resolved
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/InvoicePlane/InvoicePlane/issues/895

## Screenshots (if appropriate):

## Pull Request Checklist

  * [ ] My code follows the code formatting guidelines.
  * [X] I have an issue ID for this pull request.
  * [X] I selected the corresponding branch.
  * [X] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [ ] Bugfix
  * [X] Improvement of an existing Feature
  * [ ] New Feature
