### PR TITLE
Fix bug #840 Deleted the extra "state" field

### DIFF
--- a/application/views/quote_templates/pdf/InvoicePlane.php
+++ b/application/views/quote_templates/pdf/InvoicePlane.php
@@ -43,9 +43,6 @@
             }
             echo '</div>';
         }
-        if ($quote->client_state) {
-            echo '<div>' . htmlsc($quote->client_state) . '</div>';
-        }
         if ($quote->client_country) {
             echo '<div>' . get_country_name(trans('cldr'), $quote->client_country) . '</div>';
         }


### PR DESCRIPTION
## Description
It seems that the default pdf quote template contains an error.
If you use the "state field" then it will be shown twice in the quote pdf.

## Related Issue
closes issue #840 

## Motivation and Context
#840 I deleted the redundant field "State" in the default IP Quote pdf template file.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/30659226/219934106-8d93205e-7ec9-494c-9f58-2af7f6731667.png)

## Pull Request Checklist

  * [X] My code follows the code formatting guidelines.
  * [X] I have an issue ID for this pull request.
  * [X] I selected the corresponding branch.
  * [X] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [X] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
