### PR TITLE
Form_validation: remove empty rules in products & tasks models same other models

### DIFF
--- a/application/core/Base_Controller.php
+++ b/application/core/Base_Controller.php
@@ -34,8 +34,9 @@ class Base_Controller extends MX_Controller
             exit;
         }
 
-        // Globally disallow GET requests to delete methods
         $this->load->helper('url');
+
+        // Globally disallow GET requests to delete methods
         if (strstr(current_url(), 'delete') && $this->input->method() !== 'post') {
             show_404();
         }
@@ -64,8 +65,8 @@ class Base_Controller extends MX_Controller
             $this->load->helper('client');
 
             // Load setting model and load settings
-	    $this->load->model('settings/mdl_settings');
-	    if ($this->mdl_settings != null)
+            $this->load->model('settings/mdl_settings');
+            if ($this->mdl_settings != null)
                 $this->mdl_settings->load_settings();
             $this->load->helper('settings');
 

--- a/application/modules/clients/views/partial_client_table.php
+++ b/application/modules/clients/views/partial_client_table.php
@@ -13,9 +13,9 @@
         <tbody>
         <?php foreach ($records as $client) : ?>
             <tr>
-				<td>
-					<?php echo ($client->client_active) ? '<span class="label active">' . trans('yes') . '</span>' : '<span class="label inactive">' . trans('no') . '</span>'; ?>
-				</td>
+                <td>
+                    <?php echo ($client->client_active) ? '<span class="label active">' . trans('yes') . '</span>' : '<span class="label inactive">' . trans('no') . '</span>'; ?>
+                </td>
                 <td><?php echo anchor('clients/view/' . $client->client_id, htmlsc(format_client($client))); ?></td>
                 <td><?php _htmlsc($client->client_email); ?></td>
                 <td><?php _htmlsc($client->client_phone ? $client->client_phone : ($client->client_mobile ? $client->client_mobile : '')); ?></td>

--- a/application/modules/clients/views/partial_client_table.php
+++ b/application/modules/clients/views/partial_client_table.php
@@ -6,7 +6,7 @@
             <th><?php _trans('client_name'); ?></th>
             <th><?php _trans('email_address'); ?></th>
             <th><?php _trans('phone_number'); ?></th>
-            <th class="amount"><?php _trans('balance'); ?></th>
+            <th style="text-align: right;"><?php _trans('balance'); ?></th>
             <th><?php _trans('options'); ?></th>
         </tr>
         </thead>

--- a/application/modules/clients/views/partial_client_table.php
+++ b/application/modules/clients/views/partial_client_table.php
@@ -6,7 +6,7 @@
             <th><?php _trans('client_name'); ?></th>
             <th><?php _trans('email_address'); ?></th>
             <th><?php _trans('phone_number'); ?></th>
-            <th style="text-align: right;"><?php _trans('balance'); ?></th>
+            <th class="amount last"><?php _trans('balance'); ?></th>
             <th><?php _trans('options'); ?></th>
         </tr>
         </thead>
@@ -19,7 +19,7 @@
                 <td><?php echo anchor('clients/view/' . $client->client_id, htmlsc(format_client($client))); ?></td>
                 <td><?php _htmlsc($client->client_email); ?></td>
                 <td><?php _htmlsc($client->client_phone ? $client->client_phone : ($client->client_mobile ? $client->client_mobile : '')); ?></td>
-                <td class="amount"><?php echo format_currency($client->client_invoice_balance); ?></td>
+                <td class="amount last"><?php echo format_currency($client->client_invoice_balance); ?></td>
                 <td>
                     <div class="options btn-group">
                         <a class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown" href="#">

--- a/application/modules/clients/views/view.php
+++ b/application/modules/clients/views/view.php
@@ -57,14 +57,14 @@
 
 <?php
 $locations = [];
