### PR TITLE
sort invoices by date instead of id

### DIFF
--- a/application/modules/invoices/models/Mdl_invoices.php
+++ b/application/modules/invoices/models/Mdl_invoices.php
@@ -75,7 +75,7 @@ class Mdl_Invoices extends Response_Model
 
     public function default_order_by()
     {
-        $this->db->order_by('ip_invoices.invoice_id DESC');
+        $this->db->order_by('ip_invoices.invoice_date_created DESC');
     }
 
     public function default_join()


### PR DESCRIPTION
## Related Issue
fixes #1218 

## Motivation and Context
The invoices are sorted by ascending `invoice_id`. If you work a lot with drafts that are open for a few days before they are assigned the correct date and an invoice number, the list gets very mixed up. The list should be sorted by date (or alternatively by assigned number).

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/14c2a7d6-a2a7-4b3f-bc81-0c5d903f3778)


## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
