### PR TITLE
[IP-841]: Copy Quote UI feedback

### DIFF
--- a/application/modules/invoices/views/modal_copy_invoice.php
+++ b/application/modules/invoices/views/modal_copy_invoice.php
@@ -21,7 +21,7 @@
                     payment_method: $('#payment_method').val()
                 },
                 function (data) {
-                    <?php echo(IP_DEBUG ? 'console.log(data);' : ''); ?>
+                    <?php echo IP_DEBUG ? 'console.log(data);' : ''; ?>
                     var response = JSON.parse(data);
                     if (response.success === 1) {
                         window.location = "<?php echo site_url('invoices/view'); ?>/" + response.invoice_id;
@@ -56,7 +56,7 @@
             <div class="form-group">
                 <label for="copy_invoice_client_id"><?php _trans('client'); ?></label>
                 <select name="client_id" id="copy_invoice_client_id" class="client-id-select form-control" autofocus="autofocus">
-                <?php if (!empty($client)) : ?>
+                <?php if ( ! empty($client)) : ?>
                         <option value="<?php echo $client->client_id; ?>"><?php _htmlsc(format_client($client)); ?></option>
                     <?php endif; ?>
                 </select>

--- a/application/modules/invoices/views/modal_copy_invoice.php
+++ b/application/modules/invoices/views/modal_copy_invoice.php
@@ -12,7 +12,7 @@
         $('#copy_invoice_confirm').click(function () {
             $.post("<?php echo site_url('invoices/ajax/copy_invoice'); ?>", {
                     invoice_id: <?php echo $invoice_id; ?>,
-                    client_id: $('#client_id').val(),
+                    client_id: $('#copy_invoice_client_id').val(),
                     invoice_date_created: $('#invoice_date_created_modal').val(),
                     invoice_group_id: $('#invoice_group_id').val(),
                     invoice_password: $('#invoice_password').val(),
@@ -54,11 +54,11 @@
                    value="<?php echo $invoice->payment_method; ?>">
 
             <div class="form-group">
-                <label for="client_id"><?php _trans('client'); ?></label>
-                <select name="client_id" id="client_id" class="form-control" autofocus="autofocus">
-                    <option value="<?php echo $invoice->client_id; ?>">
-                        <?php echo format_client($invoice); ?>
-                    </option>
+                <label for="copy_invoice_client_id"><?php _trans('client'); ?></label>
+                <select name="client_id" id="copy_invoice_client_id" class="client-id-select form-control" autofocus="autofocus">
+                <?php if (!empty($client)) : ?>
+                        <option value="<?php echo $client->client_id; ?>"><?php _htmlsc(format_client($client)); ?></option>
+                    <?php endif; ?>
                 </select>
             </div>
 

--- a/application/modules/quotes/models/Mdl_quotes.php
+++ b/application/modules/quotes/models/Mdl_quotes.php
@@ -217,8 +217,13 @@ class Mdl_Quotes extends Response_Model
 
         // Copy the custom fields
         $this->load->model('custom_fields/mdl_quote_custom');
-        $db_array = $this->mdl_quote_custom->where('quote_id', $source_id)->get()->row_array() ?? [];
-        $this->mdl_quote_custom->save_custom($target_id, $db_array);
+        $custom_fields = $this->mdl_quote_custom->where('quote_id', $source_id)->get()->result();
+
+        $form_data = array();
+        foreach ($custom_fields as $field) {
+            $form_data[$field->quote_custom_fieldid] = $field->quote_custom_fieldvalue;
+        }
+        $this->mdl_quote_custom->save_custom($target_id, $form_data);        
     }
 
     /**

--- a/application/modules/quotes/models/Mdl_quotes.php
+++ b/application/modules/quotes/models/Mdl_quotes.php
@@ -217,13 +217,13 @@ class Mdl_Quotes extends Response_Model
 
         // Copy the custom fields
         $this->load->model('custom_fields/mdl_quote_custom');
-        $custom_fields = $this->mdl_quote_custom->where('quote_id', $source_id)->get()->result();
+        $db_array = $this->mdl_quote_custom->where('quote_id', $source_id)->get()->row_array() ?? [];
 
-        $form_data = array();
-        foreach ($custom_fields as $field) {
-            $form_data[$field->quote_custom_fieldid] = $field->quote_custom_fieldvalue;
+        if (count($db_array) > 2) {
+            unset($db_array['quote_custom_id']);
+            $db_array['quote_id'] = $target_id;
+            $this->mdl_quote_custom->save_custom($target_id, $db_array);
         }
-        $this->mdl_quote_custom->save_custom($target_id, $form_data);        
     }
 
     /**

--- a/application/modules/quotes/models/Mdl_quotes.php
+++ b/application/modules/quotes/models/Mdl_quotes.php
@@ -217,13 +217,13 @@ class Mdl_Quotes extends Response_Model
 
         // Copy the custom fields
         $this->load->model('custom_fields/mdl_quote_custom');
-        $db_array = $this->mdl_quote_custom->where('quote_id', $source_id)->get()->row_array();
+        $custom_fields = $this->mdl_quote_custom->where('quote_id', $source_id)->get()->result();
 
-        if (count($db_array) > 2) {
-            unset($db_array['quote_custom_id']);
-            $db_array['quote_id'] = $target_id;
-            $this->mdl_quote_custom->save_custom($target_id, $db_array);
+        $form_data = array();
+        foreach ($custom_fields as $field) {
+            $form_data[$field->quote_custom_fieldid] = $field->quote_custom_fieldvalue;
         }
+        $this->mdl_quote_custom->save_custom($target_id, $form_data);
     }
 
     /**

--- a/application/modules/quotes/models/Mdl_quotes.php
+++ b/application/modules/quotes/models/Mdl_quotes.php
@@ -1,5 +1,8 @@
 <?php
-if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+if ( ! defined('BASEPATH')) {
+    exit('No direct script access allowed');
+}
 
 /*
  * InvoicePlane
@@ -11,12 +14,14 @@ if (!defined('BASEPATH')) exit('No direct script access allowed');
  */
 
 /**
- * Class Mdl_Quotes
+ * Class Mdl_Quotes.
  */
 class Mdl_Quotes extends Response_Model
 {
     public $table = 'ip_quotes';
+
     public $primary_key = 'ip_quotes.quote_id';
+
     public $date_modified_field = 'quote_date_modified';
 
     /**
@@ -24,38 +29,38 @@ class Mdl_Quotes extends Response_Model
      */
     public function statuses()
     {
-        return array(
-            '1' => array(
+        return [
+            '1' => [
                 'label' => trans('draft'),
                 'class' => 'draft',
-                'href' => 'quotes/status/draft'
-            ),
-            '2' => array(
+                'href'  => 'quotes/status/draft'
+            ],
+            '2' => [
                 'label' => trans('sent'),
                 'class' => 'sent',
-                'href' => 'quotes/status/sent'
-            ),
-            '3' => array(
+                'href'  => 'quotes/status/sent'
+            ],
+            '3' => [
                 'label' => trans('viewed'),
                 'class' => 'viewed',
-                'href' => 'quotes/status/viewed'
-            ),
-            '4' => array(
+                'href'  => 'quotes/status/viewed'
+            ],
+            '4' => [
                 'label' => trans('approved'),
                 'class' => 'approved',
-                'href' => 'quotes/status/approved'
-            ),
-            '5' => array(
+                'href'  => 'quotes/status/approved'
+            ],
+            '5' => [
                 'label' => trans('rejected'),
                 'class' => 'rejected',
-                'href' => 'quotes/status/rejected'
-            ),
-            '6' => array(
+                'href'  => 'quotes/status/rejected'
+            ],
+            '6' => [
                 'label' => trans('canceled'),
                 'class' => 'canceled',
-                'href' => 'quotes/status/canceled'
-            )
-        );
+                'href'  => 'quotes/status/canceled'
+            ],
+        ];
     }
 
     public function default_select()
@@ -91,32 +96,32 @@ class Mdl_Quotes extends Response_Model
      */
     public function validation_rules()
     {
-        return array(
-            'client_id' => array(
+        return [
+            'client_id' => [
                 'field' => 'client_id',
                 'label' => trans('client'),
                 'rules' => 'required'
-            ),
-            'quote_date_created' => array(
+            ],
+            'quote_date_created' => [
                 'field' => 'quote_date_created',
                 'label' => trans('quote_date'),
                 'rules' => 'required'
-            ),
-            'invoice_group_id' => array(
+            ],
+            'invoice_group_id' => [
                 'field' => 'invoice_group_id',
                 'label' => trans('quote_group'),
                 'rules' => 'required'
-            ),
-            'quote_password' => array(
+            ],
+            'quote_password' => [
                 'field' => 'quote_password',
                 'label' => trans('quote_password')
-            ),
-            'user_id' => array(
+            ],
+            'user_id' => [
                 'field' => 'user_id',
                 'label' => trans('user'),
-                'rule' => 'required'
-            )
-        );
+                'rule'  => 'required'
+            ]
+        ];
     }
 
     /**
@@ -124,31 +129,32 @@ class Mdl_Quotes extends Response_Model
      */
     public function validation_rules_save_quote()
     {
-        return array(
-            'quote_number' => array(
+        return [
+            'quote_number' => [
                 'field' => 'quote_number',
                 'label' => trans('quote') . ' #',
-                'rules' => 'is_unique[ip_quotes.quote_number' . (($this->id) ? '.quote_id.' . $this->id : '') . ']'
-            ),
-            'quote_date_created' => array(
+                'rules' => 'is_unique[ip_quotes.quote_number' . (($this->id) ? '.quote_id.' . $this->id : '') . ']',
+            ],
+            'quote_date_created' => [
                 'field' => 'quote_date_created',
                 'label' => trans('date'),
                 'rules' => 'required'
-            ),
-            'quote_date_expires' => array(
+            ],
+            'quote_date_expires' => [
                 'field' => 'quote_date_expires',
                 'label' => trans('due_date'),
                 'rules' => 'required'
-            ),
-            'quote_password' => array(
+            ],
+            'quote_password' => [
                 'field' => 'quote_password',
                 'label' => trans('quote_password')
-            )
-        );
+            ]
+        ];
     }
 
     /**
      * @param null $db_array
+     *
      * @return int|null
      */
     public function create($db_array = null)
@@ -156,20 +162,20 @@ class Mdl_Quotes extends Response_Model
         $quote_id = parent::save(null, $db_array);
 
         // Create an quote amount record
-        $db_array = array(
+        $db_array = [
             'quote_id' => $quote_id
-        );
+        ];
 
         $this->db->insert('ip_quote_amounts', $db_array);
 
         // Create the default invoice tax record if applicable
         if (get_setting('default_invoice_tax_rate')) {
-            $db_array = array(
-                'quote_id' => $quote_id,
-                'tax_rate_id' => get_setting('default_invoice_tax_rate'),
-                'include_item_tax' => get_setting('default_include_item_tax'),
+            $db_array = [
+                'quote_id'              => $quote_id,
+                'tax_rate_id'           => get_setting('default_invoice_tax_rate'),
+                'include_item_tax'      => get_setting('default_include_item_tax'),
                 'quote_tax_rate_amount' => 0
-            );
+            ];
 
             $this->db->insert('ip_quote_tax_rates', $db_array);
         }
@@ -178,7 +184,8 @@ class Mdl_Quotes extends Response_Model
     }
 
     /**
-     * Copies quote items, tax rates, etc from source to target
+     * Copies quote items, tax rates, etc from source to target.
+     *
      * @param int $source_id
      * @param int $target_id
      */
@@ -189,15 +196,15 @@ class Mdl_Quotes extends Response_Model
         $quote_items = $this->mdl_quote_items->where('quote_id', $source_id)->get()->result();
 
         foreach ($quote_items as $quote_item) {
-            $db_array = array(
-                'quote_id' => $target_id,
+            $db_array = [
+                'quote_id'         => $target_id,
                 'item_tax_rate_id' => $quote_item->item_tax_rate_id,
-                'item_name' => $quote_item->item_name,
+                'item_name'        => $quote_item->item_name,
                 'item_description' => $quote_item->item_description,
-                'item_quantity' => $quote_item->item_quantity,
-                'item_price' => $quote_item->item_price,
-                'item_order' => $quote_item->item_order
-            );
+                'item_quantity'    => $quote_item->item_quantity,
+                'item_price'       => $quote_item->item_price,
+                'item_order'       => $quote_item->item_order
+            ];
 
             $this->mdl_quote_items->save(null, $db_array);
         }
@@ -205,12 +212,12 @@ class Mdl_Quotes extends Response_Model
         $quote_tax_rates = $this->mdl_quote_tax_rates->where('quote_id', $source_id)->get()->result();
 
         foreach ($quote_tax_rates as $quote_tax_rate) {
-            $db_array = array(
-                'quote_id' => $target_id,
-                'tax_rate_id' => $quote_tax_rate->tax_rate_id,
-                'include_item_tax' => $quote_tax_rate->include_item_tax,
+            $db_array = [
+                'quote_id'              => $target_id,
+                'tax_rate_id'           => $quote_tax_rate->tax_rate_id,
+                'include_item_tax'      => $quote_tax_rate->include_item_tax,
                 'quote_tax_rate_amount' => $quote_tax_rate->quote_tax_rate_amount
-            );
+            ];
 
             $this->mdl_quote_tax_rates->save(null, $db_array);
         }
@@ -243,7 +250,7 @@ class Mdl_Quotes extends Response_Model
 
         $db_array['notes'] = get_setting('default_quote_notes');
 
-        if (!isset($db_array['quote_status_id'])) {
+        if ( ! isset($db_array['quote_status_id'])) {
             $db_array['quote_status_id'] = 1;
         }
 
@@ -270,16 +277,19 @@ class Mdl_Quotes extends Response_Model
     {
         $quote_date_expires = new DateTime($quote_date_created);
         $quote_date_expires->add(new DateInterval('P' . get_setting('quotes_expire_after') . 'D'));
+
         return $quote_date_expires->format('Y-m-d');
     }
 
     /**
      * @param $invoice_group_id
+     *
      * @return mixed
      */
     public function get_quote_number($invoice_group_id)
     {
         $this->load->model('invoice_groups/mdl_invoice_groups');
+
         return $this->mdl_invoice_groups->generate_invoice_number($invoice_group_id);
     }
 
@@ -289,16 +299,19 @@ class Mdl_Quotes extends Response_Model
     public function get_url_key()
     {
         $this->load->helper('string');
+
         return random_string('alnum', 32);
     }
 
     /**
      * @param $invoice_id
+     *
      * @return mixed
      */
     public function get_invoice_group_id($invoice_id)
     {
         $invoice = $this->get_by_id($invoice_id);
+
         return $invoice->invoice_group_id;
     }
 
@@ -319,6 +332,7 @@ class Mdl_Quotes extends Response_Model
     public function is_draft()
     {
         $this->filter_where('quote_status_id', 1);
+
         return $this;
     }
 
@@ -328,6 +342,7 @@ class Mdl_Quotes extends Response_Model
     public function is_sent()
     {
         $this->filter_where('quote_status_id', 2);
+
         return $this;
     }
 
@@ -337,6 +352,7 @@ class Mdl_Quotes extends Response_Model
     public function is_viewed()
     {
         $this->filter_where('quote_status_id', 3);
+
         return $this;
     }
 
@@ -346,6 +362,7 @@ class Mdl_Quotes extends Response_Model
     public function is_approved()
     {
         $this->filter_where('quote_status_id', 4);
+
         return $this;
     }
 
@@ -355,6 +372,7 @@ class Mdl_Quotes extends Response_Model
     public function is_rejected()
     {
         $this->filter_where('quote_status_id', 5);
+
         return $this;
     }
 
@@ -364,17 +382,19 @@ class Mdl_Quotes extends Response_Model
     public function is_canceled()
     {
         $this->filter_where('quote_status_id', 6);
+
         return $this;
     }
 
     /**
-     * Used by guest module; includes only sent and viewed
+     * Used by guest module; includes only sent and viewed.
      *
      * @return $this
      */
     public function is_open()
     {
-        $this->filter_where_in('quote_status_id', array(2, 3));
+        $this->filter_where_in('quote_status_id', [2, 3]);
+
         return $this;
     }
 
@@ -383,17 +403,20 @@ class Mdl_Quotes extends Response_Model
      */
     public function guest_visible()
     {
-        $this->filter_where_in('quote_status_id', array(2, 3, 4, 5));
+        $this->filter_where_in('quote_status_id', [2, 3, 4, 5]);
+
         return $this;
     }
 
     /**
      * @param $client_id
+     *
      * @return $this
      */
     public function by_client($client_id)
     {
         $this->filter_where('ip_quotes.client_id', $client_id);
+
         return $this;
     }
 
@@ -402,7 +425,7 @@ class Mdl_Quotes extends Response_Model
      */
     public function approve_quote_by_key($quote_url_key)
     {
-        $this->db->where_in('quote_status_id', array(2, 3));
+        $this->db->where_in('quote_status_id', [2, 3]);
         $this->db->where('quote_url_key', $quote_url_key);
         $this->db->set('quote_status_id', 4);
         $this->db->update('ip_quotes');
@@ -413,7 +436,7 @@ class Mdl_Quotes extends Response_Model
      */
     public function reject_quote_by_key($quote_url_key)
     {
-        $this->db->where_in('quote_status_id', array(2, 3));
+        $this->db->where_in('quote_status_id', [2, 3]);
         $this->db->where('quote_url_key', $quote_url_key);
         $this->db->set('quote_status_id', 5);
         $this->db->update('ip_quotes');
@@ -424,7 +447,7 @@ class Mdl_Quotes extends Response_Model
      */
     public function approve_quote_by_id($quote_id)
     {
-        $this->db->where_in('quote_status_id', array(2, 3));
+        $this->db->where_in('quote_status_id', [2, 3]);
         $this->db->where('quote_id', $quote_id);
         $this->db->set('quote_status_id', 4);
         $this->db->update('ip_quotes');
@@ -435,7 +458,7 @@ class Mdl_Quotes extends Response_Model
      */
     public function reject_quote_by_id($quote_id)
     {
-        $this->db->where_in('quote_status_id', array(2, 3));
+        $this->db->where_in('quote_status_id', [2, 3]);
         $this->db->where('quote_id', $quote_id);
         $this->db->set('quote_status_id', 5);
         $this->db->update('ip_quotes');
@@ -486,8 +509,8 @@ class Mdl_Quotes extends Response_Model
     {
         $quote = $this->mdl_quotes->get_by_id($quote_id);
 
-        if (!empty($quote)) {
-            if ($quote->quote_status_id == 1 && $quote->quote_number == "") {
+        if ( ! empty($quote)) {
+            if ($quote->quote_status_id == 1 && $quote->quote_number == '') {
                 // Generate new quote number if applicable
                 if (get_setting('generate_quote_number_for_draft') == 0) {
                     $quote_number = $this->mdl_quotes->get_quote_number($quote->invoice_group_id);
@@ -500,5 +523,4 @@ class Mdl_Quotes extends Response_Model
             }
         }
     }
-
 }

--- a/application/modules/quotes/models/Mdl_quotes.php
+++ b/application/modules/quotes/models/Mdl_quotes.php
@@ -217,13 +217,8 @@ class Mdl_Quotes extends Response_Model
 
         // Copy the custom fields
         $this->load->model('custom_fields/mdl_quote_custom');
-        $custom_fields = $this->mdl_quote_custom->where('quote_id', $source_id)->get()->result();
-
-        $form_data = array();
-        foreach ($custom_fields as $field) {
-            $form_data[$field->quote_custom_fieldid] = $field->quote_custom_fieldvalue;
-        }
-        $this->mdl_quote_custom->save_custom($target_id, $form_data);
+        $db_array = $this->mdl_quote_custom->where('quote_id', $source_id)->get()->row_array() ?? [];
+        $this->mdl_quote_custom->save_custom($target_id, $db_array);
     }
 
     /**

--- a/application/modules/quotes/views/modal_copy_quote.php
+++ b/application/modules/quotes/views/modal_copy_quote.php
@@ -12,9 +12,9 @@
             $.post("<?php echo site_url('quotes/ajax/copy_quote'); ?>", {
                     quote_id: <?php echo $quote_id; ?>,
                     client_id: $('#create_quote_client_id').val(),
-                    quote_date_created: $('#quote_date_created').val(),
-                    invoice_group_id: $('#invoice_group_id').val(),
-                    user_id: $('#user_id').val()
+                    quote_date_created: $('#quote_date_created_modal').val(),
+                    user_id: $('#user_id').val(),
+                    invoice_group_id: $('#invoice_group_id').val()
                 },
                 function (data) {
                     <?php echo(IP_DEBUG ? 'console.log(data);' : ''); ?>
@@ -56,14 +56,14 @@
             </div>
 
             <div class="form-group has-feedback">
-                <label for="quote_date_created">
+                <label for="quote_date_created_modal">
                     <?php _trans('quote_date'); ?>
                 </label>
 
                 <div class="input-group">
-                    <input name="quote_date_created" id="quote_date_created"
+                    <input name="quote_date_created_modal" id="quote_date_created_modal"
                            class="form-control datepicker"
-                           value="<?php echo date_from_mysql($quote->quote_date_created, true); ?>">
+                           value="<?php echo date_from_mysql(date('Y-m-d', time()), true); ?>">
                     <span class="input-group-addon">
                         <i class="fa fa-calendar fa-fw"></i>
                     </span>

--- a/application/modules/quotes/views/modal_copy_quote.php
+++ b/application/modules/quotes/views/modal_copy_quote.php
@@ -17,7 +17,7 @@
                     invoice_group_id: $('#invoice_group_id').val()
                 },
                 function (data) {
-                    <?php echo(IP_DEBUG ? 'console.log(data);' : ''); ?>
+                    <?php echo IP_DEBUG ? 'console.log(data);' : ''; ?>
                     var response = JSON.parse(data);
                     if (response.success === 1) {
                         window.location = "<?php echo site_url('quotes/view'); ?>/" + response.quote_id;
@@ -49,7 +49,7 @@
                 <label for="create_quote_client_id"><?php _trans('client'); ?></label>
                 <select name="client_id" id="create_quote_client_id" class="client-id-select form-control"
                         autofocus="autofocus">
-                    <?php if (!empty($client)) : ?>
+                    <?php if ( ! empty($client)) : ?>
                         <option value="<?php echo $client->client_id; ?>"><?php _htmlsc(format_client($client)); ?></option>
                     <?php endif; ?>
                 </select>


### PR DESCRIPTION
## Description
The ajax form doesn't post because there is **no response** from the backend.
The problem comes when fetching the 'custom_fields' data.
As far as I understand it, the ( existing?) data is retrieved from the custom_fields db and put into an array.
If there is no data in the db the array cannot be populated and as a result of this there is no "response".
Therefore, in modal_copy_quote, the code
```
if (response.success === 1) {
    window.location = "<?php echo site_url('invoices/view'); ?>/" + response.invoice_id;
}
```
is not executed in order to close the modal window and to display the copied quote view page.
To solve the problem I extracted the snippet (copied the custom_fields code) from mdl_invoice.php and modified it in mdl_quotes.php.

## Related Issue
#841 Copy quote (modal) UI feedback

## Motivation and Context
#841 See description
* Bugfix: Selected quote date is saved
See commits
* Bugfix: Other client can be selected from list
See commits

## Screenshots (if appropriate):

## Pull Request Checklist

  * [X] My code follows the code formatting guidelines.
  * [X] I have an issue ID for this pull request.
  * [X] I selected the corresponding branch.
  * [X] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [X] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
