### PR TITLE
Add invoice_status case in template_helper (Fix #1198)

### DIFF
--- a/application/helpers/template_helper.php
+++ b/application/helpers/template_helper.php
@@ -50,6 +50,9 @@ function parse_template($object, $body)
                 case 'invoice_balance':
                     $replace = format_currency($object->invoice_balance);
                     break;
+                case 'invoice_status':
+                    $replace = get_invoice_status($object->invoice_status_id);
+                    break;
                 case 'quote_item_subtotal':
                     $replace = format_currency($object->quote_item_subtotal);
                     break;
@@ -101,6 +104,25 @@ function parse_template($object, $body)
     }
 
     return $body;
+}
+
+/**
+ * Returns the translated invoice status
+ *
+ * @param $invoice->invoice_status_id
+ * @return string
+ */
+function get_invoice_status($id)
+{
+    $CI =& get_instance();
+
+    if(empty($CI->mdl_invoices))
+    {
+        $CI->load->model('mdl_invoices');
+    }
+    $statuses = $CI->mdl_invoices->statuses();
+
+    return $statuses[$id]['label'];
 }
 
 /**


### PR DESCRIPTION
## Description
First solution of #1198 implemented

## Related Issue
#1198

## Motivation and Context
Solve a problem with `{{{invoice_status}}}` tag in remittance qr code text.
Edit: And in email body [see this comment](https://github.com/InvoicePlane/InvoicePlane/issues/1198#issuecomment-2594076307) (and maybe other).

## Screenshots (if appropriate):
![invoice_status-tag-parsed-in-qrcode-pdf](https://github.com/user-attachments/assets/4fec3105-0049-4d73-a794-b2493ab6efa3)
Sent

![invoice_status-tag-parsed-in-qrcode-pdf-draft](https://github.com/user-attachments/assets/f68dfb0b-218c-4357-9884-87c730f04b98)
Draft

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request. (#1198)
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
