### PR TITLE
Fix SMTP password wrong after saving settings #1200

### DIFF
--- a/application/modules/settings/views/partial_settings_email.php
+++ b/application/modules/settings/views/partial_settings_email.php
@@ -112,8 +112,8 @@
                                     <?php _trans('smtp_password'); ?>
                                 </label>
                                 <input type="password" id="smtp_password" class="form-control"
-                                    name="settings[smtp_password]"
-                                    value="<?php echo $this->crypt->decode(get_setting('settings[smtp_password]')); ?>">
+                                    name="settings[smtp_password]" autocomplete="new-password"
+                                    value="">
                                 <input type="hidden" name="settings[smtp_password_field_is_password]" value="1">
                             </div>
 


### PR DESCRIPTION
## Description
Smtp password settings always empty

## Related Issue
#1200

## Motivation and Context
Solve a problem of bad smtp password on save setting #1200

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request. (#1200)
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
