### PR TITLE
[IP-1012]: Revert change to invoice_logo() 

### DIFF
--- a/application/helpers/invoice_helper.php
+++ b/application/helpers/invoice_helper.php
@@ -20,8 +20,7 @@ function invoice_logo()
     $CI = &get_instance();
 
     if ($CI->mdl_settings->setting('invoice_logo')) {
-        $absolutePath = dirname(dirname(__DIR__));
-        return '<img src="' . $absolutePath . '/uploads/' . $CI->mdl_settings->setting('invoice_logo') . '">';
+        return '<img src="' . base_url() . '/uploads/' . $CI->mdl_settings->setting('invoice_logo') . '">';
     }
 
     return '';

--- a/application/helpers/invoice_helper.php
+++ b/application/helpers/invoice_helper.php
@@ -20,7 +20,7 @@ function invoice_logo()
     $CI = &get_instance();
 
     if ($CI->mdl_settings->setting('invoice_logo')) {
-        return '<img src="' . base_url() . '/uploads/' . $CI->mdl_settings->setting('invoice_logo') . '">';
+        return '<img src="' . base_url() . 'uploads/' . $CI->mdl_settings->setting('invoice_logo') . '">';
     }
 
     return '';


### PR DESCRIPTION
invoice_logo() produces an invalid URL based on an absolute file system path, it seems this change was only intended for invoice_logo_pdf()

Related issue: #1012 