### PR TITLE
Fix setup sql filenames

### DIFF
--- a/application/modules/setup/models/Mdl_setup.php
+++ b/application/modules/setup/models/Mdl_setup.php
@@ -372,7 +372,7 @@ class Mdl_Setup extends CI_Model
     {
         //upgrade the recurring invoices data and replace 0000-00-00 invalid date with null in order to be compliant
         //with the MySQL >= 5.8 defautl SQL Strict mode that is activated by default.
-        //migrate the dates data from 0000-00-00 to NULL in order to allow SQL Strict mode. Becaues the new
+        //migrate the dates data from 0000-00-00 to NULL in order to allow SQL Strict mode. Because the new
         //mysql default mode, the change must be done by PHP logic.
 
         //**recur_end_date**

--- a/application/modules/setup/sql/037_1.6.1.sql
+++ b/application/modules/setup/sql/037_1.6.1.sql
@@ -1,0 +1,1 @@
+# Added for versioning

--- a/application/modules/setup/sql/038_1.6.2.sql
+++ b/application/modules/setup/sql/038_1.6.2.sql
@@ -1,3 +1,5 @@
 ALTER table `ip_invoice_items` MODIFY `item_quantity` DECIMAL(20,8) NULL;
 ALTER table `ip_quote_items` MODIFY `item_quantity` DECIMAL(20,8) NULL;
 INSERT INTO `ip_settings` (`setting_key`,`setting_value`) VALUES ('default_item_decimals',2);
+-- [IP-1003]: Add extra field title (#1101)
+ALTER TABLE `ip_clients` ADD client_title VARCHAR(50) DEFAULT NULL AFTER `client_surname`;

--- a/application/modules/setup/sql/039_1.6.2.sql
+++ b/application/modules/setup/sql/039_1.6.2.sql
@@ -1,1 +1,0 @@
-ALTER TABLE `ip_clients` ADD client_title VARCHAR(50) DEFAULT NULL AFTER `client_surname`;


### PR DESCRIPTION
See : [IP-1003: Add extra field title (#1101)](https://github.com/InvoicePlane/InvoicePlane/commit/c64b5df878aeb351e312a75c9cc60de33b91c810#diff-f97132f81d846a5d14eb35d66fe77c943572d8db71735702e6f018f65671058c)

Devs, After need update DB Like this:
```sql
UPDATE `ip_versions` SET
`version_id` = '38',
`version_date_applied` = '1734693462',
`version_file` = '037_1.6.1.sql',
`version_sql_errors` = '0'
WHERE `version_id` = '38';

UPDATE `ip_versions` SET
`version_id` = '39',
`version_date_applied` = '1734693462',
`version_file` = '038_1.6.2.sql',
`version_sql_errors` = '0'
WHERE `version_id` = '39';
```

## Related Issue
Maybe  #1147 

## Motivation and Context
No Problem when upgrade from 1.5.11,
Fix file in db ip_version table (missing 1.6.1.sql & twice 1.6.2.sql)

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