-            foreach ($custom_fields as $custom_field) {
-                if (array_key_exists($custom_field->custom_field_location, $locations)) {
-                    $locations[$custom_field->custom_field_location] += 1;
-                } else {
-                    $locations[$custom_field->custom_field_location] = 1;
-                }
-            }
-            ?>
+foreach ($custom_fields as $custom_field) {
+    if (array_key_exists($custom_field->custom_field_location, $locations)) {
+        $locations[$custom_field->custom_field_location] += 1;
+    } else {
+        $locations[$custom_field->custom_field_location] = 1;
+    }
+}
+?>
 
 <div id="headerbar">
     <h1 class="headerbar-title"><?php _htmlsc(format_client($client)); ?></h1>

--- a/application/modules/clients/views/view.php
+++ b/application/modules/clients/views/view.php
@@ -82,11 +82,14 @@ $locations = [];
                class="btn btn-default">
                 <i class="fa fa-edit"></i> <?php _trans('edit'); ?>
             </a>
-            <a class="btn btn-danger"
-               href="<?php echo site_url('clients/delete/' . $client->client_id); ?>"
-               onclick="return confirm('<?php _trans('delete_client_warning'); ?>');">
-                <i class="fa fa-trash-o"></i> <?php _trans('delete'); ?>
-            </a>
+            <form action="<?php echo site_url('clients/delete/' . $client->client_id); ?>"
+                  method="POST" class="btn-group btn-group-sm">
+                <?php _csrf_field(); ?>
+                <button type="submit" class="btn btn-danger"
+                        onclick="return confirm('<?php _trans('delete_client_warning'); ?>');">
+                    <i class="fa fa-trash-o"></i> <?php _trans('delete'); ?>
+                </button>
+            </form>
         </div>
     </div>
 

--- a/application/modules/dashboard/views/index.php
+++ b/application/modules/dashboard/views/index.php
@@ -127,7 +127,7 @@
                             <th style="min-width: 15%;"><?php _trans('date'); ?></th>
                             <th style="min-width: 15%;"><?php _trans('quote'); ?></th>
                             <th style="min-width: 35%;"><?php _trans('client'); ?></th>
-                            <th style="text-align: right;"><?php _trans('balance'); ?></th>
+                            <th class="amount"><?php _trans('balance'); ?></th>
                             <th></th>
                         </tr>
                         </thead>
@@ -187,7 +187,7 @@
                             <th style="min-width: 15%;"><?php _trans('due_date'); ?></th>
                             <th style="min-width: 15%;"><?php _trans('invoice'); ?></th>
                             <th style="min-width: 35%;"><?php _trans('client'); ?></th>
-                            <th style="text-align: right;"><?php _trans('balance'); ?></th>
+                            <th class="amount"><?php _trans('balance'); ?></th>
                             <th></th>
                         </tr>
                         </thead>

--- a/application/modules/email_templates/views/template-tags-invoices.php
+++ b/application/modules/email_templates/views/template-tags-invoices.php
@@ -45,12 +45,10 @@
         </optgroup>
 
         <optgroup label="<?php _trans('custom_fields'); ?>">
