### PR TITLE
[IP-968] Sometimes a user isn't created, add more logging to see what's going on

### DIFF
--- a/application/modules/setup/controllers/Setup.php
+++ b/application/modules/setup/controllers/Setup.php
@@ -415,12 +415,20 @@ class Setup extends MX_Controller
             redirect('setup/prerequisites');
         }
 
+        $this->load_ci_database();
+        $users = $this->db->query('SELECT * FROM ip_users');
+        if ($users->num_rows() === 0) {
+            log_message('error', 'there was already one or more users in the database');
+            $this->session->set_flashdata('alert_error', 'Something went wrong, check the log file for errors');
+            $this->session->set_userdata('install_step', 'create_user');
+            redirect('setup/create_user');
+        }
+
         // Additional tasks after setup is completed
         $this->post_setup_tasks();
 
         // Check if this is an update or the first install
         // First get all version entries from the database and format them
-        $this->load_ci_database();
         $versions = $this->db->query('SELECT * FROM ip_versions');
         if ($versions->num_rows() > 0) {
             foreach ($versions->result() as $row):


### PR DESCRIPTION
## Description
Sometimes a user isn't created during installation process. At this time all we can do is add logging.
I've also added a check whether there are 0 users in the database after the 'create_user' step.

If 0 users, redirect to 'create_user step'

## Related Issue
addresses #968 

## Motivation and Context
It's a pain to add user manually after setup is complete:
1. Open ip_users table
2. Add user manually plus set password in a certain way.
3. These steps were discussed on the forums: https://community.invoiceplane.com

## Pull Request Checklist
  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)
  * [x] Bugfix