### PR TITLE
Form_validation: remove empty rules in products & tasks like other models

### DIFF
--- a/application/modules/products/models/Mdl_products.php
+++ b/application/modules/products/models/Mdl_products.php
@@ -58,7 +58,7 @@ class Mdl_Products extends Response_Model
         return array(
             'product_sku' => array(
                 'field' => 'product_sku',
-                'label' => trans('product_sku'),
+                'label' => trans('product_sku')
             ),
             'product_name' => array(
                 'field' => 'product_name',
@@ -67,7 +67,7 @@ class Mdl_Products extends Response_Model
             ),
             'product_description' => array(
                 'field' => 'product_description',
-                'label' => trans('product_description'),
+                'label' => trans('product_description')
             ),
             'product_price' => array(
                 'field' => 'product_price',
@@ -76,11 +76,11 @@ class Mdl_Products extends Response_Model
             ),
             'purchase_price' => array(
                 'field' => 'purchase_price',
-                'label' => trans('purchase_price'),
+                'label' => trans('purchase_price')
             ),
             'provider_name' => array(
                 'field' => 'provider_name',
-                'label' => trans('provider_name'),
+                'label' => trans('provider_name')
             ),
             'family_id' => array(
                 'field' => 'family_id',
@@ -100,7 +100,7 @@ class Mdl_Products extends Response_Model
             // Sumex
             'product_tariff' => array(
                 'field' => 'product_tariff',
-                'label' => trans('product_tariff'),
+                'label' => trans('product_tariff')
             ),
         );
     }

--- a/application/modules/products/models/Mdl_products.php
+++ b/application/modules/products/models/Mdl_products.php
@@ -59,7 +59,6 @@ class Mdl_Products extends Response_Model
             'product_sku' => array(
                 'field' => 'product_sku',
                 'label' => trans('product_sku'),
-                'rules' => ''
             ),
             'product_name' => array(
                 'field' => 'product_name',
@@ -69,7 +68,6 @@ class Mdl_Products extends Response_Model
             'product_description' => array(
                 'field' => 'product_description',
                 'label' => trans('product_description'),
-                'rules' => ''
             ),
             'product_price' => array(
                 'field' => 'product_price',
@@ -79,12 +77,10 @@ class Mdl_Products extends Response_Model
             'purchase_price' => array(
                 'field' => 'purchase_price',
                 'label' => trans('purchase_price'),
-                'rules' => ''
             ),
             'provider_name' => array(
                 'field' => 'provider_name',
                 'label' => trans('provider_name'),
-                'rules' => ''
             ),
             'family_id' => array(
                 'field' => 'family_id',
@@ -105,7 +101,6 @@ class Mdl_Products extends Response_Model
             'product_tariff' => array(
                 'field' => 'product_tariff',
                 'label' => trans('product_tariff'),
-                'rules' => ''
             ),
         );
     }

--- a/application/modules/tasks/models/Mdl_tasks.php
+++ b/application/modules/tasks/models/Mdl_tasks.php
@@ -64,7 +64,7 @@ class Mdl_Tasks extends Response_Model
             ),
             'task_description' => array(
                 'field' => 'task_description',
-                'label' => trans('task_description'),
+                'label' => trans('task_description')
             ),
             'task_price' => array(
                 'field' => 'task_price',
@@ -78,7 +78,7 @@ class Mdl_Tasks extends Response_Model
             ),
             'project_id' => array(
                 'field' => 'project_id',
-                'label' => trans('project'),
+                'label' => trans('project')
             ),
             'task_status' => array(
                 'field' => 'task_status',

--- a/application/modules/tasks/models/Mdl_tasks.php
+++ b/application/modules/tasks/models/Mdl_tasks.php
@@ -65,7 +65,6 @@ class Mdl_Tasks extends Response_Model
             'task_description' => array(
                 'field' => 'task_description',
                 'label' => trans('task_description'),
-                'rules' => ''
             ),
             'task_price' => array(
                 'field' => 'task_price',
@@ -80,7 +79,6 @@ class Mdl_Tasks extends Response_Model
             'project_id' => array(
                 'field' => 'project_id',
                 'label' => trans('project'),
-                'rules' => ''
             ),
             'task_status' => array(
                 'field' => 'task_status',


### PR DESCRIPTION
## Description
Same as numerous Models (Good practice?)
See [modules/clients/models/Mdl_clients.php line 40](https://github.com/InvoicePlane/InvoicePlane/blob/development/application/modules/clients/models/Mdl_clients.php#L40)
in `validation_rules`: `client_title`, `client_surname`, ...
have no `rule`


Same in [modules/invoices/models/Mdl_items.php line 66](https://github.com/InvoicePlane/InvoicePlane/blob/development/application/modules/invoices/models/Mdl_items.php#L66) and others...


## Related Issue
Maybe #1180

## Motivation and Context

Completion to simplify transition for php.8.4 & maintained CI
Compatibility with CodeIgniter 3.1.13 & 3.3.0 by @pocketarc
In relation with PR #1161 + Issue #1180


Exception find when use CodeIgniter 3.3.0 by @pocketarc
and when edit + save product go to blank page (prod mode)
_See [this message](https://github.com/InvoicePlane/InvoicePlane/pull/1194#issuecomment-2590057289) for backtrace._

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix (with CodeIgniter 3.3.0 by @pocketarc)
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
