### PR TITLE
Make sure we don't get unintended output in our PDF files

### DIFF
--- a/application/views/invoice_templates/pdf/InvoicePlane - overdue.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane - overdue.php
@@ -19,79 +19,79 @@
             <b><?php _htmlsc(format_client($invoice)); ?></b>
         </div>
         <?php if ($invoice->client_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . $invoice->client_vat_id . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($invoice->client_vat_id) . '</div>';
         }
         if ($invoice->client_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . $invoice->client_tax_code . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($invoice->client_tax_code) . '</div>';
         }
         if ($invoice->client_address_1) {
-            echo '<div>' . htmlsc($invoice->client_address_1) . '</div>';
+            echo '<div>' . _htmlsc($invoice->client_address_1) . '</div>';
         }
         if ($invoice->client_address_2) {
-            echo '<div>' . htmlsc($invoice->client_address_2) . '</div>';
+            echo '<div>' . _htmlsc($invoice->client_address_2) . '</div>';
         }
         if ($invoice->client_city || $invoice->client_state || $invoice->client_zip) {
             echo '<div>';
             if ($invoice->client_city) {
-                echo htmlsc($invoice->client_city) . ' ';
+                echo _htmlsc($invoice->client_city) . ' ';
             }
             if ($invoice->client_state) {
-                echo htmlsc($invoice->client_state) . ' ';
+                echo _htmlsc($invoice->client_state) . ' ';
             }
             if ($invoice->client_zip) {
-                echo htmlsc($invoice->client_zip);
+                echo _htmlsc($invoice->client_zip);
             }
             echo '</div>';
         }
         if ($invoice->client_country) {
-            echo '<div>' . get_country_name(trans('cldr'), $invoice->client_country) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($invoice->client_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($invoice->client_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($invoice->client_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($invoice->client_phone) . '</div>';
         } ?>
 
     </div>
     <div id="company">
         <div><b><?php _htmlsc($invoice->user_name); ?></b></div>
         <?php if ($invoice->user_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . $invoice->user_vat_id . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($invoice->user_vat_id) . '</div>';
         }
         if ($invoice->user_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . $invoice->user_tax_code . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($invoice->user_tax_code) . '</div>';
         }
         if ($invoice->user_address_1) {
-            echo '<div>' . htmlsc($invoice->user_address_1) . '</div>';
+            echo '<div>' . _htmlsc($invoice->user_address_1) . '</div>';
         }
         if ($invoice->user_address_2) {
-            echo '<div>' . htmlsc($invoice->user_address_2) . '</div>';
+            echo '<div>' . _htmlsc($invoice->user_address_2) . '</div>';
         }
         if ($invoice->user_city || $invoice->user_state || $invoice->user_zip) {
             echo '<div>';
             if ($invoice->user_city) {
-                echo htmlsc($invoice->user_city) . ' ';
+                echo _htmlsc($invoice->user_city) . ' ';
             }
             if ($invoice->user_state) {
-                echo htmlsc($invoice->user_state) . ' ';
+                echo _htmlsc($invoice->user_state) . ' ';
             }
             if ($invoice->user_zip) {
-                echo htmlsc($invoice->user_zip);
+                echo _htmlsc($invoice->user_zip);
             }
             echo '</div>';
         }
         if ($invoice->user_country) {
-            echo '<div>' . get_country_name(trans('cldr'), $invoice->user_country) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($invoice->user_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($invoice->user_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($invoice->user_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($invoice->user_phone) . '</div>';
         }
         if ($invoice->user_fax) {
-            echo '<div>' . trans('fax_abbr') . ': ' . htmlsc($invoice->user_fax) . '</div>';
+            echo '<div>' . trans('fax_abbr') . ': ' . _htmlsc($invoice->user_fax) . '</div>';
         }
         ?>
     </div>
@@ -104,15 +104,15 @@
         <table>
             <tr>
                 <td><?php echo trans('invoice_date') . ':'; ?></td>
-                <td><?php echo date_from_mysql($invoice->invoice_date_created, true); ?></td>
+                <td><?php echo date_from_mysql(_htmlsc($invoice->invoice_date_created), true); ?></td>
             </tr>
             <tr>
-                <td class="text-red"><?php echo trans('due_date') . ': '; ?></td>
-                <td class="text-red"><?php echo date_from_mysql($invoice->invoice_date_due, true); ?></td>
+                <td><?php echo trans('due_date') . ': '; ?></td>
+                <td><?php echo date_from_mysql(_htmlsc($invoice->invoice_date_due), true); ?></td>
             </tr>
             <tr>
-                <td class="text-red"><?php echo trans('amount_due') . ': '; ?></td>
-                <td class="text-red"><?php echo format_currency($invoice->invoice_balance); ?></td>
+                <td class="text-green"><?php echo trans('amount_due') . ': '; ?></td>
+                <td class="text-green"><?php echo format_currency(_htmlsc($invoice->invoice_balance)); ?></td>
             </tr>
             <?php if ($payment_method): ?>
                 <tr>
@@ -144,24 +144,24 @@
         foreach ($items as $item) { ?>
             <tr>
                 <td><?php _htmlsc($item->item_name); ?></td>
-                <td><?php echo nl2br(htmlsc($item->item_description)); ?></td>
+                <td><?php echo nl2br(_htmlsc($item->item_description)); ?></td>
                 <td class="text-right">
-                    <?php echo format_quantity($item->item_quantity); ?>
+                    <?php echo format_quantity(_htmlsc($item->item_quantity)); ?>
                     <?php if ($item->item_product_unit) : ?>
                         <br>
                         <small><?php _htmlsc($item->item_product_unit); ?></small>
                     <?php endif; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($item->item_price); ?>
+                    <?php echo format_currency(_htmlsc($item->item_price)); ?>
                 </td>
                 <?php if ($show_item_discounts) : ?>
                     <td class="text-right">
-                        <?php echo format_currency($item->item_discount); ?>
+                        <?php echo format_currency(_htmlsc($item->item_discount)); ?>
                     </td>
                 <?php endif; ?>
                 <td class="text-right">
-                    <?php echo format_currency($item->item_total); ?>
+                    <?php echo format_currency(_htmlsc($item->item_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -173,7 +173,7 @@
             <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
                 <?php _trans('subtotal'); ?>
             </td>
-            <td class="text-right"><?php echo format_currency($invoice->invoice_item_subtotal); ?></td>
+            <td class="text-right"><?php echo format_currency(_htmlsc($invoice->invoice_item_subtotal)); ?></td>
         </tr>
 
         <?php if ($invoice->invoice_item_tax_total > 0) { ?>
@@ -182,7 +182,7 @@
                     <?php _trans('item_tax'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($invoice->invoice_item_tax_total); ?>
+                    <?php echo format_currency(_htmlsc($invoice->invoice_item_tax_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -190,10 +190,10 @@
         <?php foreach ($invoice_tax_rates as $invoice_tax_rate) : ?>
             <tr>
                 <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
-                    <?php echo htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount($invoice_tax_rate->invoice_tax_rate_percent) . '%)'; ?>
+                    <?php echo _htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount(_htmlsc($invoice_tax_rate->invoice_tax_rate_percent)) . '%)'; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($invoice_tax_rate->invoice_tax_rate_amount); ?>
+                    <?php echo format_currency(_htmlsc($invoice_tax_rate->invoice_tax_rate_amount)); ?>
                 </td>
             </tr>
         <?php endforeach ?>
@@ -204,7 +204,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_amount($invoice->invoice_discount_percent); ?>%
+                    <?php echo format_amount(_htmlsc($invoice->invoice_discount_percent)); ?>%
                 </td>
             </tr>
         <?php endif; ?>
@@ -214,7 +214,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($invoice->invoice_discount_amount); ?>
+                    <?php echo format_currency(_htmlsc($invoice->invoice_discount_amount)); ?>
                 </td>
             </tr>
         <?php endif; ?>
@@ -224,7 +224,7 @@
                 <b><?php _trans('total'); ?></b>
             </td>
             <td class="text-right">
-                <b><?php echo format_currency($invoice->invoice_total); ?></b>
+                <b><?php echo format_currency(_htmlsc($invoice->invoice_total)); ?></b>
             </td>
         </tr>
         <tr>
@@ -232,7 +232,7 @@
                 <?php _trans('paid'); ?>
             </td>
             <td class="text-right">
-                <?php echo format_currency($invoice->invoice_paid); ?>
+                <?php echo format_currency(_htmlsc($invoice->invoice_paid)); ?>
             </td>
         </tr>
         <tr>
@@ -240,7 +240,7 @@
                 <b><?php _trans('balance'); ?></b>
             </td>
             <td class="text-right text-red">
-                <b><?php echo format_currency($invoice->invoice_balance); ?></b>
+                <b><?php echo format_currency(_htmlsc($invoice->invoice_balance)); ?></b>
             </td>
         </tr>
         </tbody>
@@ -269,7 +269,7 @@
                 </div>
             </td>
             <td class="text-right">
-                <?php echo invoice_qrcode($invoice->invoice_id); ?>
+                <?php echo invoice_qrcode(_htmlsc($invoice->invoice_id)); ?>
             </td>
         </tr>
     </table>
@@ -281,7 +281,7 @@
     <?php if ($invoice->invoice_terms) : ?>
         <div class="notes">
             <b><?php _trans('terms'); ?></b><br/>
-            <?php echo nl2br(htmlsc($invoice->invoice_terms)); ?>
+            <?php echo nl2br(_htmlsc($invoice->invoice_terms)); ?>
         </div>
     <?php endif; ?>
 </footer>

--- a/application/views/invoice_templates/pdf/InvoicePlane - overdue.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane - overdue.php
@@ -107,12 +107,12 @@
                 <td><?php echo date_from_mysql(htmlsc($invoice->invoice_date_created), true); ?></td>
             </tr>
             <tr>
-                <td><?php echo trans('due_date') . ': '; ?></td>
-                <td><?php echo date_from_mysql(htmlsc($invoice->invoice_date_due), true); ?></td>
+                <td class="text-red"><?php echo trans('due_date') . ': '; ?></td>
+                <td class="text-red"><?php echo date_from_mysql(htmlsc($invoice->invoice_date_due), true); ?></td>
             </tr>
             <tr>
-                <td class="text-green"><?php echo trans('amount_due') . ': '; ?></td>
-                <td class="text-green"><?php echo format_currency(htmlsc($invoice->invoice_balance)); ?></td>
+                <td class="text-red"><?php echo trans('amount_due') . ': '; ?></td>
+                <td class="text-red"><?php echo format_currency(htmlsc($invoice->invoice_balance)); ?></td>
             </tr>
             <?php if ($payment_method): ?>
                 <tr>

--- a/application/views/invoice_templates/pdf/InvoicePlane - overdue.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane - overdue.php
@@ -19,79 +19,79 @@
             <b><?php _htmlsc(format_client($invoice)); ?></b>
         </div>
         <?php if ($invoice->client_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($invoice->client_vat_id) . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . htmlsc($invoice->client_vat_id) . '</div>';
         }
         if ($invoice->client_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($invoice->client_tax_code) . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . htmlsc($invoice->client_tax_code) . '</div>';
         }
         if ($invoice->client_address_1) {
-            echo '<div>' . _htmlsc($invoice->client_address_1) . '</div>';
+            echo '<div>' . htmlsc($invoice->client_address_1) . '</div>';
         }
         if ($invoice->client_address_2) {
-            echo '<div>' . _htmlsc($invoice->client_address_2) . '</div>';
+            echo '<div>' . htmlsc($invoice->client_address_2) . '</div>';
         }
         if ($invoice->client_city || $invoice->client_state || $invoice->client_zip) {
             echo '<div>';
             if ($invoice->client_city) {
-                echo _htmlsc($invoice->client_city) . ' ';
+                echo htmlsc($invoice->client_city) . ' ';
             }
             if ($invoice->client_state) {
-                echo _htmlsc($invoice->client_state) . ' ';
+                echo htmlsc($invoice->client_state) . ' ';
             }
             if ($invoice->client_zip) {
-                echo _htmlsc($invoice->client_zip);
+                echo htmlsc($invoice->client_zip);
             }
             echo '</div>';
         }
         if ($invoice->client_country) {
-            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($invoice->client_country)) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), htmlsc($invoice->client_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($invoice->client_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($invoice->client_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($invoice->client_phone) . '</div>';
         } ?>
 
     </div>
     <div id="company">
         <div><b><?php _htmlsc($invoice->user_name); ?></b></div>
         <?php if ($invoice->user_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($invoice->user_vat_id) . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . htmlsc($invoice->user_vat_id) . '</div>';
         }
         if ($invoice->user_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($invoice->user_tax_code) . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . htmlsc($invoice->user_tax_code) . '</div>';
         }
         if ($invoice->user_address_1) {
-            echo '<div>' . _htmlsc($invoice->user_address_1) . '</div>';
+            echo '<div>' . htmlsc($invoice->user_address_1) . '</div>';
         }
         if ($invoice->user_address_2) {
-            echo '<div>' . _htmlsc($invoice->user_address_2) . '</div>';
+            echo '<div>' . htmlsc($invoice->user_address_2) . '</div>';
         }
         if ($invoice->user_city || $invoice->user_state || $invoice->user_zip) {
             echo '<div>';
             if ($invoice->user_city) {
-                echo _htmlsc($invoice->user_city) . ' ';
+                echo htmlsc($invoice->user_city) . ' ';
             }
             if ($invoice->user_state) {
-                echo _htmlsc($invoice->user_state) . ' ';
+                echo htmlsc($invoice->user_state) . ' ';
             }
             if ($invoice->user_zip) {
-                echo _htmlsc($invoice->user_zip);
+                echo htmlsc($invoice->user_zip);
             }
             echo '</div>';
         }
         if ($invoice->user_country) {
-            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($invoice->user_country)) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), htmlsc($invoice->user_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($invoice->user_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($invoice->user_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($invoice->user_phone) . '</div>';
         }
         if ($invoice->user_fax) {
-            echo '<div>' . trans('fax_abbr') . ': ' . _htmlsc($invoice->user_fax) . '</div>';
+            echo '<div>' . trans('fax_abbr') . ': ' . htmlsc($invoice->user_fax) . '</div>';
         }
         ?>
     </div>
@@ -104,15 +104,15 @@
         <table>
             <tr>
                 <td><?php echo trans('invoice_date') . ':'; ?></td>
-                <td><?php echo date_from_mysql(_htmlsc($invoice->invoice_date_created), true); ?></td>
+                <td><?php echo date_from_mysql(htmlsc($invoice->invoice_date_created), true); ?></td>
             </tr>
             <tr>
                 <td><?php echo trans('due_date') . ': '; ?></td>
-                <td><?php echo date_from_mysql(_htmlsc($invoice->invoice_date_due), true); ?></td>
+                <td><?php echo date_from_mysql(htmlsc($invoice->invoice_date_due), true); ?></td>
             </tr>
             <tr>
                 <td class="text-green"><?php echo trans('amount_due') . ': '; ?></td>
-                <td class="text-green"><?php echo format_currency(_htmlsc($invoice->invoice_balance)); ?></td>
+                <td class="text-green"><?php echo format_currency(htmlsc($invoice->invoice_balance)); ?></td>
             </tr>
             <?php if ($payment_method): ?>
                 <tr>
@@ -144,24 +144,24 @@
         foreach ($items as $item) { ?>
             <tr>
                 <td><?php _htmlsc($item->item_name); ?></td>
-                <td><?php echo nl2br(_htmlsc($item->item_description)); ?></td>
+                <td><?php echo nl2br(htmlsc($item->item_description)); ?></td>
                 <td class="text-right">
-                    <?php echo format_quantity(_htmlsc($item->item_quantity)); ?>
+                    <?php echo format_quantity(htmlsc($item->item_quantity)); ?>
                     <?php if ($item->item_product_unit) : ?>
                         <br>
                         <small><?php _htmlsc($item->item_product_unit); ?></small>
                     <?php endif; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($item->item_price)); ?>
+                    <?php echo format_currency(htmlsc($item->item_price)); ?>
                 </td>
                 <?php if ($show_item_discounts) : ?>
                     <td class="text-right">
-                        <?php echo format_currency(_htmlsc($item->item_discount)); ?>
+                        <?php echo format_currency(htmlsc($item->item_discount)); ?>
                     </td>
                 <?php endif; ?>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($item->item_total)); ?>
+                    <?php echo format_currency(htmlsc($item->item_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -173,7 +173,7 @@
             <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
                 <?php _trans('subtotal'); ?>
             </td>
-            <td class="text-right"><?php echo format_currency(_htmlsc($invoice->invoice_item_subtotal)); ?></td>
+            <td class="text-right"><?php echo format_currency(htmlsc($invoice->invoice_item_subtotal)); ?></td>
         </tr>
 
         <?php if ($invoice->invoice_item_tax_total > 0) { ?>
@@ -182,7 +182,7 @@
                     <?php _trans('item_tax'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($invoice->invoice_item_tax_total)); ?>
+                    <?php echo format_currency(htmlsc($invoice->invoice_item_tax_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -190,10 +190,10 @@
         <?php foreach ($invoice_tax_rates as $invoice_tax_rate) : ?>
             <tr>
                 <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
-                    <?php echo _htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount(_htmlsc($invoice_tax_rate->invoice_tax_rate_percent)) . '%)'; ?>
+                    <?php echo htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount(htmlsc($invoice_tax_rate->invoice_tax_rate_percent)) . '%)'; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($invoice_tax_rate->invoice_tax_rate_amount)); ?>
+                    <?php echo format_currency(htmlsc($invoice_tax_rate->invoice_tax_rate_amount)); ?>
                 </td>
             </tr>
         <?php endforeach ?>
@@ -204,7 +204,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_amount(_htmlsc($invoice->invoice_discount_percent)); ?>%
+                    <?php echo format_amount(htmlsc($invoice->invoice_discount_percent)); ?>%
                 </td>
             </tr>
         <?php endif; ?>
@@ -214,7 +214,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($invoice->invoice_discount_amount)); ?>
+                    <?php echo format_currency(htmlsc($invoice->invoice_discount_amount)); ?>
                 </td>
             </tr>
         <?php endif; ?>
@@ -224,7 +224,7 @@
                 <b><?php _trans('total'); ?></b>
             </td>
             <td class="text-right">
-                <b><?php echo format_currency(_htmlsc($invoice->invoice_total)); ?></b>
+                <b><?php echo format_currency(htmlsc($invoice->invoice_total)); ?></b>
             </td>
         </tr>
         <tr>
@@ -232,7 +232,7 @@
                 <?php _trans('paid'); ?>
             </td>
             <td class="text-right">
-                <?php echo format_currency(_htmlsc($invoice->invoice_paid)); ?>
+                <?php echo format_currency(htmlsc($invoice->invoice_paid)); ?>
             </td>
         </tr>
         <tr>
@@ -240,7 +240,7 @@
                 <b><?php _trans('balance'); ?></b>
             </td>
             <td class="text-right text-red">
-                <b><?php echo format_currency(_htmlsc($invoice->invoice_balance)); ?></b>
+                <b><?php echo format_currency(htmlsc($invoice->invoice_balance)); ?></b>
             </td>
         </tr>
         </tbody>
@@ -269,7 +269,7 @@
                 </div>
             </td>
             <td class="text-right">
-                <?php echo invoice_qrcode(_htmlsc($invoice->invoice_id)); ?>
+                <?php echo invoice_qrcode(htmlsc($invoice->invoice_id)); ?>
             </td>
         </tr>
     </table>
@@ -281,7 +281,7 @@
     <?php if ($invoice->invoice_terms) : ?>
         <div class="notes">
             <b><?php _trans('terms'); ?></b><br/>
-            <?php echo nl2br(_htmlsc($invoice->invoice_terms)); ?>
+            <?php echo nl2br(htmlsc($invoice->invoice_terms)); ?>
         </div>
     <?php endif; ?>
 </footer>

--- a/application/views/invoice_templates/pdf/InvoicePlane - paid.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane - paid.php
@@ -239,7 +239,7 @@
             <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
                 <b><?php _trans('balance'); ?></b>
             </td>
-            <td class="text-right text-red">
+            <td class="text-right text-green">
                 <b><?php echo format_currency(htmlsc($invoice->invoice_balance)); ?></b>
             </td>
         </tr>

--- a/application/views/invoice_templates/pdf/InvoicePlane - paid.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane - paid.php
@@ -19,79 +19,79 @@
             <b><?php _htmlsc(format_client($invoice)); ?></b>
         </div>
         <?php if ($invoice->client_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . $invoice->client_vat_id . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($invoice->client_vat_id) . '</div>';
         }
         if ($invoice->client_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . $invoice->client_tax_code . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($invoice->client_tax_code) . '</div>';
         }
         if ($invoice->client_address_1) {
-            echo '<div>' . htmlsc($invoice->client_address_1) . '</div>';
+            echo '<div>' . _htmlsc($invoice->client_address_1) . '</div>';
         }
         if ($invoice->client_address_2) {
-            echo '<div>' . htmlsc($invoice->client_address_2) . '</div>';
+            echo '<div>' . _htmlsc($invoice->client_address_2) . '</div>';
         }
         if ($invoice->client_city || $invoice->client_state || $invoice->client_zip) {
             echo '<div>';
             if ($invoice->client_city) {
-                echo htmlsc($invoice->client_city) . ' ';
+                echo _htmlsc($invoice->client_city) . ' ';
             }
             if ($invoice->client_state) {
-                echo htmlsc($invoice->client_state) . ' ';
+                echo _htmlsc($invoice->client_state) . ' ';
             }
             if ($invoice->client_zip) {
-                echo htmlsc($invoice->client_zip);
+                echo _htmlsc($invoice->client_zip);
             }
             echo '</div>';
         }
         if ($invoice->client_country) {
-            echo '<div>' . get_country_name(trans('cldr'), $invoice->client_country) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($invoice->client_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($invoice->client_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($invoice->client_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($invoice->client_phone) . '</div>';
         } ?>
 
     </div>
     <div id="company">
         <div><b><?php _htmlsc($invoice->user_name); ?></b></div>
         <?php if ($invoice->user_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . $invoice->user_vat_id . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($invoice->user_vat_id) . '</div>';
         }
         if ($invoice->user_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . $invoice->user_tax_code . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($invoice->user_tax_code) . '</div>';
         }
         if ($invoice->user_address_1) {
-            echo '<div>' . htmlsc($invoice->user_address_1) . '</div>';
+            echo '<div>' . _htmlsc($invoice->user_address_1) . '</div>';
         }
         if ($invoice->user_address_2) {
-            echo '<div>' . htmlsc($invoice->user_address_2) . '</div>';
+            echo '<div>' . _htmlsc($invoice->user_address_2) . '</div>';
         }
         if ($invoice->user_city || $invoice->user_state || $invoice->user_zip) {
             echo '<div>';
             if ($invoice->user_city) {
-                echo htmlsc($invoice->user_city) . ' ';
+                echo _htmlsc($invoice->user_city) . ' ';
             }
             if ($invoice->user_state) {
-                echo htmlsc($invoice->user_state) . ' ';
+                echo _htmlsc($invoice->user_state) . ' ';
             }
             if ($invoice->user_zip) {
-                echo htmlsc($invoice->user_zip);
+                echo _htmlsc($invoice->user_zip);
             }
             echo '</div>';
         }
         if ($invoice->user_country) {
-            echo '<div>' . get_country_name(trans('cldr'), $invoice->user_country) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($invoice->user_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($invoice->user_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($invoice->user_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($invoice->user_phone) . '</div>';
         }
         if ($invoice->user_fax) {
-            echo '<div>' . trans('fax_abbr') . ': ' . htmlsc($invoice->user_fax) . '</div>';
+            echo '<div>' . trans('fax_abbr') . ': ' . _htmlsc($invoice->user_fax) . '</div>';
         }
         ?>
     </div>
@@ -104,15 +104,15 @@
         <table>
             <tr>
                 <td><?php echo trans('invoice_date') . ':'; ?></td>
-                <td><?php echo date_from_mysql($invoice->invoice_date_created, true); ?></td>
+                <td><?php echo date_from_mysql(_htmlsc($invoice->invoice_date_created), true); ?></td>
             </tr>
             <tr>
                 <td><?php echo trans('due_date') . ': '; ?></td>
-                <td><?php echo date_from_mysql($invoice->invoice_date_due, true); ?></td>
+                <td><?php echo date_from_mysql(_htmlsc($invoice->invoice_date_due), true); ?></td>
             </tr>
             <tr>
                 <td class="text-green"><?php echo trans('amount_due') . ': '; ?></td>
-                <td class="text-green"><?php echo format_currency($invoice->invoice_balance); ?></td>
+                <td class="text-green"><?php echo format_currency(_htmlsc($invoice->invoice_balance)); ?></td>
             </tr>
             <?php if ($payment_method): ?>
                 <tr>
@@ -144,24 +144,24 @@
         foreach ($items as $item) { ?>
             <tr>
                 <td><?php _htmlsc($item->item_name); ?></td>
-                <td><?php echo nl2br(htmlsc($item->item_description)); ?></td>
+                <td><?php echo nl2br(_htmlsc($item->item_description)); ?></td>
                 <td class="text-right">
-                    <?php echo format_quantity($item->item_quantity); ?>
+                    <?php echo format_quantity(_htmlsc($item->item_quantity)); ?>
                     <?php if ($item->item_product_unit) : ?>
                         <br>
                         <small><?php _htmlsc($item->item_product_unit); ?></small>
                     <?php endif; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($item->item_price); ?>
+                    <?php echo format_currency(_htmlsc($item->item_price)); ?>
                 </td>
                 <?php if ($show_item_discounts) : ?>
                     <td class="text-right">
-                        <?php echo format_currency($item->item_discount); ?>
+                        <?php echo format_currency(_htmlsc($item->item_discount)); ?>
                     </td>
                 <?php endif; ?>
                 <td class="text-right">
-                    <?php echo format_currency($item->item_total); ?>
+                    <?php echo format_currency(_htmlsc($item->item_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -173,7 +173,7 @@
             <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
                 <?php _trans('subtotal'); ?>
             </td>
-            <td class="text-right"><?php echo format_currency($invoice->invoice_item_subtotal); ?></td>
+            <td class="text-right"><?php echo format_currency(_htmlsc($invoice->invoice_item_subtotal)); ?></td>
         </tr>
 
         <?php if ($invoice->invoice_item_tax_total > 0) { ?>
@@ -182,7 +182,7 @@
                     <?php _trans('item_tax'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($invoice->invoice_item_tax_total); ?>
+                    <?php echo format_currency(_htmlsc($invoice->invoice_item_tax_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -190,10 +190,10 @@
         <?php foreach ($invoice_tax_rates as $invoice_tax_rate) : ?>
             <tr>
                 <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
-                    <?php echo htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount($invoice_tax_rate->invoice_tax_rate_percent) . '%)'; ?>
+                    <?php echo _htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount(_htmlsc($invoice_tax_rate->invoice_tax_rate_percent)) . '%)'; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($invoice_tax_rate->invoice_tax_rate_amount); ?>
+                    <?php echo format_currency(_htmlsc($invoice_tax_rate->invoice_tax_rate_amount)); ?>
                 </td>
             </tr>
         <?php endforeach ?>
@@ -204,7 +204,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_amount($invoice->invoice_discount_percent); ?>%
+                    <?php echo format_amount(_htmlsc($invoice->invoice_discount_percent)); ?>%
                 </td>
             </tr>
         <?php endif; ?>
@@ -214,7 +214,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($invoice->invoice_discount_amount); ?>
+                    <?php echo format_currency(_htmlsc($invoice->invoice_discount_amount)); ?>
                 </td>
             </tr>
         <?php endif; ?>
@@ -224,7 +224,7 @@
                 <b><?php _trans('total'); ?></b>
             </td>
             <td class="text-right">
-                <b><?php echo format_currency($invoice->invoice_total); ?></b>
+                <b><?php echo format_currency(_htmlsc($invoice->invoice_total)); ?></b>
             </td>
         </tr>
         <tr>
@@ -232,20 +232,19 @@
                 <?php _trans('paid'); ?>
             </td>
             <td class="text-right">
-                <?php echo format_currency($invoice->invoice_paid); ?>
+                <?php echo format_currency(_htmlsc($invoice->invoice_paid)); ?>
             </td>
         </tr>
         <tr>
             <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
                 <b><?php _trans('balance'); ?></b>
             </td>
-            <td class="text-right text-green">
-                <b><?php echo format_currency($invoice->invoice_balance); ?></b>
+            <td class="text-right text-red">
+                <b><?php echo format_currency(_htmlsc($invoice->invoice_balance)); ?></b>
             </td>
         </tr>
         </tbody>
     </table>
-
 </main>
 
 <watermarktext content="<?php _trans('paid'); ?>" alpha="0.3" />
@@ -254,7 +253,7 @@
     <?php if ($invoice->invoice_terms) : ?>
         <div class="notes">
             <b><?php _trans('terms'); ?></b><br/>
-            <?php echo nl2br(htmlsc($invoice->invoice_terms)); ?>
+            <?php echo nl2br(_htmlsc($invoice->invoice_terms)); ?>
         </div>
     <?php endif; ?>
 </footer>

--- a/application/views/invoice_templates/pdf/InvoicePlane - paid.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane - paid.php
@@ -19,79 +19,79 @@
             <b><?php _htmlsc(format_client($invoice)); ?></b>
         </div>
         <?php if ($invoice->client_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($invoice->client_vat_id) . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . htmlsc($invoice->client_vat_id) . '</div>';
         }
         if ($invoice->client_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($invoice->client_tax_code) . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . htmlsc($invoice->client_tax_code) . '</div>';
         }
         if ($invoice->client_address_1) {
-            echo '<div>' . _htmlsc($invoice->client_address_1) . '</div>';
+            echo '<div>' . htmlsc($invoice->client_address_1) . '</div>';
         }
         if ($invoice->client_address_2) {
-            echo '<div>' . _htmlsc($invoice->client_address_2) . '</div>';
+            echo '<div>' . htmlsc($invoice->client_address_2) . '</div>';
         }
         if ($invoice->client_city || $invoice->client_state || $invoice->client_zip) {
             echo '<div>';
             if ($invoice->client_city) {
-                echo _htmlsc($invoice->client_city) . ' ';
+                echo htmlsc($invoice->client_city) . ' ';
             }
             if ($invoice->client_state) {
-                echo _htmlsc($invoice->client_state) . ' ';
+                echo htmlsc($invoice->client_state) . ' ';
             }
             if ($invoice->client_zip) {
-                echo _htmlsc($invoice->client_zip);
+                echo htmlsc($invoice->client_zip);
             }
             echo '</div>';
         }
         if ($invoice->client_country) {
-            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($invoice->client_country)) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), htmlsc($invoice->client_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($invoice->client_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($invoice->client_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($invoice->client_phone) . '</div>';
         } ?>
 
     </div>
     <div id="company">
         <div><b><?php _htmlsc($invoice->user_name); ?></b></div>
         <?php if ($invoice->user_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($invoice->user_vat_id) . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . htmlsc($invoice->user_vat_id) . '</div>';
         }
         if ($invoice->user_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($invoice->user_tax_code) . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . htmlsc($invoice->user_tax_code) . '</div>';
         }
         if ($invoice->user_address_1) {
-            echo '<div>' . _htmlsc($invoice->user_address_1) . '</div>';
+            echo '<div>' . htmlsc($invoice->user_address_1) . '</div>';
         }
         if ($invoice->user_address_2) {
-            echo '<div>' . _htmlsc($invoice->user_address_2) . '</div>';
+            echo '<div>' . htmlsc($invoice->user_address_2) . '</div>';
         }
         if ($invoice->user_city || $invoice->user_state || $invoice->user_zip) {
             echo '<div>';
             if ($invoice->user_city) {
-                echo _htmlsc($invoice->user_city) . ' ';
+                echo htmlsc($invoice->user_city) . ' ';
             }
             if ($invoice->user_state) {
-                echo _htmlsc($invoice->user_state) . ' ';
+                echo htmlsc($invoice->user_state) . ' ';
             }
             if ($invoice->user_zip) {
-                echo _htmlsc($invoice->user_zip);
+                echo htmlsc($invoice->user_zip);
             }
             echo '</div>';
         }
         if ($invoice->user_country) {
-            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($invoice->user_country)) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), htmlsc($invoice->user_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($invoice->user_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($invoice->user_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($invoice->user_phone) . '</div>';
         }
         if ($invoice->user_fax) {
-            echo '<div>' . trans('fax_abbr') . ': ' . _htmlsc($invoice->user_fax) . '</div>';
+            echo '<div>' . trans('fax_abbr') . ': ' . htmlsc($invoice->user_fax) . '</div>';
         }
         ?>
     </div>
@@ -104,15 +104,15 @@
         <table>
             <tr>
                 <td><?php echo trans('invoice_date') . ':'; ?></td>
-                <td><?php echo date_from_mysql(_htmlsc($invoice->invoice_date_created), true); ?></td>
+                <td><?php echo date_from_mysql(htmlsc($invoice->invoice_date_created), true); ?></td>
             </tr>
             <tr>
                 <td><?php echo trans('due_date') . ': '; ?></td>
-                <td><?php echo date_from_mysql(_htmlsc($invoice->invoice_date_due), true); ?></td>
+                <td><?php echo date_from_mysql(htmlsc($invoice->invoice_date_due), true); ?></td>
             </tr>
             <tr>
                 <td class="text-green"><?php echo trans('amount_due') . ': '; ?></td>
-                <td class="text-green"><?php echo format_currency(_htmlsc($invoice->invoice_balance)); ?></td>
+                <td class="text-green"><?php echo format_currency(htmlsc($invoice->invoice_balance)); ?></td>
             </tr>
             <?php if ($payment_method): ?>
                 <tr>
@@ -144,24 +144,24 @@
         foreach ($items as $item) { ?>
             <tr>
                 <td><?php _htmlsc($item->item_name); ?></td>
-                <td><?php echo nl2br(_htmlsc($item->item_description)); ?></td>
+                <td><?php echo nl2br(htmlsc($item->item_description)); ?></td>
                 <td class="text-right">
-                    <?php echo format_quantity(_htmlsc($item->item_quantity)); ?>
+                    <?php echo format_quantity(htmlsc($item->item_quantity)); ?>
                     <?php if ($item->item_product_unit) : ?>
                         <br>
                         <small><?php _htmlsc($item->item_product_unit); ?></small>
                     <?php endif; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($item->item_price)); ?>
+                    <?php echo format_currency(htmlsc($item->item_price)); ?>
                 </td>
                 <?php if ($show_item_discounts) : ?>
                     <td class="text-right">
-                        <?php echo format_currency(_htmlsc($item->item_discount)); ?>
+                        <?php echo format_currency(htmlsc($item->item_discount)); ?>
                     </td>
                 <?php endif; ?>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($item->item_total)); ?>
+                    <?php echo format_currency(htmlsc($item->item_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -173,7 +173,7 @@
             <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
                 <?php _trans('subtotal'); ?>
             </td>
-            <td class="text-right"><?php echo format_currency(_htmlsc($invoice->invoice_item_subtotal)); ?></td>
+            <td class="text-right"><?php echo format_currency(htmlsc($invoice->invoice_item_subtotal)); ?></td>
         </tr>
 
         <?php if ($invoice->invoice_item_tax_total > 0) { ?>
@@ -182,7 +182,7 @@
                     <?php _trans('item_tax'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($invoice->invoice_item_tax_total)); ?>
+                    <?php echo format_currency(htmlsc($invoice->invoice_item_tax_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -190,10 +190,10 @@
         <?php foreach ($invoice_tax_rates as $invoice_tax_rate) : ?>
             <tr>
                 <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
-                    <?php echo _htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount(_htmlsc($invoice_tax_rate->invoice_tax_rate_percent)) . '%)'; ?>
+                    <?php echo htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount(htmlsc($invoice_tax_rate->invoice_tax_rate_percent)) . '%)'; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($invoice_tax_rate->invoice_tax_rate_amount)); ?>
+                    <?php echo format_currency(htmlsc($invoice_tax_rate->invoice_tax_rate_amount)); ?>
                 </td>
             </tr>
         <?php endforeach ?>
@@ -204,7 +204,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_amount(_htmlsc($invoice->invoice_discount_percent)); ?>%
+                    <?php echo format_amount(htmlsc($invoice->invoice_discount_percent)); ?>%
                 </td>
             </tr>
         <?php endif; ?>
@@ -214,7 +214,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($invoice->invoice_discount_amount)); ?>
+                    <?php echo format_currency(htmlsc($invoice->invoice_discount_amount)); ?>
                 </td>
             </tr>
         <?php endif; ?>
@@ -224,7 +224,7 @@
                 <b><?php _trans('total'); ?></b>
             </td>
             <td class="text-right">
-                <b><?php echo format_currency(_htmlsc($invoice->invoice_total)); ?></b>
+                <b><?php echo format_currency(htmlsc($invoice->invoice_total)); ?></b>
             </td>
         </tr>
         <tr>
@@ -232,7 +232,7 @@
                 <?php _trans('paid'); ?>
             </td>
             <td class="text-right">
-                <?php echo format_currency(_htmlsc($invoice->invoice_paid)); ?>
+                <?php echo format_currency(htmlsc($invoice->invoice_paid)); ?>
             </td>
         </tr>
         <tr>
@@ -240,7 +240,7 @@
                 <b><?php _trans('balance'); ?></b>
             </td>
             <td class="text-right text-red">
-                <b><?php echo format_currency(_htmlsc($invoice->invoice_balance)); ?></b>
+                <b><?php echo format_currency(htmlsc($invoice->invoice_balance)); ?></b>
             </td>
         </tr>
         </tbody>
@@ -253,7 +253,7 @@
     <?php if ($invoice->invoice_terms) : ?>
         <div class="notes">
             <b><?php _trans('terms'); ?></b><br/>
-            <?php echo nl2br(_htmlsc($invoice->invoice_terms)); ?>
+            <?php echo nl2br(htmlsc($invoice->invoice_terms)); ?>
         </div>
     <?php endif; ?>
 </footer>

--- a/application/views/invoice_templates/pdf/InvoicePlane.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane.php
@@ -19,78 +19,78 @@
             <b><?php _htmlsc(format_client($invoice)); ?></b>
         </div>
         <?php if ($invoice->client_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($invoice->client_vat_id) . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . htmlsc($invoice->client_vat_id) . '</div>';
         }
         if ($invoice->client_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($invoice->client_tax_code) . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . htmlsc($invoice->client_tax_code) . '</div>';
         }
         if ($invoice->client_address_1) {
-            echo '<div>' . _htmlsc($invoice->client_address_1) . '</div>';
+            echo '<div>' . htmlsc($invoice->client_address_1) . '</div>';
         }
         if ($invoice->client_address_2) {
-            echo '<div>' . _htmlsc($invoice->client_address_2) . '</div>';
+            echo '<div>' . htmlsc($invoice->client_address_2) . '</div>';
         }
         if ($invoice->client_city || $invoice->client_state || $invoice->client_zip) {
             echo '<div>';
             if ($invoice->client_city) {
-                echo _htmlsc($invoice->client_city) . ' ';
+                echo htmlsc($invoice->client_city) . ' ';
             }
             if ($invoice->client_state) {
-                echo _htmlsc($invoice->client_state) . ' ';
+                echo htmlsc($invoice->client_state) . ' ';
             }
             if ($invoice->client_zip) {
-                echo _htmlsc($invoice->client_zip);
+                echo htmlsc($invoice->client_zip);
             }
             echo '</div>';
         }
         if ($invoice->client_country) {
-            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($invoice->client_country)) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), htmlsc($invoice->client_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($invoice->client_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($invoice->client_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($invoice->client_phone) . '</div>';
         } ?>
     </div>
     <div id="company">
         <div><b><?php _htmlsc($invoice->user_name); ?></b></div>
         <?php if ($invoice->user_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($invoice->user_vat_id) . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . htmlsc($invoice->user_vat_id) . '</div>';
         }
             if ($invoice->user_tax_code) {
-                echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($invoice->user_tax_code) . '</div>';
+                echo '<div>' . trans('tax_code_short') . ': ' . htmlsc($invoice->user_tax_code) . '</div>';
             }
             if ($invoice->user_address_1) {
-                echo '<div>' . _htmlsc($invoice->user_address_1) . '</div>';
+                echo '<div>' . htmlsc($invoice->user_address_1) . '</div>';
             }
             if ($invoice->user_address_2) {
-                echo '<div>' . _htmlsc($invoice->user_address_2) . '</div>';
+                echo '<div>' . htmlsc($invoice->user_address_2) . '</div>';
             }
             if ($invoice->user_city || $invoice->user_state || $invoice->user_zip) {
                 echo '<div>';
                 if ($invoice->user_city) {
-                    echo _htmlsc($invoice->user_city) . ' ';
+                    echo htmlsc($invoice->user_city) . ' ';
                 }
                 if ($invoice->user_state) {
-                    echo _htmlsc($invoice->user_state) . ' ';
+                    echo htmlsc($invoice->user_state) . ' ';
                 }
                 if ($invoice->user_zip) {
-                    echo _htmlsc($invoice->user_zip);
+                    echo htmlsc($invoice->user_zip);
                 }
                 echo '</div>';
             }
             if ($invoice->user_country) {
-                echo '<div>' . get_country_name(trans('cldr'), _htmlsc($invoice->user_country)) . '</div>';
+                echo '<div>' . get_country_name(trans('cldr'), htmlsc($invoice->user_country)) . '</div>';
             }
 
             echo '<br/>';
 
             if ($invoice->user_phone) {
-                echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($invoice->user_phone) . '</div>';
+                echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($invoice->user_phone) . '</div>';
             }
             if ($invoice->user_fax) {
-                echo '<div>' . trans('fax_abbr') . ': ' . _htmlsc($invoice->user_fax) . '</div>';
+                echo '<div>' . trans('fax_abbr') . ': ' . htmlsc($invoice->user_fax) . '</div>';
             }
             ?>
     </div>
@@ -103,15 +103,15 @@
         <table>
             <tr>
                 <td><?php echo trans('invoice_date') . ':'; ?></td>
-                <td><?php echo date_from_mysql(_htmlsc($invoice->invoice_date_created), true); ?></td>
+                <td><?php echo date_from_mysql(htmlsc($invoice->invoice_date_created), true); ?></td>
             </tr>
             <tr>
                 <td><?php echo trans('due_date') . ': '; ?></td>
-                <td><?php echo date_from_mysql(_htmlsc($invoice->invoice_date_due), true); ?></td>
+                <td><?php echo date_from_mysql(htmlsc($invoice->invoice_date_due), true); ?></td>
             </tr>
             <tr>
                 <td><?php echo trans('amount_due') . ': '; ?></td>
-                <td><?php echo format_currency(_htmlsc($invoice->invoice_balance)); ?></td>
+                <td><?php echo format_currency(htmlsc($invoice->invoice_balance)); ?></td>
             </tr>
             <?php if ($payment_method) { ?>
                 <tr>
@@ -122,7 +122,7 @@
         </table>
     </div>
 
-    <h1 class="invoice-title"><?php echo trans('invoice') . ' ' . _htmlsc($invoice->invoice_number); ?></h1>
+    <h1 class="invoice-title"><?php echo trans('invoice') . ' ' . htmlsc($invoice->invoice_number); ?></h1>
 
     <table class="item-table">
         <thead>
@@ -143,24 +143,24 @@
             foreach ($items as $item) { ?>
             <tr>
                 <td><?php _htmlsc($item->item_name); ?></td>
-                <td><?php echo nl2br(_htmlsc($item->item_description)); ?></td>
+                <td><?php echo nl2br(htmlsc($item->item_description)); ?></td>
                 <td class="text-right">
-                    <?php echo format_quantity(_htmlsc($item->item_quantity)); ?>
+                    <?php echo format_quantity(htmlsc($item->item_quantity)); ?>
                     <?php if ($item->item_product_unit) { ?>
                         <br>
                         <small><?php _htmlsc($item->item_product_unit); ?></small>
                     <?php } ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($item->item_price)); ?>
+                    <?php echo format_currency(htmlsc($item->item_price)); ?>
                 </td>
                 <?php if ($show_item_discounts) { ?>
                     <td class="text-right">
-                        <?php echo format_currency(_htmlsc($item->item_discount)); ?>
+                        <?php echo format_currency(htmlsc($item->item_discount)); ?>
                     </td>
                 <?php } ?>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($item->item_total)); ?>
+                    <?php echo format_currency(htmlsc($item->item_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -172,7 +172,7 @@
             <td <?php echo $show_item_discounts ? 'colspan="5"' : 'colspan="4"'; ?> class="text-right">
                 <?php _trans('subtotal'); ?>
             </td>
-            <td class="text-right"><?php echo format_currency(_htmlsc($invoice->invoice_item_subtotal)); ?></td>
+            <td class="text-right"><?php echo format_currency(htmlsc($invoice->invoice_item_subtotal)); ?></td>
         </tr>
 
         <?php if ($invoice->invoice_item_tax_total > 0) { ?>
@@ -181,7 +181,7 @@
                     <?php _trans('item_tax'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($invoice->invoice_item_tax_total)); ?>
+                    <?php echo format_currency(htmlsc($invoice->invoice_item_tax_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -189,10 +189,10 @@
         <?php foreach ($invoice_tax_rates as $invoice_tax_rate) { ?>
             <tr>
                 <td <?php echo $show_item_discounts ? 'colspan="5"' : 'colspan="4"'; ?> class="text-right">
-                    <?php echo _htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount($invoice_tax_rate->invoice_tax_rate_percent) . '%)'; ?>
+                    <?php echo htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount($invoice_tax_rate->invoice_tax_rate_percent) . '%)'; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($invoice_tax_rate->invoice_tax_rate_amount)); ?>
+                    <?php echo format_currency(htmlsc($invoice_tax_rate->invoice_tax_rate_amount)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -203,7 +203,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_amount(_htmlsc($invoice->invoice_discount_percent)); ?>%
+                    <?php echo format_amount(htmlsc($invoice->invoice_discount_percent)); ?>%
                 </td>
             </tr>
         <?php } ?>
@@ -213,7 +213,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($invoice->invoice_discount_amount)); ?>
+                    <?php echo format_currency(htmlsc($invoice->invoice_discount_amount)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -223,7 +223,7 @@
                 <b><?php _trans('total'); ?></b>
             </td>
             <td class="text-right">
-                <b><?php echo format_currency(_htmlsc($invoice->invoice_total)); ?></b>
+                <b><?php echo format_currency(htmlsc($invoice->invoice_total)); ?></b>
             </td>
         </tr>
         <tr>
@@ -231,7 +231,7 @@
                 <?php _trans('paid'); ?>
             </td>
             <td class="text-right">
-                <?php echo format_currency(_htmlsc($invoice->invoice_paid)); ?>
+                <?php echo format_currency(htmlsc($invoice->invoice_paid)); ?>
             </td>
         </tr>
         <tr>
@@ -239,7 +239,7 @@
                 <b><?php _trans('balance'); ?></b>
             </td>
             <td class="text-right">
-                <b><?php echo format_currency(_htmlsc($invoice->invoice_balance)); ?></b>
+                <b><?php echo format_currency(htmlsc($invoice->invoice_balance)); ?></b>
             </td>
         </tr>
         </tbody>
@@ -268,7 +268,7 @@
                 </div>
             </td>
             <td class="text-right">
-                <?php echo invoice_qrcode(_htmlsc($invoice->invoice_id)); ?>
+                <?php echo invoice_qrcode(htmlsc($invoice->invoice_id)); ?>
             </td>
         </tr>
     </table>
@@ -278,7 +278,7 @@
     <?php if ($invoice->invoice_terms) { ?>
         <div class="notes">
             <b><?php _trans('terms'); ?></b><br/>
-            <?php echo nl2br(_htmlsc($invoice->invoice_terms)); ?>
+            <?php echo nl2br(htmlsc($invoice->invoice_terms)); ?>
         </div>
     <?php } ?>
 </footer>

--- a/application/views/invoice_templates/pdf/InvoicePlane.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane.php
@@ -19,81 +19,80 @@
             <b><?php _htmlsc(format_client($invoice)); ?></b>
         </div>
         <?php if ($invoice->client_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . $invoice->client_vat_id . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($invoice->client_vat_id) . '</div>';
         }
         if ($invoice->client_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . $invoice->client_tax_code . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($invoice->client_tax_code) . '</div>';
         }
         if ($invoice->client_address_1) {
-            echo '<div>' . htmlsc($invoice->client_address_1) . '</div>';
+            echo '<div>' . _htmlsc($invoice->client_address_1) . '</div>';
         }
         if ($invoice->client_address_2) {
-            echo '<div>' . htmlsc($invoice->client_address_2) . '</div>';
+            echo '<div>' . _htmlsc($invoice->client_address_2) . '</div>';
         }
         if ($invoice->client_city || $invoice->client_state || $invoice->client_zip) {
             echo '<div>';
             if ($invoice->client_city) {
-                echo htmlsc($invoice->client_city) . ' ';
+                echo _htmlsc($invoice->client_city) . ' ';
             }
             if ($invoice->client_state) {
-                echo htmlsc($invoice->client_state) . ' ';
+                echo _htmlsc($invoice->client_state) . ' ';
             }
             if ($invoice->client_zip) {
-                echo htmlsc($invoice->client_zip);
+                echo _htmlsc($invoice->client_zip);
             }
             echo '</div>';
         }
         if ($invoice->client_country) {
-            echo '<div>' . get_country_name(trans('cldr'), $invoice->client_country) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($invoice->client_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($invoice->client_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($invoice->client_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($invoice->client_phone) . '</div>';
         } ?>
-
     </div>
     <div id="company">
         <div><b><?php _htmlsc($invoice->user_name); ?></b></div>
         <?php if ($invoice->user_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . $invoice->user_vat_id . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($invoice->user_vat_id) . '</div>';
         }
-        if ($invoice->user_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . $invoice->user_tax_code . '</div>';
-        }
-        if ($invoice->user_address_1) {
-            echo '<div>' . htmlsc($invoice->user_address_1) . '</div>';
-        }
-        if ($invoice->user_address_2) {
-            echo '<div>' . htmlsc($invoice->user_address_2) . '</div>';
-        }
-        if ($invoice->user_city || $invoice->user_state || $invoice->user_zip) {
-            echo '<div>';
-            if ($invoice->user_city) {
-                echo htmlsc($invoice->user_city) . ' ';
+            if ($invoice->user_tax_code) {
+                echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($invoice->user_tax_code) . '</div>';
             }
-            if ($invoice->user_state) {
-                echo htmlsc($invoice->user_state) . ' ';
+            if ($invoice->user_address_1) {
+                echo '<div>' . _htmlsc($invoice->user_address_1) . '</div>';
             }
-            if ($invoice->user_zip) {
-                echo htmlsc($invoice->user_zip);
+            if ($invoice->user_address_2) {
+                echo '<div>' . _htmlsc($invoice->user_address_2) . '</div>';
             }
-            echo '</div>';
-        }
-        if ($invoice->user_country) {
-            echo '<div>' . get_country_name(trans('cldr'), $invoice->user_country) . '</div>';
-        }
+            if ($invoice->user_city || $invoice->user_state || $invoice->user_zip) {
+                echo '<div>';
+                if ($invoice->user_city) {
+                    echo _htmlsc($invoice->user_city) . ' ';
+                }
+                if ($invoice->user_state) {
+                    echo _htmlsc($invoice->user_state) . ' ';
+                }
+                if ($invoice->user_zip) {
+                    echo _htmlsc($invoice->user_zip);
+                }
+                echo '</div>';
+            }
+            if ($invoice->user_country) {
+                echo '<div>' . get_country_name(trans('cldr'), _htmlsc($invoice->user_country)) . '</div>';
+            }
 
-        echo '<br/>';
+            echo '<br/>';
 
-        if ($invoice->user_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($invoice->user_phone) . '</div>';
-        }
-        if ($invoice->user_fax) {
-            echo '<div>' . trans('fax_abbr') . ': ' . htmlsc($invoice->user_fax) . '</div>';
-        }
-        ?>
+            if ($invoice->user_phone) {
+                echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($invoice->user_phone) . '</div>';
+            }
+            if ($invoice->user_fax) {
+                echo '<div>' . trans('fax_abbr') . ': ' . _htmlsc($invoice->user_fax) . '</div>';
+            }
+            ?>
     </div>
 
 </header>
@@ -104,26 +103,26 @@
         <table>
             <tr>
                 <td><?php echo trans('invoice_date') . ':'; ?></td>
-                <td><?php echo date_from_mysql($invoice->invoice_date_created, true); ?></td>
+                <td><?php echo date_from_mysql(_htmlsc($invoice->invoice_date_created), true); ?></td>
             </tr>
             <tr>
                 <td><?php echo trans('due_date') . ': '; ?></td>
-                <td><?php echo date_from_mysql($invoice->invoice_date_due, true); ?></td>
+                <td><?php echo date_from_mysql(_htmlsc($invoice->invoice_date_due), true); ?></td>
             </tr>
             <tr>
                 <td><?php echo trans('amount_due') . ': '; ?></td>
-                <td><?php echo format_currency($invoice->invoice_balance); ?></td>
+                <td><?php echo format_currency(_htmlsc($invoice->invoice_balance)); ?></td>
             </tr>
-            <?php if ($payment_method): ?>
+            <?php if ($payment_method) { ?>
                 <tr>
                     <td><?php echo trans('payment_method') . ': '; ?></td>
                     <td><?php _htmlsc($payment_method->payment_method_name); ?></td>
                 </tr>
-            <?php endif; ?>
+            <?php } ?>
         </table>
     </div>
 
-    <h1 class="invoice-title"><?php echo trans('invoice') . ' ' . $invoice->invoice_number; ?></h1>
+    <h1 class="invoice-title"><?php echo trans('invoice') . ' ' . _htmlsc($invoice->invoice_number); ?></h1>
 
     <table class="item-table">
         <thead>
@@ -132,36 +131,36 @@
             <th class="item-desc"><?php _trans('description'); ?></th>
             <th class="item-amount text-right"><?php _trans('qty'); ?></th>
             <th class="item-price text-right"><?php _trans('price'); ?></th>
-            <?php if ($show_item_discounts) : ?>
+            <?php if ($show_item_discounts) { ?>
                 <th class="item-discount text-right"><?php _trans('discount'); ?></th>
-            <?php endif; ?>
+            <?php } ?>
             <th class="item-total text-right"><?php _trans('total'); ?></th>
         </tr>
         </thead>
         <tbody>
 
         <?php
-        foreach ($items as $item) { ?>
+            foreach ($items as $item) { ?>
             <tr>
                 <td><?php _htmlsc($item->item_name); ?></td>
-                <td><?php echo nl2br(htmlsc($item->item_description)); ?></td>
+                <td><?php echo nl2br(_htmlsc($item->item_description)); ?></td>
                 <td class="text-right">
-                    <?php echo format_quantity($item->item_quantity); ?>
-                    <?php if ($item->item_product_unit) : ?>
+                    <?php echo format_quantity(_htmlsc($item->item_quantity)); ?>
+                    <?php if ($item->item_product_unit) { ?>
                         <br>
                         <small><?php _htmlsc($item->item_product_unit); ?></small>
-                    <?php endif; ?>
+                    <?php } ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($item->item_price); ?>
+                    <?php echo format_currency(_htmlsc($item->item_price)); ?>
                 </td>
-                <?php if ($show_item_discounts) : ?>
+                <?php if ($show_item_discounts) { ?>
                     <td class="text-right">
-                        <?php echo format_currency($item->item_discount); ?>
+                        <?php echo format_currency(_htmlsc($item->item_discount)); ?>
                     </td>
-                <?php endif; ?>
+                <?php } ?>
                 <td class="text-right">
-                    <?php echo format_currency($item->item_total); ?>
+                    <?php echo format_currency(_htmlsc($item->item_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -170,84 +169,84 @@
         <tbody class="invoice-sums">
 
         <tr>
-            <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
+            <td <?php echo $show_item_discounts ? 'colspan="5"' : 'colspan="4"'; ?> class="text-right">
                 <?php _trans('subtotal'); ?>
             </td>
-            <td class="text-right"><?php echo format_currency($invoice->invoice_item_subtotal); ?></td>
+            <td class="text-right"><?php echo format_currency(_htmlsc($invoice->invoice_item_subtotal)); ?></td>
         </tr>
 
         <?php if ($invoice->invoice_item_tax_total > 0) { ?>
             <tr>
-                <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
+                <td <?php echo $show_item_discounts ? 'colspan="5"' : 'colspan="4"'; ?> class="text-right">
                     <?php _trans('item_tax'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($invoice->invoice_item_tax_total); ?>
+                    <?php echo format_currency(_htmlsc($invoice->invoice_item_tax_total)); ?>
                 </td>
             </tr>
         <?php } ?>
 
-        <?php foreach ($invoice_tax_rates as $invoice_tax_rate) : ?>
+        <?php foreach ($invoice_tax_rates as $invoice_tax_rate) { ?>
             <tr>
-                <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
-                    <?php echo htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount($invoice_tax_rate->invoice_tax_rate_percent) . '%)'; ?>
+                <td <?php echo $show_item_discounts ? 'colspan="5"' : 'colspan="4"'; ?> class="text-right">
+                    <?php echo _htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount($invoice_tax_rate->invoice_tax_rate_percent) . '%)'; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($invoice_tax_rate->invoice_tax_rate_amount); ?>
+                    <?php echo format_currency(_htmlsc($invoice_tax_rate->invoice_tax_rate_amount)); ?>
                 </td>
             </tr>
-        <?php endforeach ?>
+        <?php } ?>
 
-        <?php if ($invoice->invoice_discount_percent != '0.00') : ?>
+        <?php if ($invoice->invoice_discount_percent != '0.00') { ?>
             <tr>
-                <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
+                <td <?php echo $show_item_discounts ? 'colspan="5"' : 'colspan="4"'; ?> class="text-right">
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_amount($invoice->invoice_discount_percent); ?>%
+                    <?php echo format_amount(_htmlsc($invoice->invoice_discount_percent)); ?>%
                 </td>
             </tr>
-        <?php endif; ?>
-        <?php if ($invoice->invoice_discount_amount != '0.00') : ?>
+        <?php } ?>
+        <?php if ($invoice->invoice_discount_amount != '0.00') { ?>
             <tr>
-                <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
+                <td <?php echo $show_item_discounts ? 'colspan="5"' : 'colspan="4"'; ?> class="text-right">
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($invoice->invoice_discount_amount); ?>
+                    <?php echo format_currency(_htmlsc($invoice->invoice_discount_amount)); ?>
                 </td>
             </tr>
-        <?php endif; ?>
+        <?php } ?>
 
         <tr>
-            <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
+            <td <?php echo $show_item_discounts ? 'colspan="5"' : 'colspan="4"'; ?> class="text-right">
                 <b><?php _trans('total'); ?></b>
             </td>
             <td class="text-right">
-                <b><?php echo format_currency($invoice->invoice_total); ?></b>
+                <b><?php echo format_currency(_htmlsc($invoice->invoice_total)); ?></b>
             </td>
         </tr>
         <tr>
-            <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
+            <td <?php echo $show_item_discounts ? 'colspan="5"' : 'colspan="4"'; ?> class="text-right">
                 <?php _trans('paid'); ?>
             </td>
             <td class="text-right">
-                <?php echo format_currency($invoice->invoice_paid); ?>
+                <?php echo format_currency(_htmlsc($invoice->invoice_paid)); ?>
             </td>
         </tr>
         <tr>
-            <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
+            <td <?php echo $show_item_discounts ? 'colspan="5"' : 'colspan="4"'; ?> class="text-right">
                 <b><?php _trans('balance'); ?></b>
             </td>
             <td class="text-right">
-                <b><?php echo format_currency($invoice->invoice_balance); ?></b>
+                <b><?php echo format_currency(_htmlsc($invoice->invoice_balance)); ?></b>
             </td>
         </tr>
         </tbody>
     </table>
 </main>
 
-<?php if (get_setting('qr_code')) : ?>
+<?php if (get_setting('qr_code')) { ?>
     <table class="invoice-qr-code-table">
         <tr>
             <td>
@@ -269,19 +268,19 @@
                 </div>
             </td>
             <td class="text-right">
-                <?php echo invoice_qrcode($invoice->invoice_id); ?>
+                <?php echo invoice_qrcode(_htmlsc($invoice->invoice_id)); ?>
             </td>
         </tr>
     </table>
-<?php endif; ?>
+<?php } ?>
 
 <footer>
-    <?php if ($invoice->invoice_terms) : ?>
+    <?php if ($invoice->invoice_terms) { ?>
         <div class="notes">
             <b><?php _trans('terms'); ?></b><br/>
-            <?php echo nl2br(htmlsc($invoice->invoice_terms)); ?>
+            <?php echo nl2br(_htmlsc($invoice->invoice_terms)); ?>
         </div>
-    <?php endif; ?>
+    <?php } ?>
 </footer>
 
 </body>

--- a/application/views/quote_templates/pdf/InvoicePlane.php
+++ b/application/views/quote_templates/pdf/InvoicePlane.php
@@ -165,7 +165,7 @@
 
         <tr>
             <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?>
-                    class="text-right"><?php _trans('subtotal'); ?></td>
+                class="text-right"><?php _trans('subtotal'); ?></td>
             <td class="text-right"><?php echo format_currency(htmlsc($quote->quote_item_subtotal)); ?></td>
         </tr>
 

--- a/application/views/quote_templates/pdf/InvoicePlane.php
+++ b/application/views/quote_templates/pdf/InvoicePlane.php
@@ -19,79 +19,79 @@
             <b><?php _htmlsc($quote->client_name); ?></b>
         </div>
         <?php if ($quote->client_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($quote->client_vat_id) . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . htmlsc($quote->client_vat_id) . '</div>';
         }
         if ($quote->client_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($quote->client_tax_code) . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . htmlsc($quote->client_tax_code) . '</div>';
         }
         if ($quote->client_address_1) {
-            echo '<div>' . _htmlsc($quote->client_address_1) . '</div>';
+            echo '<div>' . htmlsc($quote->client_address_1) . '</div>';
         }
         if ($quote->client_address_2) {
-            echo '<div>' . _htmlsc($quote->client_address_2) . '</div>';
+            echo '<div>' . htmlsc($quote->client_address_2) . '</div>';
         }
         if ($quote->client_city || $quote->client_state || $quote->client_zip) {
             echo '<div>';
             if ($quote->client_city) {
-                echo _htmlsc($quote->client_city) . ' ';
+                echo htmlsc($quote->client_city) . ' ';
             }
             if ($quote->client_state) {
-                echo _htmlsc($quote->client_state) . ' ';
+                echo htmlsc($quote->client_state) . ' ';
             }
             if ($quote->client_zip) {
-                echo _htmlsc($quote->client_zip);
+                echo htmlsc($quote->client_zip);
             }
             echo '</div>';
         }
         if ($quote->client_country) {
-            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($quote->client_country)) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), htmlsc($quote->client_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($quote->client_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($quote->client_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($quote->client_phone) . '</div>';
         } ?>
 
     </div>
     <div id="company">
         <div><b><?php _htmlsc($quote->user_name); ?></b></div>
         <?php if ($quote->user_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($quote->user_vat_id) . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . htmlsc($quote->user_vat_id) . '</div>';
         }
         if ($quote->user_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($quote->user_tax_code) . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . htmlsc($quote->user_tax_code) . '</div>';
         }
         if ($quote->user_address_1) {
-            echo '<div>' . _htmlsc($quote->user_address_1) . '</div>';
+            echo '<div>' . htmlsc($quote->user_address_1) . '</div>';
         }
         if ($quote->user_address_2) {
-            echo '<div>' . _htmlsc($quote->user_address_2) . '</div>';
+            echo '<div>' . htmlsc($quote->user_address_2) . '</div>';
         }
         if ($quote->user_city || $quote->user_state || $quote->user_zip) {
             echo '<div>';
             if ($quote->user_city) {
-                echo _htmlsc($quote->user_city) . ' ';
+                echo htmlsc($quote->user_city) . ' ';
             }
             if ($quote->user_state) {
-                echo _htmlsc($quote->user_state) . ' ';
+                echo htmlsc($quote->user_state) . ' ';
             }
             if ($quote->user_zip) {
-                echo _htmlsc($quote->user_zip);
+                echo htmlsc($quote->user_zip);
             }
             echo '</div>';
         }
         if ($quote->user_country) {
-            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($quote->user_country)) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), htmlsc($quote->user_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($quote->user_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($quote->user_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($quote->user_phone) . '</div>';
         }
         if ($quote->user_fax) {
-            echo '<div>' . trans('fax_abbr') . ': ' . _htmlsc($quote->user_fax) . '</div>';
+            echo '<div>' . trans('fax_abbr') . ': ' . htmlsc($quote->user_fax) . '</div>';
         }
         ?>
     </div>
@@ -104,20 +104,20 @@
         <table>
             <tr>
                 <td><?php echo trans('quote_date') . ':'; ?></td>
-                <td><?php echo date_from_mysql(_htmlsc($quote->quote_date_created), true); ?></td>
+                <td><?php echo date_from_mysql(htmlsc($quote->quote_date_created), true); ?></td>
             </tr>
             <tr>
                 <td><?php echo trans('expires') . ': '; ?></td>
-                <td><?php echo date_from_mysql(_htmlsc($quote->quote_date_expires), true); ?></td>
+                <td><?php echo date_from_mysql(htmlsc($quote->quote_date_expires), true); ?></td>
             </tr>
             <tr>
                 <td><?php echo trans('total') . ': '; ?></td>
-                <td><?php echo format_currency(_htmlsc($quote->quote_total)); ?></td>
+                <td><?php echo format_currency(htmlsc($quote->quote_total)); ?></td>
             </tr>
         </table>
     </div>
 
-    <h1 class="invoice-title"><?php echo trans('quote') . ' ' . _htmlsc($quote->quote_number); ?></h1>
+    <h1 class="invoice-title"><?php echo trans('quote') . ' ' . htmlsc($quote->quote_number); ?></h1>
 
     <table class="item-table">
         <thead>
@@ -138,24 +138,24 @@
         foreach ($items as $item) { ?>
             <tr>
                 <td><?php _htmlsc($item->item_name); ?></td>
-                <td><?php echo nl2br(_htmlsc($item->item_description)); ?></td>
+                <td><?php echo nl2br(htmlsc($item->item_description)); ?></td>
                 <td class="text-right">
-                    <?php echo format_quantity(_htmlsc($item->item_quantity)); ?>
+                    <?php echo format_quantity(htmlsc($item->item_quantity)); ?>
                     <?php if ($item->item_product_unit) : ?>
                         <br>
                         <small><?php _htmlsc($item->item_product_unit); ?></small>
                     <?php endif; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($item->item_price)); ?>
+                    <?php echo format_currency(htmlsc($item->item_price)); ?>
                 </td>
                 <?php if ($show_item_discounts) : ?>
                     <td class="text-right">
-                        <?php echo format_currency(_htmlsc($item->item_discount)); ?>
+                        <?php echo format_currency(htmlsc($item->item_discount)); ?>
                     </td>
                 <?php endif; ?>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($item->item_total)); ?>
+                    <?php echo format_currency(htmlsc($item->item_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -166,7 +166,7 @@
         <tr>
             <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?>
                     class="text-right"><?php _trans('subtotal'); ?></td>
-            <td class="text-right"><?php echo format_currency(_htmlsc($quote->quote_item_subtotal)); ?></td>
+            <td class="text-right"><?php echo format_currency(htmlsc($quote->quote_item_subtotal)); ?></td>
         </tr>
 
         <?php if ($quote->quote_item_tax_total > 0) { ?>
@@ -175,7 +175,7 @@
                     <?php _trans('item_tax'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($quote->quote_item_tax_total)); ?>
+                    <?php echo format_currency(htmlsc($quote->quote_item_tax_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -183,10 +183,10 @@
         <?php foreach ($quote_tax_rates as $quote_tax_rate) : ?>
             <tr>
                 <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
-                    <?php echo $quote_tax_rate->quote_tax_rate_name . ' (' . format_amount(_htmlsc($quote_tax_rate->quote_tax_rate_percent)) . '%)'; ?>
+                    <?php echo $quote_tax_rate->quote_tax_rate_name . ' (' . format_amount(htmlsc($quote_tax_rate->quote_tax_rate_percent)) . '%)'; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($quote_tax_rate->quote_tax_rate_amount)); ?>
+                    <?php echo format_currency(htmlsc($quote_tax_rate->quote_tax_rate_amount)); ?>
                 </td>
             </tr>
         <?php endforeach ?>
@@ -197,7 +197,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_amount(_htmlsc($quote->quote_discount_percent)); ?>%
+                    <?php echo format_amount(htmlsc($quote->quote_discount_percent)); ?>%
                 </td>
             </tr>
         <?php endif; ?>
@@ -207,7 +207,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency(_htmlsc($quote->quote_discount_amount)); ?>
+                    <?php echo format_currency(htmlsc($quote->quote_discount_amount)); ?>
                 </td>
             </tr>
         <?php endif; ?>
@@ -217,7 +217,7 @@
                 <b><?php _trans('total'); ?></b>
             </td>
             <td class="text-right">
-                <b><?php echo format_currency(_htmlsc($quote->quote_total)); ?></b>
+                <b><?php echo format_currency(htmlsc($quote->quote_total)); ?></b>
             </td>
         </tr>
         </tbody>
@@ -228,7 +228,7 @@
     <?php if ($quote->notes) : ?>
         <div class="notes">
             <b><?php _trans('notes'); ?></b><br/>
-            <?php echo nl2br(_htmlsc($quote->notes)); ?>
+            <?php echo nl2br(htmlsc($quote->notes)); ?>
         </div>
     <?php endif; ?>
 </footer>

--- a/application/views/quote_templates/pdf/InvoicePlane.php
+++ b/application/views/quote_templates/pdf/InvoicePlane.php
@@ -19,79 +19,79 @@
             <b><?php _htmlsc($quote->client_name); ?></b>
         </div>
         <?php if ($quote->client_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . $quote->client_vat_id . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($quote->client_vat_id) . '</div>';
         }
         if ($quote->client_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . $quote->client_tax_code . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($quote->client_tax_code) . '</div>';
         }
         if ($quote->client_address_1) {
-            echo '<div>' . htmlsc($quote->client_address_1) . '</div>';
+            echo '<div>' . _htmlsc($quote->client_address_1) . '</div>';
         }
         if ($quote->client_address_2) {
-            echo '<div>' . htmlsc($quote->client_address_2) . '</div>';
+            echo '<div>' . _htmlsc($quote->client_address_2) . '</div>';
         }
         if ($quote->client_city || $quote->client_state || $quote->client_zip) {
             echo '<div>';
             if ($quote->client_city) {
-                echo htmlsc($quote->client_city) . ' ';
+                echo _htmlsc($quote->client_city) . ' ';
             }
             if ($quote->client_state) {
-                echo htmlsc($quote->client_state) . ' ';
+                echo _htmlsc($quote->client_state) . ' ';
             }
             if ($quote->client_zip) {
-                echo htmlsc($quote->client_zip);
+                echo _htmlsc($quote->client_zip);
             }
             echo '</div>';
         }
         if ($quote->client_country) {
-            echo '<div>' . get_country_name(trans('cldr'), $quote->client_country) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($quote->client_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($quote->client_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($quote->client_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($quote->client_phone) . '</div>';
         } ?>
 
     </div>
     <div id="company">
         <div><b><?php _htmlsc($quote->user_name); ?></b></div>
         <?php if ($quote->user_vat_id) {
-            echo '<div>' . trans('vat_id_short') . ': ' . $quote->user_vat_id . '</div>';
+            echo '<div>' . trans('vat_id_short') . ': ' . _htmlsc($quote->user_vat_id) . '</div>';
         }
         if ($quote->user_tax_code) {
-            echo '<div>' . trans('tax_code_short') . ': ' . $quote->user_tax_code . '</div>';
+            echo '<div>' . trans('tax_code_short') . ': ' . _htmlsc($quote->user_tax_code) . '</div>';
         }
         if ($quote->user_address_1) {
-            echo '<div>' . htmlsc($quote->user_address_1) . '</div>';
+            echo '<div>' . _htmlsc($quote->user_address_1) . '</div>';
         }
         if ($quote->user_address_2) {
-            echo '<div>' . htmlsc($quote->user_address_2) . '</div>';
+            echo '<div>' . _htmlsc($quote->user_address_2) . '</div>';
         }
         if ($quote->user_city || $quote->user_state || $quote->user_zip) {
             echo '<div>';
             if ($quote->user_city) {
-                echo htmlsc($quote->user_city) . ' ';
+                echo _htmlsc($quote->user_city) . ' ';
             }
             if ($quote->user_state) {
-                echo htmlsc($quote->user_state) . ' ';
+                echo _htmlsc($quote->user_state) . ' ';
             }
             if ($quote->user_zip) {
-                echo htmlsc($quote->user_zip);
+                echo _htmlsc($quote->user_zip);
             }
             echo '</div>';
         }
         if ($quote->user_country) {
-            echo '<div>' . get_country_name(trans('cldr'), $quote->user_country) . '</div>';
+            echo '<div>' . get_country_name(trans('cldr'), _htmlsc($quote->user_country)) . '</div>';
         }
 
         echo '<br/>';
 
         if ($quote->user_phone) {
-            echo '<div>' . trans('phone_abbr') . ': ' . htmlsc($quote->user_phone) . '</div>';
+            echo '<div>' . trans('phone_abbr') . ': ' . _htmlsc($quote->user_phone) . '</div>';
         }
         if ($quote->user_fax) {
-            echo '<div>' . trans('fax_abbr') . ': ' . htmlsc($quote->user_fax) . '</div>';
+            echo '<div>' . trans('fax_abbr') . ': ' . _htmlsc($quote->user_fax) . '</div>';
         }
         ?>
     </div>
@@ -104,20 +104,20 @@
         <table>
             <tr>
                 <td><?php echo trans('quote_date') . ':'; ?></td>
-                <td><?php echo date_from_mysql($quote->quote_date_created, true); ?></td>
+                <td><?php echo date_from_mysql(_htmlsc($quote->quote_date_created), true); ?></td>
             </tr>
             <tr>
                 <td><?php echo trans('expires') . ': '; ?></td>
-                <td><?php echo date_from_mysql($quote->quote_date_expires, true); ?></td>
+                <td><?php echo date_from_mysql(_htmlsc($quote->quote_date_expires), true); ?></td>
             </tr>
             <tr>
                 <td><?php echo trans('total') . ': '; ?></td>
-                <td><?php echo format_currency($quote->quote_total); ?></td>
+                <td><?php echo format_currency(_htmlsc($quote->quote_total)); ?></td>
             </tr>
         </table>
     </div>
 
-    <h1 class="invoice-title"><?php echo trans('quote') . ' ' . $quote->quote_number; ?></h1>
+    <h1 class="invoice-title"><?php echo trans('quote') . ' ' . _htmlsc($quote->quote_number); ?></h1>
 
     <table class="item-table">
         <thead>
@@ -138,24 +138,24 @@
         foreach ($items as $item) { ?>
             <tr>
                 <td><?php _htmlsc($item->item_name); ?></td>
-                <td><?php echo nl2br(htmlsc($item->item_description)); ?></td>
+                <td><?php echo nl2br(_htmlsc($item->item_description)); ?></td>
                 <td class="text-right">
-                    <?php echo format_quantity($item->item_quantity); ?>
+                    <?php echo format_quantity(_htmlsc($item->item_quantity)); ?>
                     <?php if ($item->item_product_unit) : ?>
                         <br>
                         <small><?php _htmlsc($item->item_product_unit); ?></small>
                     <?php endif; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($item->item_price); ?>
+                    <?php echo format_currency(_htmlsc($item->item_price)); ?>
                 </td>
                 <?php if ($show_item_discounts) : ?>
                     <td class="text-right">
-                        <?php echo format_currency($item->item_discount); ?>
+                        <?php echo format_currency(_htmlsc($item->item_discount)); ?>
                     </td>
                 <?php endif; ?>
                 <td class="text-right">
-                    <?php echo format_currency($item->item_total); ?>
+                    <?php echo format_currency(_htmlsc($item->item_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -166,7 +166,7 @@
         <tr>
             <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?>
                     class="text-right"><?php _trans('subtotal'); ?></td>
-            <td class="text-right"><?php echo format_currency($quote->quote_item_subtotal); ?></td>
+            <td class="text-right"><?php echo format_currency(_htmlsc($quote->quote_item_subtotal)); ?></td>
         </tr>
 
         <?php if ($quote->quote_item_tax_total > 0) { ?>
@@ -175,7 +175,7 @@
                     <?php _trans('item_tax'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($quote->quote_item_tax_total); ?>
+                    <?php echo format_currency(_htmlsc($quote->quote_item_tax_total)); ?>
                 </td>
             </tr>
         <?php } ?>
@@ -183,10 +183,10 @@
         <?php foreach ($quote_tax_rates as $quote_tax_rate) : ?>
             <tr>
                 <td <?php echo($show_item_discounts ? 'colspan="5"' : 'colspan="4"'); ?> class="text-right">
-                    <?php echo $quote_tax_rate->quote_tax_rate_name . ' (' . format_amount($quote_tax_rate->quote_tax_rate_percent) . '%)'; ?>
+                    <?php echo $quote_tax_rate->quote_tax_rate_name . ' (' . format_amount(_htmlsc($quote_tax_rate->quote_tax_rate_percent)) . '%)'; ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($quote_tax_rate->quote_tax_rate_amount); ?>
+                    <?php echo format_currency(_htmlsc($quote_tax_rate->quote_tax_rate_amount)); ?>
                 </td>
             </tr>
         <?php endforeach ?>
@@ -197,7 +197,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_amount($quote->quote_discount_percent); ?>%
+                    <?php echo format_amount(_htmlsc($quote->quote_discount_percent)); ?>%
                 </td>
             </tr>
         <?php endif; ?>
@@ -207,7 +207,7 @@
                     <?php _trans('discount'); ?>
                 </td>
                 <td class="text-right">
-                    <?php echo format_currency($quote->quote_discount_amount); ?>
+                    <?php echo format_currency(_htmlsc($quote->quote_discount_amount)); ?>
                 </td>
             </tr>
         <?php endif; ?>
@@ -217,19 +217,18 @@
                 <b><?php _trans('total'); ?></b>
             </td>
             <td class="text-right">
-                <b><?php echo format_currency($quote->quote_total); ?></b>
+                <b><?php echo format_currency(_htmlsc($quote->quote_total)); ?></b>
             </td>
         </tr>
         </tbody>
     </table>
-
 </main>
 
 <footer>
     <?php if ($quote->notes) : ?>
         <div class="notes">
             <b><?php _trans('notes'); ?></b><br/>
-            <?php echo nl2br(htmlsc($quote->notes)); ?>
+            <?php echo nl2br(_htmlsc($quote->notes)); ?>
         </div>
     <?php endif; ?>
 </footer>


### PR DESCRIPTION
Making sure all the fields in the templates are escaped by htmlspecialchars

## Description
To make sure we don't get unintended output in our PDF files, we're surrounding every output by the `_htmlsc()` function, which is basically htmlspecialchars

## Related Issue
To be determined

## Motivation and Context
Just something that needed to be done

## Screenshots (if appropriate):

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
