### PR TITLE
Fix for issue 1038: Wrong translation string in setup

### DIFF
--- a/application/modules/setup/controllers/Setup.php
+++ b/application/modules/setup/controllers/Setup.php
@@ -270,7 +270,7 @@ class Setup extends MX_Controller
             $this->errors += 1;
 
             return [
-                'message' => trans('cannot_connect_database_server'),
+                'message' => trans('setup_database_message'),
                 'success' => false,
             ];
         }


### PR DESCRIPTION
Fixes #1038

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
