### PR TITLE
Add buttons on client view to delete note (Ajax)

### DIFF
--- a/application/modules/clients/controllers/Ajax.php
+++ b/application/modules/clients/controllers/Ajax.php
@@ -101,6 +101,37 @@ class Ajax extends Admin_Controller
         $this->mdl_settings->save('enable_permissive_search_clients', $permissiveSearchClients);
     }
 
+    /**
+     * Delete client note id
+     */
+    public function delete_client_note()
+    {
+        $success = 0;
+        $client_note_id = $this->input->post('client_note_id');
+        $this->load->model('mdl_client_notes');
+
+        // Only continue if the note exists or no item id was provided
+        if ($this->mdl_client_notes->get_by_id($client_note_id) || empty($client_note_id)) {
+
+            // Delete invoice item
+            $this->load->model('mdl_client_notes');
+            $item = $this->mdl_client_notes->delete($client_note_id);
+
+            // Check if deletion was successful
+            if ($item) {
+                $success = 1;
+            }
+
+        }
+
+        // Return the response
+        echo json_encode([
+            'success' => $success,
+        ]);
+    }
+
+
+
     public function save_client_note()
     {
         $this->load->model('clients/mdl_client_notes');

--- a/application/modules/clients/models/Mdl_client_notes.php
+++ b/application/modules/clients/models/Mdl_client_notes.php
@@ -48,4 +48,15 @@ class Mdl_Client_Notes extends Response_Model
 
         return $db_array;
     }
+
+    /**
+     * @param int $id
+     */
+    public function delete($id)
+    {
+        parent::delete($id);
+        // For Ajax Check if deletion was successful
+        return true;
+    }
+
 }

--- a/application/modules/clients/views/partial_notes.php
+++ b/application/modules/clients/views/partial_notes.php
@@ -5,6 +5,9 @@
         </div>
         <div class="panel-footer text-muted">
             <?php echo date_from_mysql($client_note->client_note_date, true); ?>
+            <span data-id="<?php echo $client_note->client_note_id; ?>" class="delete_client_note pull-right btn btn-xs btn-danger">
+                <i class="fa fa-trash-o"></i> <?php _trans('delete'); ?>
+            </span>
         </div>
     </div>
 <?php endforeach; ?>

--- a/application/modules/clients/views/view.php
+++ b/application/modules/clients/views/view.php
@@ -9,7 +9,7 @@
                     var response = JSON.parse(data);
                     if (response.success === 1) {
                         // The validation was successful
-                        $('.control-group').removeClass('error');
+                        $('.has-error').removeClass('has-error');
                         $('#client_note').val('');
 
                         // Reload all notes
@@ -24,7 +24,7 @@
                     } else {
                         // The validation was not successful
                         $('.fullpage-loader-close').click();
-                        $('.control-group').removeClass('error');
+                        $('.has-error').removeClass('has-error');
                         for (var key in response.validation_errors) {
                             $('#' + key).parent().addClass('has-error');
                         }
@@ -48,7 +48,7 @@
                     var response = JSON.parse(data);
                     if (response.success === 1) {
                         // The validation was successful
-                        $('.control-group').removeClass('error');
+                        $('.has-error').removeClass('has-error');
                         $('#client_note').val('');
 
                         // Reload all notes
@@ -62,7 +62,7 @@
                             });
                     } else {
                         // The validation was not successful
-                        $('.control-group').removeClass('error');
+                        $('.has-error').removeClass('has-error');
                         for (var key in response.validation_errors) {
                             $('#' + key).parent().addClass('has-error');
                         }

--- a/application/modules/clients/views/view.php
+++ b/application/modules/clients/views/view.php
@@ -1,74 +1,57 @@
 <script>
     $(function () {
+        const client_id = <?php echo $client->client_id; ?>;
+        function add_delete_client_notes_click_event(){
+            $('.delete_client_note').click(delete_client_note);
+        }
+        function reload_client_notes(data){
+            <?php echo IP_DEBUG ? 'console.log(data);' : ''; ?>
+            var response = JSON.parse(data);
+            if (response.success === 1) {
+                // The validation was successful
+                $('.has-error').removeClass('has-error');
+                $('#client_note').val('');
+
+                // Reload all notes
+                $('#notes_list').load("<?php echo site_url('clients/ajax/load_client_notes'); ?>",
+                    {
+                        client_id: client_id
+                    }, function (response) {
+                        <?php echo IP_DEBUG ? 'console.log(response);' : ''; ?>
+
+                        setTimeout(add_delete_client_notes_click_event, 161);
+                    });
+            } else {
+                // The validation was not successful
+                $('.has-error').removeClass('has-error');
+                for (var key in response.validation_errors) {
+                    $('#' + key).parent().addClass('has-error');
+                }
+            }
+            $('#fullpage-loader').fadeOut(200);
+        }
         function delete_client_note(event) {
+            $('#fullpage-loader').fadeIn(200);
             $.post('<?php echo site_url('clients/ajax/delete_client_note'); ?>',
                 {
                     client_note_id: $(this).attr('data-id')
                 }, function (data) {
-                    <?php echo IP_DEBUG ? 'console.log(data);' : ''; ?>
-                    var response = JSON.parse(data);
-                    if (response.success === 1) {
-                        // The validation was successful
-                        $('.has-error').removeClass('has-error');
-                        $('#client_note').val('');
-
-                        // Reload all notes
-                        $('#notes_list').load("<?php echo site_url('clients/ajax/load_client_notes'); ?>",
-                            {
-                                client_id: <?php echo $client->client_id; ?>
-                            }, function (response) {
-                                <?php echo IP_DEBUG ? 'console.log(response);' : ''; ?>
-
-                                setTimeout(add_delete_client_notes_click_event, 161);
-                            });
-                    } else {
-                        // The validation was not successful
-                        $('.fullpage-loader-close').click();
-                        $('.has-error').removeClass('has-error');
-                        for (var key in response.validation_errors) {
-                            $('#' + key).parent().addClass('has-error');
-                        }
-                    }
-                });
+                    reload_client_notes(data)
+                }
+            );
         }
-
-        function add_delete_client_notes_click_event(){
-            $('.delete_client_note').click(delete_client_note);
-        }
-
-        add_delete_client_notes_click_event();
-
         $('#save_client_note').click(function () {
+            $('#fullpage-loader').fadeIn(200);
             $.post('<?php echo site_url('clients/ajax/save_client_note'); ?>',
                 {
-                    client_id: $('#client_id').val(),
+                    client_id: client_id,
                     client_note: $('#client_note').val()
                 }, function (data) {
-                    <?php echo IP_DEBUG ? 'console.log(data);' : ''; ?>
-                    var response = JSON.parse(data);
-                    if (response.success === 1) {
-                        // The validation was successful
-                        $('.has-error').removeClass('has-error');
-                        $('#client_note').val('');
-
-                        // Reload all notes
-                        $('#notes_list').load("<?php echo site_url('clients/ajax/load_client_notes'); ?>",
-                            {
-                                client_id: <?php echo $client->client_id; ?>
-                            }, function (response) {
-                                <?php echo IP_DEBUG ? 'console.log(response);' : ''; ?>
-
-                                setTimeout(add_delete_client_notes_click_event, 161);
-                            });
-                    } else {
-                        // The validation was not successful
-                        $('.has-error').removeClass('has-error');
-                        for (var key in response.validation_errors) {
-                            $('#' + key).parent().addClass('has-error');
-                        }
-                    }
-                });
+                    reload_client_notes(data)
+                }
+            );
         });
