### PR TITLE
Update template_helper.php to fix email template with custom single choice field

### DIFF
--- a/application/helpers/template_helper.php
+++ b/application/helpers/template_helper.php
@@ -91,6 +91,11 @@ function parse_template($object, $body)
                             // Get the values for the custom field
                             $cf_model = str_replace('ip_', 'mdl_', $cf->custom_field_table);
                             $replace = $CI->mdl_custom_fields->get_value_for_field($cf_id[1], $cf_model, $object);
+                            if ($cf->custom_field_type == 'SINGLE-CHOICE') {
+								$CI->load->model('custom_values/mdl_custom_values', 'cv');
+    							$el = $CI->cv->get_by_id($replace)->row();
+								$replace = $el->custom_values_value;
+							}
                         } else {
                             $replace = '';
                         }


### PR DESCRIPTION
This update will use written label instead of option number in email template, if the filed is an custom field with single choice

## Description

## Related Issue
solves https://community.invoiceplane.com/t/topic/10911

## Motivation and Context
Using a custom field which is single choice in email templates is returned as number (of selected option) instead of text. This fix will return the chosen text.

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request.
  * [ ] I selected the corresponding branch.
  * [ ] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
