### PR TITLE
sort quotes by date instead of id

### DIFF
--- a/application/modules/quotes/models/Mdl_quotes.php
+++ b/application/modules/quotes/models/Mdl_quotes.php
@@ -78,7 +78,7 @@ class Mdl_Quotes extends Response_Model
 
     public function default_order_by()
     {
-        $this->db->order_by('ip_quotes.quote_id DESC');
+        $this->db->order_by('ip_quotes.quote_date_created DESC');
     }
 
     public function default_join()


### PR DESCRIPTION
## Description

see #1218 to apply same thing of #1219 for quotes

## Screenshoot

Before

![quotes-order-by-id](https://github.com/user-attachments/assets/099693b4-2e4a-43c5-b630-73bcaf693184)

After

![quotes-order-by-date](https://github.com/user-attachments/assets/adf48284-06d1-4a01-8160-dd4bf4741a23)


## Related Issue
#1218 

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request (#1218).
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
