### PR TITLE
Show list of themes on Windows

### DIFF
--- a/application/modules/settings/models/Mdl_settings.php
+++ b/application/modules/settings/models/Mdl_settings.php
@@ -126,7 +126,7 @@ class Mdl_Settings extends CI_Model
             }
 
             // Get the theme info file
-            $theme = str_replace('/', '', $theme);
+            $theme = str_replace(DIRECTORY_SEPARATOR, '', $theme);
             $info_path = THEME_FOLDER . $theme . '/';
             $info_file = $theme . '.theme';
 


### PR DESCRIPTION
## Description
Since Windows uses `\` as a folder separator, this causes the problem that the list of themes in the settings is empty.

## Related Issue
<!--- Please make sure there's an accomanying issue in the issues list -->
<!--- Please try and link to an accompanying thread on the forums, if there is one -->

## Motivation and Context
<!--- Why would you like this change? Does it solve a provlem or is it an improvement? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
