### PR TITLE
898: Fix bug where logo wasn't found while creating PDF invoice

### DIFF
--- a/application/helpers/invoice_helper.php
+++ b/application/helpers/invoice_helper.php
@@ -20,7 +20,8 @@ function invoice_logo()
     $CI = &get_instance();
 
     if ($CI->mdl_settings->setting('invoice_logo')) {
-        return '<img src="' . base_url() . 'uploads/' . $CI->mdl_settings->setting('invoice_logo') . '">';
+        $absolutePath = dirname(dirname(__DIR__));
+        return '<img src="' . $absolutePath . '/uploads/' . $CI->mdl_settings->setting('invoice_logo') . '">';
     }
 
     return '';
@@ -36,7 +37,8 @@ function invoice_logo_pdf()
     $CI = &get_instance();
 
     if ($CI->mdl_settings->setting('invoice_logo')) {
-        return '<img src="' . base_url() . 'uploads/' . $CI->mdl_settings->setting('invoice_logo') . '" id="invoice-logo">';
+        $absolutePath = dirname(dirname(__DIR__));
+        return '<img src="' . $absolutePath . '/uploads/' . $CI->mdl_settings->setting('invoice_logo') . '" id="invoice-logo">';
     }
 
     return '';


### PR DESCRIPTION
## Description
Fix bug where logo wasn't found while creating PDF invoice

## Related Issue
- [x] closes #898 

## Motivation and Context
When you create PDF invoice, the logo is fetched, but somehow the appropriate path isn't generated properly.
This PR fixes that bug

## Pull Request Checklist
  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)
  * [x] Bugfix
