### PR TITLE
[IP-959]: set encryption key after installing

### DIFF
--- a/application/modules/setup/controllers/Setup.php
+++ b/application/modules/setup/controllers/Setup.php
@@ -340,7 +340,11 @@ class Setup extends MX_Controller
         $this->load_ci_database();
 
         // Set a new encryption key if none exists
-        if (env('ENCRYPTION_KEY') === null) {
+        if (
+            env('ENCRYPTION_KEY') === null
+            ||
+            env('ENCRYPTION_KEY') === ''
+        ) {
             $this->set_encryption_key();
         }
 


### PR DESCRIPTION
## Description
After installing InvoicePlane, the ENCRYPTION_KEY should be set

## Related Issue
#959 

## Steps to Reproduce
1. Clean install of InvoicePlane
2. Before installing, check the ipconfig.php file
3. Value of Encryption Key is: `ENCRYPTION_KEY=`
4. After installing, Value of Encryption Key is: `ENCRYPTION_KEY=`

## Issue Type (Please check one or more)

  * [x] Bugfix
