### PR TITLE
Update QrCode.php wrong variable

### DIFF
--- a/application/libraries/QrCode.php
+++ b/application/libraries/QrCode.php
@@ -40,7 +40,7 @@ class QrCode {
       ->setBic($this->bic)
       ->setCurrency($this->currencyCode)
       ->setRemittanceText($this->remittance_text)
-      ->setAmount($this->invoice->invoice_total);
+      ->setAmount($this->invoice->invoice_balance);
 
     return $paymentData;
   }


### PR DESCRIPTION
## Description
When an invoice is paid in part. The QR code always displays the total paid, not what remains to be paid.
<!--
You can check items by changing `[ ]` to `[x]`.
If you can't check all checklist items please add `[WIP]` in front of your title.
Remove this first paragraph but please keep the following checklist even if it's incomplete.
-->

## Related Issue
#1128

## Motivation and Context
Avoid paying my customer twice for an amount that is already half paid.

As for the branch. I'm having a bit of trouble understanding the variety of branches that InvoicePlane currently has. I didn't check the last two checklists because of this.

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request.
  * [ ] I selected the corresponding branch.
  * [ ] I have rebased my changes on top of the corresponding branch.

## Issue Type

  * [x] Bugfix?
  * [x] Improvement of an existing Feature
  * [ ] New Feature