-            <?php if(isset($custom_fields['ip_invoice_custom'])) {
-                foreach ($custom_fields['ip_invoice_custom'] as $custom) { ?>
-                    <option value="{{{<?php echo 'ip_cf_' . $custom->custom_field_id; ?>}}}">
-                        <?php echo $custom->custom_field_label . ' (ID ' . $custom->custom_field_id . ')'; ?>
-                    </option>
-                <?php } ?>
+            <?php foreach ($custom_fields['ip_invoice_custom'] as $custom) { ?>
+                <option value="{{{<?php echo 'ip_cf_' . $custom->custom_field_id; ?>}}}">
+                    <?php echo $custom->custom_field_label . ' (ID ' . $custom->custom_field_id . ')'; ?>
+                </option>
             <?php } ?>
         </optgroup>
     </select>

--- a/application/modules/invoices/controllers/Invoices.php
+++ b/application/modules/invoices/controllers/Invoices.php
@@ -109,7 +109,7 @@ public function download($invoice)
 {
     $safeBaseDir = realpath(UPLOADS_ARCHIVE_FOLDER);
 
-    $fileName = basename($invoice) . '.pdf'; // Strip directory traversal sequences
+    $fileName = basename($invoice); // Strip directory traversal sequences
     $filePath = realpath($safeBaseDir . DIRECTORY_SEPARATOR . $fileName);
 
     if ($filePath === false || strpos($filePath, $safeBaseDir) !== 0) {

--- a/application/modules/invoices/views/partial_invoice_table.php
+++ b/application/modules/invoices/views/partial_invoice_table.php
@@ -8,8 +8,8 @@
             <th><?php _trans('created'); ?></th>
             <th><?php _trans('due_date'); ?></th>
             <th><?php _trans('client_name'); ?></th>
-            <th style="text-align: right;"><?php _trans('amount'); ?></th>
-            <th style="text-align: right;"><?php _trans('balance'); ?></th>
+            <th class="amount"><?php _trans('amount'); ?></th>
+            <th class="amount last"><?php _trans('balance'); ?></th>
             <th><?php _trans('options'); ?></th>
         </tr>
         </thead>
@@ -73,7 +73,7 @@
                     <?php echo format_currency($invoice->invoice_total); ?>
                 </td>
 
-                <td class="amount">
+                <td class="amount last">
                     <?php echo format_currency($invoice->invoice_balance); ?>
                 </td>
 

--- a/application/modules/payments/views/partial_payment_table.php
+++ b/application/modules/payments/views/partial_payment_table.php
@@ -7,7 +7,7 @@
             <th><?php _trans('invoice_date'); ?></th>
             <th><?php _trans('invoice'); ?></th>
             <th><?php _trans('client'); ?></th>
-            <th><?php _trans('amount'); ?></th>
+            <th class="amount last"><?php _trans('amount'); ?></th>
             <th><?php _trans('payment_method'); ?></th>
             <th><?php _trans('note'); ?></th>
             <th><?php _trans('options'); ?></th>
@@ -26,7 +26,7 @@
                         <?php _htmlsc(format_client($payment)); ?>
                     </a>
                 </td>
-                <td class="amount"><?php echo format_currency($payment->payment_amount); ?></td>
+                <td class="amount last"><?php echo format_currency($payment->payment_amount); ?></td>
                 <td><?php _htmlsc($payment->payment_method_name); ?></td>
                 <td><?php _htmlsc($payment->payment_note); ?></td>
                 <td>

--- a/application/modules/products/models/Mdl_products.php
+++ b/application/modules/products/models/Mdl_products.php
@@ -58,8 +58,7 @@ class Mdl_Products extends Response_Model
         return array(
             'product_sku' => array(
                 'field' => 'product_sku',
-                'label' => trans('product_sku'),
-                'rules' => ''
+                'label' => trans('product_sku')
             ),
             'product_name' => array(
                 'field' => 'product_name',
@@ -68,8 +67,7 @@ class Mdl_Products extends Response_Model
             ),
             'product_description' => array(
                 'field' => 'product_description',
-                'label' => trans('product_description'),
-                'rules' => ''
+                'label' => trans('product_description')
             ),
             'product_price' => array(
                 'field' => 'product_price',
@@ -78,13 +76,11 @@ class Mdl_Products extends Response_Model
             ),
             'purchase_price' => array(
                 'field' => 'purchase_price',
-                'label' => trans('purchase_price'),
-                'rules' => ''
+                'label' => trans('purchase_price')
             ),
             'provider_name' => array(
                 'field' => 'provider_name',
-                'label' => trans('provider_name'),
-                'rules' => ''
+                'label' => trans('provider_name')
             ),
             'family_id' => array(
                 'field' => 'family_id',
@@ -104,8 +100,7 @@ class Mdl_Products extends Response_Model
             // Sumex
             'product_tariff' => array(
                 'field' => 'product_tariff',
-                'label' => trans('product_tariff'),
-                'rules' => ''
+                'label' => trans('product_tariff')
             ),
         );
     }

--- a/application/modules/products/views/index.php
+++ b/application/modules/products/views/index.php
@@ -26,7 +26,7 @@
                 <th><?php _trans('product_sku'); ?></th>
                 <th><?php _trans('product_name'); ?></th>
                 <th><?php _trans('product_description'); ?></th>
-                <th><?php _trans('product_price'); ?></th>
+                <th class="amount last"><?php _trans('product_price'); ?></th>
                 <th><?php _trans('product_unit'); ?></th>
                 <th><?php _trans('tax_rate'); ?></th>
                 <?php if (get_setting('sumex')) : ?>
@@ -43,7 +43,7 @@
                     <td><?php _htmlsc($product->product_sku); ?></td>
                     <td><?php _htmlsc($product->product_name); ?></td>
                     <td><?php echo nl2br(htmlsc($product->product_description)); ?></td>
-                    <td class="amount"><?php echo format_currency($product->product_price); ?></td>
+                    <td class="amount last"><?php echo format_currency($product->product_price); ?></td>
                     <td><?php _htmlsc($product->unit_name); ?></td>
                     <td><?php echo ($product->tax_rate_id) ? htmlsc($product->tax_rate_name) : trans('none'); ?></td>
                     <?php if (get_setting('sumex')) : ?>

--- a/application/modules/products/views/partial_product_table_modal.php
+++ b/application/modules/products/views/partial_product_table_modal.php
@@ -6,7 +6,7 @@
             <th><?php _trans('family_name'); ?></th>
             <th><?php _trans('product_name'); ?></th>
             <th><?php _trans('product_description'); ?></th>
-            <th class="text-right"><?php _trans('product_price'); ?></th>
+            <th class="amount"><?php _trans('product_price'); ?></th>
         </tr>
         <?php foreach ($products as $product) { ?>
             <tr class="product">
@@ -26,7 +26,7 @@
                 <td>
                     <?php echo nl2br(htmlsc($product->product_description)); ?>
                 </td>
-                <td class="text-right">
+                <td class="amount">
                     <?php echo format_currency($product->product_price); ?>
                 </td>
             </tr>

--- a/application/modules/quotes/views/partial_quote_table.php
+++ b/application/modules/quotes/views/partial_quote_table.php
@@ -8,7 +8,7 @@
             <th><?php _trans('created'); ?></th>
             <th><?php _trans('due_date'); ?></th>
             <th><?php _trans('client_name'); ?></th>
-            <th style="text-align: right; padding-right: 25px;"><?php _trans('amount'); ?></th>
+            <th class="amount last"><?php _trans('amount'); ?></th>
             <th><?php _trans('options'); ?></th>
         </tr>
         </thead>
@@ -47,7 +47,7 @@
                         <?php _htmlsc(format_client($quote)); ?>
                     </a>
                 </td>
-                <td style="text-align: right; padding-right: 25px;">
+                <td class="amount last">
                     <?php echo format_currency($quote->quote_total); ?>
                 </td>
                 <td>

--- a/application/modules/settings/controllers/Settings.php
+++ b/application/modules/settings/controllers/Settings.php
@@ -133,6 +133,7 @@ class Settings extends Admin_Controller
         $this->load->model('email_templates/mdl_email_templates');
         $this->load->model('payment_methods/mdl_payment_methods');
         $this->load->model('invoices/mdl_templates');
+        $this->load->model('custom_fields/mdl_invoice_custom');
 
         $this->load->helper('country');
 
@@ -162,10 +163,11 @@ class Settings extends Admin_Controller
                 'available_themes' => $available_themes,
                 'email_templates_quote' => $this->mdl_email_templates->where('email_template_type', 'quote')->get()->result(),
                 'email_templates_invoice' => $this->mdl_email_templates->where('email_template_type', 'invoice')->get()->result(),
+                'custom_fields' => ['ip_invoice_custom' => $this->mdl_invoice_custom->get()->result()],
                 'gateway_drivers' => $gateways,
                 'number_formats' => $number_formats,
                 'gateway_currency_codes' => get_currencies(),
-                'first_days_of_weeks' => array('0' => lang('sunday'), '1' => lang('monday'))
+                'first_days_of_weeks' => ['0' => lang('sunday'), '1' => lang('monday')]
             )
         );
 

--- a/application/modules/settings/views/partial_settings_general.php
+++ b/application/modules/settings/views/partial_settings_general.php
@@ -371,7 +371,6 @@
 
                 <div class="row">
                     <div class="col-xs-12 col-md-6">
-
                         <div class="form-group">
                             <label for="monospace_amounts">
                                 <?php _trans('monospaced_font_for_amounts'); ?>
@@ -387,13 +386,12 @@
                             <p class="help-block">
                                 <?php _trans('example'); ?>:
                                 <span style="font-family: Monaco, Lucida Console, monospace">
-                        <?php echo format_currency(123456.78); ?>
-                    </span>
+                                    <?php echo format_currency(123456.78); ?>
+                                </span>
                             </p>
                         </div>
-                      </div>
-
-                      <div class="col-xs-12 col-md-6">
+                    </div>
+                    <div class="col-xs-12 col-md-6">
                         <div class="form-group">
                             <label for="login_logo">
                                 <?php _trans('login_logo'); ?>
@@ -409,7 +407,7 @@
                     </div>
                 </div>
 
-              	<div class="row">
+                <div class="row">
                     <div class="col-xs-12 col-md-6">
                         <div class="form-group">
                             <label for="settings[reports_in_new_tab]">
@@ -423,9 +421,9 @@
                                 </option>
                             </select>
                         </div>
- 				            </div>
+                    </div>
                     <div class="col-xs-12 col-md-6">
-    					          <div class="form-group">
+                        <div class="form-group">
                             <label for="settings[show_responsive_itemlist]">
                                 <?php _trans('show_responsive_itemlist'); ?>
                             </label>
@@ -439,7 +437,6 @@
                                 </option>
                             </select>
                         </div>
-
                     </div>
                 </div>
 

--- a/application/modules/tasks/models/Mdl_tasks.php
+++ b/application/modules/tasks/models/Mdl_tasks.php
@@ -64,8 +64,7 @@ class Mdl_Tasks extends Response_Model
             ),
             'task_description' => array(
                 'field' => 'task_description',
-                'label' => trans('task_description'),
-                'rules' => ''
+                'label' => trans('task_description')
             ),
             'task_price' => array(
                 'field' => 'task_price',
@@ -79,8 +78,7 @@ class Mdl_Tasks extends Response_Model
             ),
             'project_id' => array(
                 'field' => 'project_id',
-                'label' => trans('project'),
-                'rules' => ''
+                'label' => trans('project')
             ),
             'task_status' => array(
                 'field' => 'task_status',

--- a/application/modules/tasks/views/index.php
+++ b/application/modules/tasks/views/index.php
@@ -26,7 +26,7 @@
                 <th><?php _trans('task_name'); ?></th>
                 <th><?php _trans('task_finish_date'); ?></th>
                 <th><?php _trans('project'); ?></th>
-                <th><?php _trans('task_price'); ?></th>
+                <th class="amount last"><?php _trans('task_price'); ?></th>
                 <th><?php _trans('options'); ?></th>
             </tr>
             </thead>
@@ -50,7 +50,7 @@
                     <td>
                         <?php echo !empty($task->project_id) ? anchor('projects/view/' . $task->project_id, htmlsc($task->project_name)) : ''; ?>
                     </td>
-                    <td>
+                    <td class="amount last">
                         <?php echo format_currency($task->task_price); ?>
                     </td>
                     <td>

--- a/application/modules/tasks/views/partial_task_table_modal.php
+++ b/application/modules/tasks/views/partial_task_table_modal.php
@@ -6,8 +6,7 @@
             <th><?php echo lang('task_name'); ?></th>
             <th><?php echo lang('task_finish_date'); ?></th>
             <th><?php echo lang('task_description'); ?></th>
-            <th class="text-right">
-                <?php echo lang('task_price'); ?></th>
+            <th class="amount"><?php echo lang('task_price'); ?></th>
         </tr>
 
         <?php foreach ($tasks as $task) { ?>

--- a/application/views/invoice_templates/public/InvoicePlane_Web.php
+++ b/application/views/invoice_templates/public/InvoicePlane_Web.php
@@ -253,7 +253,7 @@
 
             <hr>
 
-            <?php if (get_setting('qr_code')) : ?>
+            <?php if (get_setting('qr_code') && $invoice->invoice_balance > 0) : ?>
                 <table class="invoice-qr-code-table">
                     <tr>
                         <td>

--- a/assets/core/js/scripts.js
+++ b/assets/core/js/scripts.js
@@ -225,8 +225,8 @@ $(document).ready(function () {
         update_email_template_preview();
     });
 
-    // Fullpage loader
-    $(document).on('click', '.ajax-loader', function (event) {
+    // Fullpage loader (spinner)
+    $(document).on('click', '.ajax-loader', function () {
         var requiredFieldsFilledIn = true;
 
         $('input[required], textarea[required], select[required]').each(function () {
@@ -235,9 +235,9 @@ $(document).ready(function () {
             }
         });
 
-        // Checks if required fields are filled it. If not, don't display spinner.
+        // Checks if required fields are filled it.
         if (!requiredFieldsFilledIn) {
-            return;
+            return; // If not, don't display spinner.
         }
 
         // Show loader

--- a/assets/core/js/scripts.js
+++ b/assets/core/js/scripts.js
@@ -240,13 +240,13 @@ $(document).ready(function () {
             return;
         }
 
-        $(document).on('click', '.ajax-loader', function () {
-            $('#fullpage-loader').fadeIn(200);
-            window.fullpageloaderTimeout = window.setTimeout(function () {
-                $('#loader-error').fadeIn(200);
-                $('#loader-icon').removeClass('fa-spin').addClass('text-danger');
-            }, 10000);
-        });
+        // Show loader
+        $('#fullpage-loader').fadeIn(200);
+        window.fullpageloaderTimeout = window.setTimeout(function () {
+            $('#loader-error').fadeIn(200);
+            $('#loader-icon').removeClass('fa-spin').addClass('text-danger');
+        }, 10000);
+
     });
 
     $(document).on('click', '.fullpage-loader-close', function () {

--- a/assets/core/scss/_core.scss
+++ b/assets/core/scss/_core.scss
@@ -773,6 +773,10 @@ div.table-content {
   text-align: right;
 }
 
+.amount.last {
+  padding-right: 25px;
+}
+
 .no-border-radius {
   border-radius: 0;
 }


### PR DESCRIPTION
## Description
Same as numerous Models (Good practice?)
See [modules/clients/models/Mdl_clients.php line 40](https://github.com/InvoicePlane/InvoicePlane/blob/development/application/modules/clients/models/Mdl_clients.php#L40)
in `validation_rules`: `client_title`, `client_surname`, ...
have no `rule`


Same in [modules/invoices/models/Mdl_items.php line 66](https://github.com/InvoicePlane/InvoicePlane/blob/development/application/modules/invoices/models/Mdl_items.php#L66) and others...


## Related Issue
Maybe #1180

## Motivation and Context

Completion to simplify transition for php.8.4 & maintained CI
Compatibility with CodeIgniter 3.1.13 & 3.3.0 by @pocketarc
In relation with PR #1161 + Issue #1180


Exception find when use CodeIgniter 3.3.0 by @pocketarc
and when edit + save product go to blank page (prod mode)
_See [this message](https://github.com/InvoicePlane/InvoicePlane/pull/1195#issuecomment-2590174628) for backtrace._

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix (with CodeIgniter 3.3.0 by @pocketarc)
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
