### PR TITLE
Fix: Creation of dynamic property is depreceated

### DIFF
--- a/application/core/Validator.php
+++ b/application/core/Validator.php
@@ -1,5 +1,6 @@
 <?php
-if (!defined('BASEPATH')) {
+
+if ( ! defined('BASEPATH')) {
     exit('No direct script access allowed');
 }
 
@@ -13,10 +14,11 @@ if (!defined('BASEPATH')) {
  */
 
 /**
- * Class Validator
+ * Class Validator.
  */
 class Validator extends MY_Model
 {
+    public $_formdata;
 
     /**
      * @return bool
@@ -33,12 +35,13 @@ class Validator extends MY_Model
      */
     public function validate_date($value)
     {
-        if ($value == "") {
-            return null;
+        if ($value == '') {
+            return;
         }
 
-        if (!is_date($value)) {
+        if ( ! is_date($value)) {
             $this->form_validation->set_message('validate_date', 'Invalid date');
+
             return false;
         }
 
@@ -52,12 +55,12 @@ class Validator extends MY_Model
      */
     public function validate_boolean($value)
     {
-        if ($value == "0" || $value == "1") {
+        if ($value == '0' || $value == '1') {
             return true;
         }
 
-        if ($value == "") {
-            return null;
+        if ($value == '') {
+            return;
         }
 
         return false;
@@ -71,8 +74,8 @@ class Validator extends MY_Model
      */
     public function validate_singlechoice($value, $key)
     {
-        if ($value == "") {
-            return null;
+        if ($value == '') {
+            return;
         }
 
         $this->load->model('custom_values/mdl_custom_values', 'custom_value');
@@ -89,19 +92,15 @@ class Validator extends MY_Model
      */
     public function validate_multiplechoice($value, $id)
     {
-        if ($value == "") {
-            return null;
+        if ($value == '') {
+            return;
         }
 
         $this->load->model('custom_values/mdl_custom_values', 'custom_value');
         $this->custom_value->where('custom_field_id', $id);
         $dbvals = $this->custom_value->where_in('custom_values_id', $value)->get();
 
-        if ($dbvals->num_rows() == sizeof($value)) {
-            return true;
-        }
-
-        return false;
+        return (bool) ($dbvals->num_rows() == sizeof($value));
     }
 
     /**
@@ -139,7 +138,7 @@ class Validator extends MY_Model
         $el = $this->cf->get_by_column($column)->row();
 
         if ($el == null) {
-            return null;
+            return;
         }
 
         return $el->custom_field_type;
@@ -168,12 +167,12 @@ class Validator extends MY_Model
 
             if ($model->num_rows()) {
                 $model = $model->row();
-                if (@$model->custom_field_required == "1") {
-                    if ($value == "") {
+                if (@$model->custom_field_required == '1') {
+                    if ($value == '') {
                         $errors[] = [
-                            "field" => $model->custom_field_id,
-                            "label" => $model->custom_field_label,
-                            "error_msg" => "missing field required",
+                            'field'     => $model->custom_field_id,
+                            'label'     => $model->custom_field_label,
+                            'error_msg' => 'missing field required',
                         ];
                         continue;
                     }
@@ -183,9 +182,9 @@ class Validator extends MY_Model
 
                 if ($result === false) {
                     $errors[] = [
-                        "field" => $model->custom_field_id,
-                        "label" => $model->custom_field_label,
-                        "error_msg" => "invalid input",
+                        'field'     => $model->custom_field_id,
+                        'label'     => $model->custom_field_label,
+                        'error_msg' => 'invalid input',
                     ];
                 }
             }
@@ -194,6 +193,7 @@ class Validator extends MY_Model
         if (sizeof($errors) == 0) {
             $this->_formdata = $db_array;
             $this->fixinput();
+
             return true;
         }
 
@@ -211,10 +211,11 @@ class Validator extends MY_Model
     {
         $nicename = $this->mdl_custom_fields->get_nicename($type);
         $validation_rule = 'validate_' . $nicename;
+
         return $this->{$validation_rule}($value, $key);
     }
 
-    public function fixinput()
+    public function fixinput(): void
     {
         foreach ($this->_formdata as $key => $value) {
             $model = $this->mdl_custom_fields->where('custom_field_id', $key)->get();
@@ -224,8 +225,8 @@ class Validator extends MY_Model
                 $ftype = $model->custom_field_type;
 
                 switch ($ftype) {
-                    case "DATE":
-                        if ($value == "") {
+                    case 'DATE':
+                        if ($value == '') {
                             $this->_formdata[$key] = null;
                         } else {
                             $this->_formdata[$key] = date_to_mysql($value);
@@ -233,12 +234,12 @@ class Validator extends MY_Model
 
                         break;
 
-                    case "MULTIPLE-CHOICE":
+                    case 'MULTIPLE-CHOICE':
                         $this->_formdata[$key] = is_array($value) ? implode(',', $value) : $value;
                         break;
 
-                    case "TEXT":
-                        if ($value == "") {
+                    case 'TEXT':
+                        if ($value == '') {
                             $this->_formdata[$key] = null;
                         }
                         break;

--- a/application/libraries/Sumex.php
+++ b/application/libraries/Sumex.php
@@ -1,10 +1,12 @@
-<?php if (!defined('BASEPATH')) {
+<?php
+
+if ( ! defined('BASEPATH')) {
     exit('No direct script access allowed');
 }
 
 class Sumex
 {
-    const ROLES = array(
+    public const ROLES = [
         'physician',
         'physiotherapist',
         'chiropractor',
@@ -25,106 +27,125 @@ class Sumex
         'druggist',
         'naturopathicdoctor',
         'naturopathictherapist',
-        'other');
-    const PLACES = array(
+        'other'];
+
+    public const PLACES = [
         'practice',
         'hospital',
         'lab',
         'association',
-        'company'
-    );
-    const CANTONS = array(
-        "AG",
-        "AI",
-        "AR",
-        "BE",
-        "BL",
-        "BS",
-        "FR",
-        "GE",
-        "GL",
-        "GR",
-        "JU",
-        "LU",
-        "NE",
-        "NW",
-        "OW",
-        "SG",
-        "SH",
-        "SO",
-        "SZ",
-        "TI",
-        "TG",
-        "UR",
-        "VD",
-        "VS",
-        "ZG",
-        "ZH",
-        "LI",
-        "A",
-        "D",
-        "F",
-        "I"
-    );
+        'company',
+    ];
+
+    public const CANTONS = [
+        'AG',
+        'AI',
+        'AR',
+        'BE',
+        'BL',
+        'BS',
+        'FR',
+        'GE',
+        'GL',
+        'GR',
+        'JU',
+        'LU',
+        'NE',
+        'NW',
+        'OW',
+        'SG',
+        'SH',
+        'SO',
+        'SZ',
+        'TI',
+        'TG',
+        'UR',
+        'VD',
+        'VS',
+        'ZG',
+        'ZH',
+        'LI',
+        'A',
+        'D',
+        'F',
+        'I',
+    ];
+
     public $invoice;
+
     public $doc;
+
     public $root;
-    public $_lang = "it";
-    public $_mode = "production";
-    public $_copy = "0";
-    public $_storno = "0";
-    public $_role = "physiotherapist";
-    public $_place = "practice";
-    public $_currency = "CHF";
-    public $_paymentperiod = "P30D";
-    public $_canton = "TI";
-    public $_esrType = "9";
 
-    public $_patient = array(
-        'gender' => 'male',
-        'birthdate' => '1970-01-01',
+    public $_lang = 'it';
+
+    public $_mode = 'production';
+
+    public $_copy = '0';
+
+    public $_storno = '0';
+
+    public $_role = 'physiotherapist';
+
+    public $_place = 'practice';
+
+    public $_currency = 'CHF';
+
+    public $_paymentperiod = 'P30D';
+
+    public $_canton = 'TI';
+
+    public $_esrType = '9';
+
+    public $_patient = [
+        'gender'     => 'male',
+        'birthdate'  => '1970-01-01',
         'familyName' => 'FamilyName',
-        'givenName' => 'GivenName',
-        'street' => 'ClientStreet 10',
-        'zip' => '0000',
-        'city' => 'ClientCity',
-        'phone' => '000 000 00 00',
-        'avs' => '7000000000000'
-    );
+        'givenName'  => 'GivenName',
+        'street'     => 'ClientStreet 10',
+        'zip'        => '0000',
+        'city'       => 'ClientCity',
+        'phone'      => '000 000 00 00',
+        'avs'        => '7000000000000',
+    ];
 
-    public $_casedate = "1970-01-01";
-    public $_casenumber = "0";
+    public $_casedate = '1970-01-01';
+
+    public $_casenumber = '0';
+
     public $_insuredid = '1234567';
 
-    public $_treatment = array(
-        'start' => '',
-        'end' => '',
-        'reason' => 'disease',
-        'diagnosis' => '.'
-    );
+    public $_treatment = [
+        'start'     => '',
+        'end'       => '',
+        'reason'    => 'disease',
+        'diagnosis' => '.',
+    ];
 
-    public $_company = array(
-        'name' => 'SomeCompany GmbH',
+    public $_company = [
+        'name'   => 'SomeCompany GmbH',
         'street' => 'Via Cantonale 5',
-        'zip' => '6900',
-        'city' => 'Lugano',
-        'phone' => '091 902 11 00',
-        'gln' => '123456789123', // EAN 13
-        'rcc' => 'C000002'
-    );
+        'zip'    => '6900',
+        'city'   => 'Lugano',
+        'phone'  => '091 902 11 00',
+        'gln'    => '123456789123', // EAN 13
+        'rcc'    => 'C000002',
+    ];
 
-    public $_insurance = array(
-        'gln' => '7634567890000',
-        'name' => 'SUVA',
+    public $_insurance = [
+        'gln'    => '7634567890000',
+        'name'   => 'SUVA',
         'street' => 'ChangeMe 12',
-        'zip' => '6900',
-        'city' => 'Lugano'
-    );
+        'zip'    => '6900',
+        'city'   => 'Lugano',
+    ];
 
-    public $_options = array(
-        'copy' => "0",
-        'storno' => "0"
-    );
+    public $_options = [
+        'copy'   => '0',
+        'storno' => '0',
+    ];
+    public $currencyCode;
+    public $items;
 
     public function __construct($params)
     {
@@ -134,23 +155,22 @@ class Sumex
 
         $this->invoice = $params['invoice'];
         $this->items = $params['items'];
-        if (!is_array(@$params['options'])) {
-            $params['options'] = array();
+        if ( ! is_array(@$params['options'])) {
+            $params['options'] = [];
         }
         $this->_options = array_merge($this->_options, $params['options']);
 
         $this->_storno = $this->_options['storno'];
         $this->_copy = $this->_options['copy'];
 
-
         $this->_patient['givenName'] = $this->invoice->client_name;
         $this->_patient['familyName'] = $this->invoice->client_surname;
         $this->_patient['birthdate'] = $this->invoice->client_birthdate;
-        $this->_patient['gender'] = ($this->invoice->client_gender == "0" ? "male" : "female");
+        $this->_patient['gender'] = ($this->invoice->client_gender == '0' ? 'male' : 'female');
         $this->_patient['street'] = $this->invoice->client_address_1;
         $this->_patient['zip'] = $this->invoice->client_zip;
         $this->_patient['city'] = $this->invoice->client_city;
-        $this->_patient['phone'] = ($this->invoice->client_phone == "" ? null : $this->invoice->client_phone);
+        $this->_patient['phone'] = ($this->invoice->client_phone == '' ? null : $this->invoice->client_phone);
         $this->_patient['avs'] = $this->invoice->client_avs;
 
         $this->_company['name'] = $this->invoice->user_company;
@@ -165,32 +185,30 @@ class Sumex
         $this->_casenumber = $this->invoice->sumex_casenumber;
         $this->_insuredid = $this->invoice->client_insurednumber;
 
-
-        $treatments = array(
+        $treatments = [
             'disease',
             'accident',
             'maternity',
             'prevention',
             'birthdefect',
-            'unknown'
-        );
+            'unknown',
+        ];
 
-
-        $this->_treatment = array(
-            'start' => $this->invoice->sumex_treatmentstart,
-            'end' => $this->invoice->sumex_treatmentend,
-            'reason' => $treatments[$this->invoice->sumex_reason],
-            'diagnosis' => $this->invoice->sumex_diagnosis,
+        $this->_treatment = [
+            'start'        => $this->invoice->sumex_treatmentstart,
+            'end'          => $this->invoice->sumex_treatmentend,
+            'reason'       => $treatments[$this->invoice->sumex_reason],
+            'diagnosis'    => $this->invoice->sumex_diagnosis,
             'observations' => $this->invoice->sumex_observations,
-        );
+        ];
 
-        $esrTypes = array("9", "red");
+        $esrTypes = ['9', 'red'];
         $this->_esrType = $esrTypes[$CI->mdl_settings->setting('sumex_sliptype')];
 
         $this->currencyCode = $CI->mdl_settings->setting('currency_code');
-        $this->_role = Sumex::ROLES[$CI->mdl_settings->setting('sumex_role')];
-        $this->_place = Sumex::PLACES[$CI->mdl_settings->setting('sumex_place')];
-        $this->_canton = Sumex::CANTONS[$CI->mdl_settings->setting('sumex_canton')];
+        $this->_role = self::ROLES[$CI->mdl_settings->setting('sumex_role')];
+        $this->_place = self::PLACES[$CI->mdl_settings->setting('sumex_place')];
+        $this->_canton = self::CANTONS[$CI->mdl_settings->setting('sumex_canton')];
     }
 
     public function pdf()
@@ -199,7 +217,7 @@ class Sumex
 
         $xml = $this->xml();
 
-        curl_setopt($ch, CURLOPT_URL, SUMEX_URL . "/generateInvoice");
+        curl_setopt($ch, CURLOPT_URL, SUMEX_URL . '/generateInvoice');
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 30);
@@ -207,7 +225,6 @@ class Sumex
         curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
         $out = curl_exec($ch);
         curl_close($ch);
-
 
         return $out;
     }
@@ -222,6 +239,7 @@ class Sumex
         $this->root->appendChild($this->xmlInvoicePayload());
 
         $this->doc->appendChild($this->root);
+
         return $this->doc->saveXML();
     }
 
@@ -234,6 +252,7 @@ class Sumex
         $node->setAttribute('xsi:schemaLocation', 'http://www.forum-datenaustausch.ch/invoice generalInvoiceRequest_440.xsd');
         $node->setAttribute('modus', $this->_mode);
         $node->setAttribute('language', $this->_lang);
+
         return $node;
     }
 
@@ -247,15 +266,16 @@ class Sumex
 
         $transport = $this->doc->createElement('invoice:transport');
         $transport->setAttribute('from', $this->_company['gln']);
-        $transport->setAttribute('to', '7601003000078'); # Example: SUVA
+        $transport->setAttribute('to', '7601003000078'); // Example: SUVA
 
         $via = $this->doc->createElement('invoice:via');
-        $via->setAttribute('via', '7601003000078'); # Example: SUVA
+        $via->setAttribute('via', '7601003000078'); // Example: SUVA
         $via->setAttribute('sequence_id', '1');
 
         $transport->appendChild($via);
 
         $node->appendChild($transport);
+
         return $node;
     }
 
@@ -285,7 +305,7 @@ class Sumex
         $node->setAttribute('role', $this->_role);
         $node->setAttribute('place', $this->_place);
 
-        if ($this->_esrType == "9") {
+        if ($this->_esrType == '9') {
             $esr = $this->xmlInvoiceEsr9();
         } else {
             // Red
@@ -303,7 +323,7 @@ class Sumex
         $services = $this->xmlServices();
 
         $node->appendChild($prolog);
-        if ($this->_treatment['observations'] != "") {
+        if ($this->_treatment['observations'] != '') {
             $node->appendChild($remark);
         }
         $node->appendChild($balance);
@@ -327,37 +347,37 @@ class Sumex
         $node->setAttribute('type', '16or27'); // 16or27 = 01, 16or27plus = 04
 
         // 26numbers + 1 chek
-        $referenceNumber = "";
+        $referenceNumber = '';
 
         // Custom style, we create the reference number as following:
         // 5 digits for client id, 10 digits for invoice ID, 9 digits for Invoice Date, 1 for checksum
 
-        $referenceNumber .= "06"; // Dog Fooding
-        $referenceNumber .= sprintf("%05d", $this->invoice->client_id);
-        $referenceNumber .= sprintf("%010d", $this->invoice->invoice_id);
-        $referenceNumber .= sprintf("%09d", date("Ymd", strtotime($this->invoice->invoice_date_modified)));
+        $referenceNumber .= '06'; // Dog Fooding
+        $referenceNumber .= sprintf('%05d', $this->invoice->client_id);
+        $referenceNumber .= sprintf('%010d', $this->invoice->invoice_id);
+        $referenceNumber .= sprintf('%09d', date('Ymd', strtotime($this->invoice->invoice_date_modified)));
         $refCsum = invoice_recMod10($referenceNumber);
         $referenceNumber = $referenceNumber . $refCsum;
 
-        if (!preg_match("/\d{27}/", $referenceNumber)) {
-            throw new Error("Invalid reference number!");
+        if ( ! preg_match("/\d{27}/", $referenceNumber)) {
+            throw new Error('Invalid reference number!');
         }
 
-        $slipType = "01"; // ISR in CHF
+        $slipType = '01'; // ISR in CHF
         $amount = $this->invoice->invoice_total;
 
-        $formattedRN = "";
-        $formattedRN .= substr($referenceNumber, 0, 2);
-        $formattedRN .= " ";
-        $formattedRN .= substr($referenceNumber, 2, 5);
-        $formattedRN .= " ";
-        $formattedRN .= substr($referenceNumber, 7, 5);
-        $formattedRN .= " ";
-        $formattedRN .= substr($referenceNumber, 12, 5);
-        $formattedRN .= " ";
-        $formattedRN .= substr($referenceNumber, 17, 5);
-        $formattedRN .= " ";
-        $formattedRN .= substr($referenceNumber, 22, 5);
+        $formattedRN = '';
+        $formattedRN .= mb_substr($referenceNumber, 0, 2);
+        $formattedRN .= ' ';
+        $formattedRN .= mb_substr($referenceNumber, 2, 5);
+        $formattedRN .= ' ';
+        $formattedRN .= mb_substr($referenceNumber, 7, 5);
+        $formattedRN .= ' ';
+        $formattedRN .= mb_substr($referenceNumber, 12, 5);
+        $formattedRN .= ' ';
+        $formattedRN .= mb_substr($referenceNumber, 17, 5);
+        $formattedRN .= ' ';
+        $formattedRN .= mb_substr($referenceNumber, 22, 5);
 
         $codingLine = invoice_genCodeline($slipType, $amount, $formattedRN, $subNumb);
 
@@ -380,7 +400,6 @@ class Sumex
         // Assume always postal: This should be have an option in the future
         $node->setAttribute('payment_to', 'postal_account');
         $node->setAttribute('post_account', $subNumb);
-
 
         // IBAN not required
         //$node->setAttribute('iban', 'CH1111111111111111111');
@@ -415,6 +434,7 @@ class Sumex
     {
         $node = $this->doc->createElement('invoice:remark');
         $node->nodeValue = $this->_treatment['observations'];
+
         return $node;
     }
 
@@ -430,12 +450,12 @@ class Sumex
         $node->setAttribute('amount_obligations', 7.89);
 
         $vat = $this->doc->createElement('invoice:vat');
-        $vat->setAttribute('vat', "0.00");
+        $vat->setAttribute('vat', '0.00');
 
         $vatRate = $this->doc->createElement('invoice:vat_rate');
-        $vatRate->setAttribute('vat_rate', "0.00");
-        $vatRate->setAttribute('amount', "9.99");
-        $vatRate->setAttribute('vat', "0.00");
+        $vatRate->setAttribute('vat_rate', '0.00');
+        $vatRate->setAttribute('amount', '9.99');
+        $vatRate->setAttribute('vat', '0.00');
 
         $vat->appendChild($vatRate);
         $node->appendChild($vat);
@@ -557,7 +577,6 @@ class Sumex
             $telecom = null;
         }
 
-
         $person->appendChild($familyName);
         $person->appendChild($givenName);
         $person->appendChild($postal);
@@ -574,6 +593,7 @@ class Sumex
         $phone = $this->doc->createElement('invoice:phone');
         $phone->nodeValue = $phoneNr;
         $telecom->appendChild($phone);
+
         return $telecom;
     }
 
@@ -581,11 +601,11 @@ class Sumex
     {
         $node = $this->doc->createElement('invoice:org');
         $node->setAttribute('case_date', date("Y-m-d\TH:i:s", strtotime($this->_casedate)));
-        if ($this->_casenumber != "") {
+        if ($this->_casenumber != '') {
             $node->setAttribute('case_id', $this->_casenumber);
         }
 
-        if ($this->_insuredid != "") {
+        if ($this->_insuredid != '') {
             $node->setAttribute('insured_id', $this->_insuredid);
         }
 
@@ -600,7 +620,7 @@ class Sumex
         $node->setAttribute('canton', $this->_canton);
         $node->setAttribute('reason', $this->_treatment['reason']);
 
-        if ($this->_treatment['diagnosis'] != "") {
+        if ($this->_treatment['diagnosis'] != '') {
             $diag = $this->doc->createElement('invoice:diagnosis');
             $diag->setAttribute('type', 'freetext');
             //$diag->setAttribute('code', );
@@ -626,25 +646,25 @@ class Sumex
     }
 
     /**
-     * @param integer $recordId
+     * @param int $recordId
      */
     protected function generateRecord($recordId, $item)
     {
         $node = $this->doc->createElement('invoice:record_other');
         $node->setAttribute('record_id', $recordId);
         $node->setAttribute('tariff_type', 590);
-        $node->setAttribute('code', (int)$item->product_sku);
+        $node->setAttribute('code', (int) $item->product_sku);
         $node->setAttribute('session', 1);
         $node->setAttribute('quantity', $item->item_quantity);
         $node->setAttribute('date_begin', date("Y-m-d\TH:i:s", strtotime($item->item_date)));
         $node->setAttribute('provider_id', $this->_company['gln']);
         $node->setAttribute('responsible_id', $this->_company['gln']);
         $node->setAttribute('unit', $item->item_price);
-        #$node->setAttribute('unit_factor', 1);
+        //$node->setAttribute('unit_factor', 1);
         $node->setAttribute('amount', $item->item_total);
-        #$node->setAttribute('validate', 0);
-        #$node->setAttribute('service_attributes', 0);
-        #$node->setAttribute('obligation', 0);
+        //$node->setAttribute('validate', 0);
+        //$node->setAttribute('service_attributes', 0);
+        //$node->setAttribute('obligation', 0);
         $node->setAttribute('name', $item->item_name);
 
         //var_dump($item);
@@ -749,7 +769,7 @@ class Sumex
     {
         $node = $this->doc->createElement('invoice:mvg');
         $node->setAttribute('ssn', $this->_patient['avs']);
-        #$node->setAttribute('insured_id', '1234');
+        //$node->setAttribute('insured_id', '1234');
         $node->setAttribute('case_date', date("Y-m-d\TH:i:s", strtotime($this->_casedate)));
 
         return $node;

--- a/application/libraries/ZugferdXml.php
+++ b/application/libraries/ZugferdXml.php
@@ -1,5 +1,8 @@
 <?php
-if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+if (!defined('BASEPATH')) {
+    exit('No direct script access allowed');
+}
 
 /*
  * InvoicePlane
@@ -11,13 +14,17 @@ if (!defined('BASEPATH')) exit('No direct script access allowed');
  */
 
 /**
- * Class ZugferdXml
+ * Class ZugferdXml.
  */
 class ZugferdXml
 {
-    var $invoice;
-    var $doc;
-    var $root;
+    public $invoice;
+
+    public $doc;
+
+    public $root;
+    public $items;
+    public $currencyCode;
 
     public function __construct($params)
     {
@@ -38,7 +45,48 @@ class ZugferdXml
         $this->root->appendChild($this->xmlSpecifiedSupplyChainTradeTransaction());
 
         $this->doc->appendChild($this->root);
+
         return $this->doc->saveXML();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function zugferdFormattedDate($date)
+    {
+        if ($date) {
+            $date = DateTime::createFromFormat('Y-m-d', $date);
+
+            return $date->format('Ymd');
+        }
+
+        return '';
+    }
+
+    public function itemsSubtotalGroupedByTaxPercent()
+    {
+        $result = [];
+        foreach ($this->items as $item) {
+            if ($item->item_tax_rate_percent == 0) {
+                continue;
+            }
+
+            if (!isset($result[$item->item_tax_rate_percent])) {
+                $result[$item->item_tax_rate_percent] = 0;
+            }
+            $result[$item->item_tax_rate_percent] += $item->item_subtotal;
+        }
+
+        return $result;
+    }
+
+    // ===========================================================================
+    // elements helpers
+    // ===========================================================================
+
+    public function zugferdFormattedFloat($amount, $nb_decimals = 2)
+    {
+        return number_format((float)$amount, $nb_decimals);
     }
 
     protected function xmlRoot()
@@ -48,6 +96,7 @@ class ZugferdXml
         $node->setAttribute('xmlns:rsm', 'urn:ferd:CrossIndustryDocument:invoice:1p0');
         $node->setAttribute('xmlns:ram', 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12');
         $node->setAttribute('xmlns:udt', 'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15');
+
         return $node;
     }
 
@@ -57,6 +106,7 @@ class ZugferdXml
         $guidelineNode = $this->doc->createElement('ram:GuidelineSpecifiedDocumentContextParameter');
         $guidelineNode->appendChild($this->doc->createElement('ram:ID', 'urn:ferd:CrossIndustryDocument:invoice:1p0:basic'));
         $node->appendChild($guidelineNode);
+
         return $node;
     }
 
@@ -85,19 +135,8 @@ class ZugferdXml
     {
         $el = $this->doc->createElement('udt:DateTimeString', $this->zugferdFormattedDate($date));
         $el->setAttribute('format', 102);
-        return $el;
-    }
 
-    /**
-     * @return string|null
-     */
-    function zugferdFormattedDate($date)
-    {
-        if ($date) {
-            $date = DateTime::createFromFormat('Y-m-d', $date);
-            return $date->format('Ymd');
-        }
-        return '';
+        return $el;
     }
 
     protected function xmlSpecifiedSupplyChainTradeTransaction()
@@ -109,6 +148,7 @@ class ZugferdXml
         foreach ($this->items as $index => $item) {
             $node->appendChild($this->xmlIncludedSupplyChainTradeLineItem($index + 1, $item));
         }
+
         return $node;
     }
 
@@ -117,6 +157,7 @@ class ZugferdXml
         $node = $this->doc->createElement('ram:ApplicableSupplyChainTradeAgreement');
         $node->appendChild($this->xmlSellerTradeParty());
         $node->appendChild($this->xmlBuyerTradeParty());
+
         return $node;
     }
 
@@ -140,6 +181,7 @@ class ZugferdXml
         $addressNode->appendChild($this->doc->createElement('ram:CountryID', htmlsc($this->invoice->user_country)));
 
         $node->appendChild($addressNode);
+
         return $node;
     }
 
@@ -173,6 +215,7 @@ class ZugferdXml
         $el = $this->doc->createElement('ram:ID', $content);
         $el->setAttribute('schemeID', $schemeID);
         $node->appendChild($el);
+
         return $node;
     }
 
@@ -187,6 +230,7 @@ class ZugferdXml
         $eventNode->appendChild($dateNode);
 
         $node->appendChild($eventNode);
+
         return $node;
     }
 
@@ -208,22 +252,6 @@ class ZugferdXml
         return $node;
     }
 
-    function itemsSubtotalGroupedByTaxPercent()
-    {
-        $result = [];
-        foreach ($this->items as $item) {
-            if ($item->item_tax_rate_percent == 0) {
-                continue;
-            }
-
-            if (!isset($result[$item->item_tax_rate_percent])) {
-                $result[$item->item_tax_rate_percent] = 0;
-            }
-            $result[$item->item_tax_rate_percent] += $item->item_subtotal;
-        }
-        return $result;
-    }
-
     protected function xmlApplicableTradeTax($percent, $subtotal)
     {
         $node = $this->doc->createElement('ram:ApplicableTradeTax');
@@ -232,6 +260,7 @@ class ZugferdXml
         $node->appendChild($this->currencyElement('ram:BasisAmount', $subtotal));
         $node->appendChild($this->doc->createElement('ram:CategoryCode', 'S'));
         $node->appendChild($this->doc->createElement('ram:ApplicablePercent', $percent));
+
         return $node;
     }
 
@@ -242,16 +271,8 @@ class ZugferdXml
     {
         $el = $this->doc->createElement($name, $this->zugferdFormattedFloat($amount, $nb_decimals));
         $el->setAttribute('currencyID', $this->currencyCode);
+
         return $el;
-    }
-
-    // ===========================================================================
-    // elements helpers
-    // ===========================================================================
-
-    function zugferdFormattedFloat($amount, $nb_decimals = 2)
-    {
-        return number_format((float)$amount, $nb_decimals);
     }
 
     protected function xmlSpecifiedTradeSettlementMonetarySummation()
@@ -265,6 +286,7 @@ class ZugferdXml
         $node->appendChild($this->currencyElement('ram:GrandTotalAmount', $this->invoice->invoice_total));
         $node->appendChild($this->currencyElement('ram:TotalPrepaidAmount', $this->invoice->invoice_paid));
         $node->appendChild($this->currencyElement('ram:DuePayableAmount', $this->invoice->invoice_balance));
+
         return $node;
     }
 
@@ -324,6 +346,7 @@ class ZugferdXml
     {
         $el = $this->doc->createElement($name, $this->zugferdFormattedFloat($quantity, 4));
         $el->setAttribute('unitCode', 'C62');
+
         return $el;
     }
 

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,170 @@
+{
+  "preset": "per",
+  "exclude": [
+    "resources",
+    "storage"
+  ],
+  "rules": {
+    "@PSR12": true,
+    "align_multiline_comment": true,
+    "array_indentation": true,
+    "array_syntax": {
+      "syntax": "short"
+    },
+    "assign_null_coalescing_to_coalesce_equal": true,
+    "binary_operator_spaces": {
+      "default": "single_space",
+      "operators": {
+        "=>": "align_single_space_minimal"
+      }
+    },
+    "blank_line_after_namespace": true,
+    "blank_line_after_opening_tag": true,
+    "blank_line_before_statement": {
+      "statements": [
+        "return"
+      ]
+    },
+    "cast_spaces": true,
+    "class_attributes_separation": {
+      "elements": {
+        "const": "one",
+        "method": "one",
+        "property": "one"
+      }
+    },
+    "combine_consecutive_issets": true,
+    "combine_consecutive_unsets": true,
+    "concat_space": {
+      "spacing": "one"
+    },
+    "declare_parentheses": true,
+    "declare_strict_types": false,
+    "explicit_indirect_variable": true,
+    "explicit_string_variable": true,
+    "final_class": false,
+    "fully_qualified_strict_types": false,
+    "function_typehint_space": true,
+    "global_namespace_import": {
+      "import_classes": true,
+      "import_constants": true,
+      "import_functions": true
+    },
+    "include": true,
+    "increment_style": {
+      "style": "post"
+    },
+    "is_null": true,
+    "lambda_not_used_import": true,
+    "logical_operators": true,
+    "mb_str_functions": true,
+    "method_argument_space": {
+      "on_multiline": "ensure_fully_multiline"
+    },
+    "method_chaining_indentation": true,
+    "modernize_strpos": true,
+    "modernize_types_casting": true,
+    "multiline_whitespace_before_semicolons": true,
+    "native_function_casing": true,
+    "new_with_braces": true,
+    "no_blank_lines_after_phpdoc": true,
+    "no_empty_comment": true,
+    "no_empty_phpdoc": true,
+    "no_empty_statement": true,
+    "no_extra_blank_lines": {
+      "tokens": [
+        "curly_brace_block",
+        "extra",
+        "parenthesis_brace_block",
+        "square_brace_block",
+        "throw",
+        "use"
+      ]
+    },
+    "no_leading_namespace_whitespace": true,
+    "no_mixed_echo_print": {
+      "use": "echo"
+    },
+    "no_multiline_whitespace_around_double_arrow": true,
+    "no_short_bool_cast": true,
+    "no_singleline_whitespace_before_semicolons": true,
+    "no_spaces_around_offset": true,
+    "no_superfluous_elseif": true,
+    "no_trailing_comma_in_list_call": true,
+    "no_unneeded_control_parentheses": true,
+    "no_unused_imports": true,
+    "no_useless_else": true,
+    "no_useless_return": true,
+    "no_whitespace_before_comma_in_array": true,
+    "normalize_index_brace": true,
+    "not_operator_with_space": true,
+    "nullable_type_declaration_for_default_null_value": true,
+    "object_operator_without_whitespace": true,
+    "ordered_class_elements": {
+      "order": [
+        "use_trait",
+        "case",
+        "constant",
+        "constant_public",
+        "constant_protected",
+        "constant_private",
+        "property_public",
+        "property_protected",
+        "property_private",
+        "construct",
+        "destruct",
+        "magic",
+        "phpunit",
+        "method_abstract",
+        "method_public_static",
+        "method_public",
+        "method_protected_static",
+        "method_protected",
+        "method_private_static",
+        "method_private"
+      ],
+      "sort_algorithm": "none"
+    },
+    "ordered_imports": {
+      "sort_algorithm": "alpha"
+    },
+    "ordered_traits": true,
+    "phpdoc_align": true,
+    "phpdoc_annotation_without_dot": true,
+    "phpdoc_indent": true,
+    "phpdoc_no_access": true,
+    "phpdoc_no_alias_tag": true,
+    "phpdoc_no_empty_return": false,
+    "phpdoc_no_package": true,
+    "phpdoc_no_useless_inheritdoc": true,
+    "phpdoc_return_self_reference": true,
+    "phpdoc_scalar": true,
+    "phpdoc_separation": true,
+    "phpdoc_single_line_var_spacing": true,
+    "phpdoc_summary": true,
+    "phpdoc_to_comment": true,
+    "phpdoc_trim": true,
+    "phpdoc_types": true,
+    "phpdoc_var_without_name": true,
+    "protected_to_private": true,
+    "self_accessor": true,
+    "simplified_if_return": true,
+    "simplified_null_return": true,
+    "single_line_comment_style": true,
+    "single_quote": true,
+    "space_after_semicolon": true,
+    "standardize_not_equals": true,
+    "strict_comparison": false,
+    "ternary_to_null_coalescing": true,
+    "trailing_comma_in_multiline": {
+      "elements": [
+        "arrays"
+      ]
+    },
+    "trim_array_spaces": true,
+    "use_arrow_functions": false,
+    "void_return": true,
+    "whitespace_after_comma_in_array": true,
+    "yoda_style": false
+  }
+}

--- a/storage/framework/cache/.gitignore
+++ b/storage/framework/cache/.gitignore
@@ -1,0 +1,3 @@
+*
+!data/
+!.gitignore

--- a/storage/framework/cache/data/.gitignore
+++ b/storage/framework/cache/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/framework/sessions/.gitignore
+++ b/storage/framework/sessions/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/logs/.gitignore
+++ b/storage/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Description
This PR fixes the error message `Creation of dynamic property is depreceated` (it was needed for PHP 8.2)

## Related Issue
#1009 
and
#1063 

## Motivation and Context
After this error message is resolved we shouldn't have any problems going over to version PHP 8.2 as far as InvoicePlane is concerned

## Screenshots (if appropriate):

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