+        add_delete_client_notes_click_event();
     });
 </script>
 
@@ -385,8 +368,6 @@ $locations = [];
                             <div id="notes_list">
                                 <?php echo $partial_notes; ?>
                             </div>
-                            <input type="hidden" name="client_id" id="client_id"
-                                   value="<?php echo $client->client_id; ?>">
                             <div class="input-group">
                                 <textarea id="client_note" class="form-control" rows="2" style="resize:none"></textarea>
                                 <span id="save_client_note" class="input-group-addon btn btn-default">

--- a/application/modules/clients/views/view.php
+++ b/application/modules/clients/views/view.php
@@ -1,5 +1,43 @@
 <script>
     $(function () {
+        function delete_client_note(event) {
+            $.post('<?php echo site_url('clients/ajax/delete_client_note'); ?>',
+                {
+                    client_note_id: $(this).attr('data-id')
+                }, function (data) {
+                    <?php echo IP_DEBUG ? 'console.log(data);' : ''; ?>
+                    var response = JSON.parse(data);
+                    if (response.success === 1) {
+                        // The validation was successful
+                        $('.control-group').removeClass('error');
+                        $('#client_note').val('');
+
+                        // Reload all notes
+                        $('#notes_list').load("<?php echo site_url('clients/ajax/load_client_notes'); ?>",
+                            {
+                                client_id: <?php echo $client->client_id; ?>
+                            }, function (response) {
+                                <?php echo IP_DEBUG ? 'console.log(response);' : ''; ?>
+
+                                setTimeout(add_delete_client_notes_click_event, 161);
+                            });
+                    } else {
+                        // The validation was not successful
+                        $('.fullpage-loader-close').click();
+                        $('.control-group').removeClass('error');
+                        for (var key in response.validation_errors) {
+                            $('#' + key).parent().addClass('has-error');
+                        }
+                    }
+                });
+        }
+
+        function add_delete_client_notes_click_event(){
+            $('.delete_client_note').click(delete_client_note);
+        }
+
+        add_delete_client_notes_click_event();
+
         $('#save_client_note').click(function () {
             $.post('<?php echo site_url('clients/ajax/save_client_note'); ?>',
                 {
@@ -19,6 +57,8 @@
                                 client_id: <?php echo $client->client_id; ?>
                             }, function (response) {
                                 <?php echo IP_DEBUG ? 'console.log(response);' : ''; ?>
+
+                                setTimeout(add_delete_client_notes_click_event, 161);
                             });
                     } else {
                         // The validation was not successful


### PR DESCRIPTION
## Motivation and Context

Fix Impossible to delete client notes (Only option it's del client...)

Now, all notes have **delete button** by Ajax (see below)
Fix if .has-error never dropped.

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch. (development after 1.6.2b1)
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type

  * [x] Bugfix
  * [x] Improvement of an existing Feature
  * [ ] New Feature

![delete-client-note-btn](https://github.com/user-attachments/assets/19297da4-ab1e-4dd2-abe6-ffdf52a8aa02)
