### PR TITLE
Fix #1169 : Add custom_fields in controllers/Settings

### DIFF
--- a/application/modules/email_templates/views/template-tags-invoices.php
+++ b/application/modules/email_templates/views/template-tags-invoices.php
@@ -45,12 +45,10 @@
         </optgroup>
 
         <optgroup label="<?php _trans('custom_fields'); ?>">
-            <?php if(isset($custom_fields['ip_invoice_custom'])) {
-                foreach ($custom_fields['ip_invoice_custom'] as $custom) { ?>
-                    <option value="{{{<?php echo 'ip_cf_' . $custom->custom_field_id; ?>}}}">
-                        <?php echo $custom->custom_field_label . ' (ID ' . $custom->custom_field_id . ')'; ?>
-                    </option>
-                <?php } ?>
+            <?php foreach ($custom_fields['ip_invoice_custom'] as $custom) { ?>
+                <option value="{{{<?php echo 'ip_cf_' . $custom->custom_field_id; ?>}}}">
+                    <?php echo $custom->custom_field_label . ' (ID ' . $custom->custom_field_id . ')'; ?>
+                </option>
             <?php } ?>
         </optgroup>
     </select>

--- a/application/modules/settings/controllers/Settings.php
+++ b/application/modules/settings/controllers/Settings.php
@@ -133,6 +133,7 @@ class Settings extends Admin_Controller
         $this->load->model('email_templates/mdl_email_templates');
         $this->load->model('payment_methods/mdl_payment_methods');
         $this->load->model('invoices/mdl_templates');
+        $this->load->model('custom_fields/mdl_invoice_custom');
 
         $this->load->helper('country');
 
@@ -162,10 +163,11 @@ class Settings extends Admin_Controller
                 'available_themes' => $available_themes,
                 'email_templates_quote' => $this->mdl_email_templates->where('email_template_type', 'quote')->get()->result(),
                 'email_templates_invoice' => $this->mdl_email_templates->where('email_template_type', 'invoice')->get()->result(),
+                'custom_fields' => ['ip_invoice_custom' => $this->mdl_invoice_custom->get()->result()],
                 'gateway_drivers' => $gateways,
                 'number_formats' => $number_formats,
                 'gateway_currency_codes' => get_currencies(),
-                'first_days_of_weeks' => array('0' => lang('sunday'), '1' => lang('monday'))
+                'first_days_of_weeks' => ['0' => lang('sunday'), '1' => lang('monday')]
             )
         );
 

--- a/application/modules/settings/views/partial_settings_general.php
+++ b/application/modules/settings/views/partial_settings_general.php
@@ -371,7 +371,6 @@
 
                 <div class="row">
                     <div class="col-xs-12 col-md-6">
-
                         <div class="form-group">
                             <label for="monospace_amounts">
                                 <?php _trans('monospaced_font_for_amounts'); ?>
@@ -387,13 +386,12 @@
                             <p class="help-block">
                                 <?php _trans('example'); ?>:
                                 <span style="font-family: Monaco, Lucida Console, monospace">
-                        <?php echo format_currency(123456.78); ?>
-                    </span>
+                                    <?php echo format_currency(123456.78); ?>
+                                </span>
                             </p>
                         </div>
-                      </div>
-
-                      <div class="col-xs-12 col-md-6">
+                    </div>
+                    <div class="col-xs-12 col-md-6">
                         <div class="form-group">
                             <label for="login_logo">
                                 <?php _trans('login_logo'); ?>
@@ -409,7 +407,7 @@
                     </div>
                 </div>
 
-              	<div class="row">
+                <div class="row">
                     <div class="col-xs-12 col-md-6">
                         <div class="form-group">
                             <label for="settings[reports_in_new_tab]">
@@ -423,9 +421,9 @@
                                 </option>
                             </select>
                         </div>
- 				            </div>
+                    </div>
                     <div class="col-xs-12 col-md-6">
-    					          <div class="form-group">
+                        <div class="form-group">
                             <label for="settings[show_responsive_itemlist]">
                                 <?php _trans('show_responsive_itemlist'); ?>
                             </label>
@@ -439,7 +437,6 @@
                                 </option>
                             </select>
                         </div>
-
                     </div>
                 </div>
 


### PR DESCRIPTION

Now Custom Fields ip_invoice_custom is present in settings page
  

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request : #1169
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature

------------------

+ Remove hard fix in view template-tags-invoices

+ Indents of settings view partial_settings general
