### PR TITLE
Amounts calculation: Legacy or not

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -17,7 +17,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 | Note: need set to false to valid Zugferd2 & Facturx xml (discounts & VAT)
 |
 */
-$config['taxes_after_discounts'] = env_bool('TAXES_AFTER_DISCOUNTS');
+$config['legacy_calculation'] = env_bool('LEGACY_CALCULATION');
 
 /*
 |--------------------------------------------------------------------------

--- a/application/helpers/pdf_helper.php
+++ b/application/helpers/pdf_helper.php
@@ -160,14 +160,14 @@ function generate_invoice_pdf($invoice_id, $stream = true, $invoice_template = n
     }
 
     $data = [
-        'invoice'               => $invoice,
-        'invoice_tax_rates'     => $CI->mdl_invoice_tax_rates->where('invoice_id', $invoice_id)->get()->result(),
-        'items'                 => $items,
-        'payment_method'        => $payment_method,
-        'output_type'           => 'pdf',
-        'show_item_discounts'   => $show_item_discounts,
-        'custom_fields'         => $custom_fields,
-        'taxes_after_discounts' => config_item('taxes_after_discounts'),
+        'invoice'             => $invoice,
+        'invoice_tax_rates'   => $CI->mdl_invoice_tax_rates->where('invoice_id', $invoice_id)->get()->result(),
+        'items'               => $items,
+        'payment_method'      => $payment_method,
+        'output_type'         => 'pdf',
+        'show_item_discounts' => $show_item_discounts,
+        'custom_fields'       => $custom_fields,
+        'legacy_calculation'  => config_item('legacy_calculation'),
     ];
 
     $html = $CI->load->view('invoice_templates/pdf/' . $invoice_template, $data, true);
@@ -374,13 +374,13 @@ function generate_quote_pdf($quote_id, $stream = true, $quote_template = null)
 
     $data =
     [
-        'quote'                 => $quote,
-        'quote_tax_rates'       => $CI->mdl_quote_tax_rates->where('quote_id', $quote_id)->get()->result(),
-        'items'                 => $items,
-        'output_type'           => 'pdf',
-        'show_item_discounts'   => $show_item_discounts,
-        'custom_fields'         => $custom_fields,
-        'taxes_after_discounts' => config_item('taxes_after_discounts'),
+        'quote'               => $quote,
+        'quote_tax_rates'     => $CI->mdl_quote_tax_rates->where('quote_id', $quote_id)->get()->result(),
+        'items'               => $items,
+        'output_type'         => 'pdf',
+        'show_item_discounts' => $show_item_discounts,
+        'custom_fields'       => $custom_fields,
+        'legacy_calculation'  => config_item('legacy_calculation'),
     ];
 
     $html = $CI->load->view('quote_templates/pdf/' . $quote_template, $data, true);

--- a/application/libraries/XMLtemplates/Facturxv10Xml.php
+++ b/application/libraries/XMLtemplates/Facturxv10Xml.php
@@ -10,7 +10,7 @@ if (!defined('BASEPATH')) exit('No direct script access allowed');
  * @link        https://invoiceplane.com
  * @Note        Zugferd 2.3 & Factur-X 1.0.7 compatibility
  *
- * @Important   Need TAXES_AFTER_DISCOUNTS=false (In ip_config)
+ * @Important   Need LEGACY_CALCULATION=false (In ip_config)
  *               For embeded xml are valid (discounts calculation)
  *
  * @todos?
@@ -341,7 +341,7 @@ class Facturxv10Xml
      * Add missing discount invoice vars [for factur-x validation](ecosio.com/en/peppol-and-xml-document-validator)
      *
      * invoice_subtotal                    Scope TaxBasisTotalAmount
-     * invoice_discount_amount_total       Scope AllowanceTotalAmount (todo: it's used)
+     * invoice_discount_amount_total       Scope addSpecifiedTradeAllowanceCharge_discount()
      * invoice_discount_amount_subtotal    Scope SpecifiedTradeAllowanceCharge > ActualAmount>
      */
     protected function set_invoice_discount_amount_total()

--- a/application/modules/guest/controllers/View.php
+++ b/application/modules/guest/controllers/View.php
@@ -58,8 +58,8 @@ class View extends Base_Controller
         // Get all custom fields
         $custom_fields = [
             'invoice' => $this->mdl_custom_fields->get_values_for_fields('mdl_invoice_custom', $invoice->invoice_id),
-            'client' => $this->mdl_custom_fields->get_values_for_fields('mdl_client_custom', $invoice->client_id),
-            'user' => $this->mdl_custom_fields->get_values_for_fields('mdl_user_custom', $invoice->user_id),
+            'client'  => $this->mdl_custom_fields->get_values_for_fields('mdl_client_custom', $invoice->client_id),
+            'user'    => $this->mdl_custom_fields->get_values_for_fields('mdl_user_custom', $invoice->user_id),
         ];
 
         // Attachments
@@ -68,16 +68,16 @@ class View extends Base_Controller
         $is_overdue = ($invoice->invoice_balance > 0 && strtotime($invoice->invoice_date_due) < time() ? true : false);
 
         $data = [
-            'invoice'               => $invoice,
-            'items'                 => $this->mdl_items->where('invoice_id', $invoice->invoice_id)->get()->result(),
-            'invoice_tax_rates'     => $this->mdl_invoice_tax_rates->where('invoice_id', $invoice->invoice_id)->get()->result(),
-            'invoice_url_key'       => $invoice_url_key,
-            'flash_message'         => $this->session->flashdata('flash_message'),
-            'payment_method'        => $payment_method,
-            'is_overdue'            => $is_overdue,
-            'attachments'           => $attachments,
-            'custom_fields'         => $custom_fields,
-            'taxes_after_discounts' => config_item('taxes_after_discounts'),
+            'invoice'            => $invoice,
+            'items'              => $this->mdl_items->where('invoice_id', $invoice->invoice_id)->get()->result(),
+            'invoice_tax_rates'  => $this->mdl_invoice_tax_rates->where('invoice_id', $invoice->invoice_id)->get()->result(),
+            'invoice_url_key'    => $invoice_url_key,
+            'flash_message'      => $this->session->flashdata('flash_message'),
+            'payment_method'     => $payment_method,
+            'is_overdue'         => $is_overdue,
+            'attachments'        => $attachments,
+            'custom_fields'      => $custom_fields,
+            'legacy_calculation' => config_item('legacy_calculation'),
         ];
 
         $this->load->view('invoice_templates/public/' . get_setting('public_invoice_template') . '.php', $data);
@@ -95,10 +95,10 @@ class View extends Base_Controller
             {
                 if ('.' != $file && '..' != $file && strpos($file, $key) !== false)
                 {
-                    $obj['name'] = substr($file, strpos($file, '_', 1) + 1);
+                    $obj['name']     = substr($file, strpos($file, '_', 1) + 1);
                     $obj['fullname'] = $file;
-                    $obj['size'] = filesize($path . '/' . $file);
-                    $attachments[] = $obj;
+                    $obj['size']     = filesize($path . '/' . $file);
+                    $attachments[]   = $obj;
                 }
             }
         }
@@ -196,9 +196,9 @@ class View extends Base_Controller
 
         // Get all custom fields
         $custom_fields = array(
-            'quote' => $this->mdl_custom_fields->get_values_for_fields('mdl_quote_custom', $quote->quote_id),
+            'quote'  => $this->mdl_custom_fields->get_values_for_fields('mdl_quote_custom', $quote->quote_id),
             'client' => $this->mdl_custom_fields->get_values_for_fields('mdl_client_custom', $quote->client_id),
-            'user' => $this->mdl_custom_fields->get_values_for_fields('mdl_user_custom', $quote->user_id),
+            'user'   => $this->mdl_custom_fields->get_values_for_fields('mdl_user_custom', $quote->user_id),
         );
 
         // Attachments
@@ -207,15 +207,15 @@ class View extends Base_Controller
         $is_expired = (strtotime($quote->quote_date_expires) < time() ? true : false);
 
         $data = [
-            'quote'                 => $quote,
-            'items'                 => $this->mdl_quote_items->where('quote_id', $quote->quote_id)->get()->result(),
-            'quote_tax_rates'       => $this->mdl_quote_tax_rates->where('quote_id', $quote->quote_id)->get()->result(),
-            'quote_url_key'         => $quote_url_key,
-            'flash_message'         => $this->session->flashdata('flash_message'),
-            'is_expired'            => $is_expired,
-            'attachments'           => $attachments,
-            'custom_fields'         => $custom_fields,
-            'taxes_after_discounts' => config_item('taxes_after_discounts'),
+            'quote'              => $quote,
+            'items'              => $this->mdl_quote_items->where('quote_id', $quote->quote_id)->get()->result(),
+            'quote_tax_rates'    => $this->mdl_quote_tax_rates->where('quote_id', $quote->quote_id)->get()->result(),
+            'quote_url_key'      => $quote_url_key,
+            'flash_message'      => $this->session->flashdata('flash_message'),
+            'is_expired'         => $is_expired,
+            'attachments'        => $attachments,
+            'custom_fields'      => $custom_fields,
+            'legacy_calculation' => config_item('legacy_calculation'),
         ];
 
         $this->load->view('quote_templates/public/' . get_setting('public_quote_template') . '.php', $data);

--- a/application/modules/invoices/controllers/Ajax.php
+++ b/application/modules/invoices/controllers/Ajax.php
@@ -44,7 +44,7 @@ class Ajax extends Admin_Controller
                     }
                 }
             }
-// todo? on client side (only one) / server side (2 are possible?) && aplied before all taxes
+            // todo? on client side (only one) / server side (2 are possible)
             if ($this->input->post('invoice_discount_percent') === '') {
                 $invoice_discount_percent = floatval(0);
             } else {
@@ -148,10 +148,13 @@ class Ajax extends Admin_Controller
                 $this->mdl_invoice_sumex->save($invoice_id, $sumex_array);
             }
 
-            // Recalculate for discounts (why?)
-            //~ $this->load->model('invoices/mdl_invoice_amounts');
-            //~ $this->mdl_invoice_amounts->calculate($invoice_id, $global_discount);
-//~ $e = new \Exception;var_dump($e->getTraceAsString());exit(__file__.__line__);
+            if(config_item('legacy_calculation'))
+            {
+                // Recalculate for discounts
+                $this->load->model('invoices/mdl_invoice_amounts');
+                $this->mdl_invoice_amounts->calculate($invoice_id, $global_discount);
+            }
+
             $response = [
                 'success' => 1,
             ];

--- a/application/modules/invoices/controllers/Invoices.php
+++ b/application/modules/invoices/controllers/Invoices.php
@@ -7,10 +7,10 @@ if ( ! defined('BASEPATH')) {
 /*
  * InvoicePlane
  *
- * @author		InvoicePlane Developers & Contributors
- * @copyright	Copyright (c) 2012 - 2018 InvoicePlane.com
- * @license		https://invoiceplane.com/license.txt
- * @link		https://invoiceplane.com
+ * @author      InvoicePlane Developers & Contributors
+ * @copyright   Copyright (c) 2012 - 2018 InvoicePlane.com
+ * @license     https://invoiceplane.com/license.txt
+ * @link        https://invoiceplane.com
  */
 
 #[AllowDynamicProperties]
@@ -325,11 +325,13 @@ class Invoices extends Admin_Controller
 
     public function delete_invoice_tax($invoice_id, $invoice_tax_rate_id): void
     {
-        $this->load->model('mdl_invoice_tax_rates');
+        $this->load->model('invoices/mdl_invoice_tax_rates');
         $this->mdl_invoice_tax_rates->delete($invoice_tax_rate_id);
 
-        $this->load->model('mdl_invoice_amounts');
-        $this->mdl_invoice_amounts->calculate($invoice_id);
+        $this->load->model('invoices/mdl_invoice_amounts');
+        $global_discount['item'] = $this->mdl_invoice_amounts->get_global_discount($invoice_id);
+        // Recalculate invoice amounts
+        $this->mdl_invoice_amounts->calculate($invoice_id, $global_discount);
 
         redirect('invoices/view/' . $invoice_id);
     }
@@ -339,11 +341,13 @@ class Invoices extends Admin_Controller
         $this->db->select('invoice_id');
         $invoice_ids = $this->db->get('ip_invoices')->result();
 
-        $this->load->model('mdl_invoice_amounts');
+        $this->load->model('invoices/mdl_invoice_amounts');
 
         foreach ($invoice_ids as $invoice_id)
         {
-            $this->mdl_invoice_amounts->calculate($invoice_id->invoice_id);
+            $global_discount['item'] = $this->mdl_invoice_amounts->get_global_discount($invoice_id->invoice_id);
+            // Recalculate invoice amounts
+            $this->mdl_invoice_amounts->calculate($invoice_id->invoice_id, $global_discount);
         }
     }
 }

--- a/application/modules/invoices/controllers/Invoices.php
+++ b/application/modules/invoices/controllers/Invoices.php
@@ -216,9 +216,9 @@ class Invoices extends Admin_Controller
                     'currency_symbol_placement' => get_setting('currency_symbol_placement'),
                     'decimal_point'             => get_setting('decimal_point'),
                 ],
-                'invoice_statuses'      => $this->mdl_invoices->statuses(),
-                'payment_cf_exist'      => $payment_cf_exist,
-                'taxes_after_discounts' => config_item('taxes_after_discounts'),
+                'invoice_statuses'   => $this->mdl_invoices->statuses(),
+                'payment_cf_exist'   => $payment_cf_exist,
+                'legacy_calculation' => config_item('legacy_calculation'),
             ]
         );
 

--- a/application/modules/invoices/models/Mdl_invoice_amounts.php
+++ b/application/modules/invoices/models/Mdl_invoice_amounts.php
@@ -55,7 +55,7 @@ class Mdl_Invoice_Amounts extends CI_Model
         $invoice_amounts = $query->row();
 
         // Discounts calculation - since v1.6.3
-        if(config_item('taxes_after_discounts'))
+        if(config_item('legacy_calculation'))
         {
             $invoice_item_subtotal = $invoice_amounts->invoice_item_subtotal - $invoice_amounts->invoice_item_discount;
             $invoice_subtotal = $invoice_item_subtotal + $invoice_amounts->invoice_item_tax_total;
@@ -166,7 +166,7 @@ class Mdl_Invoice_Amounts extends CI_Model
      */
     public function get_global_discount($invoice_id)
     {
-        // The global_discount amounts is needed to recalculate invoice amounts
+        // The global_discount amounts is needed to recalculate invoice amounts (if legacy_calculation is false)
         $row = $this->db->query("
             SELECT SUM(item_subtotal) - (SUM(item_total) - SUM(item_tax_total) + SUM(item_discount)) AS global_discount
             FROM ip_invoice_item_amounts
@@ -227,7 +227,7 @@ class Mdl_Invoice_Amounts extends CI_Model
             $invoice_total = $invoice_amount->invoice_item_subtotal + $invoice_amount->invoice_item_tax_total + $invoice_amount->invoice_tax_total;
 
             // Discounts calculation - since v1.6.3
-            if(config_item('taxes_after_discounts'))
+            if(config_item('legacy_calculation'))
             {
                 $invoice_total = $this->calculate_discount($invoice_id, $invoice_total);
             }

--- a/application/modules/invoices/models/Mdl_invoice_tax_rates.php
+++ b/application/modules/invoices/models/Mdl_invoice_tax_rates.php
@@ -49,8 +49,9 @@ class Mdl_Invoice_Tax_Rates extends Response_Model
         }
 
         if ($invoice_id) {
-            $this->mdl_invoice_amounts->calculate_invoice_taxes($invoice_id);
-            $this->mdl_invoice_amounts->calculate($invoice_id);
+            $global_discount['item'] = $this->mdl_invoice_amounts->get_global_discount($invoice_id);
+            // Recalculate invoice amounts
+            $this->mdl_invoice_amounts->calculate($invoice_id, $global_discount);
         }
 
     }

--- a/application/modules/invoices/models/Mdl_item_amounts.php
+++ b/application/modules/invoices/models/Mdl_item_amounts.php
@@ -34,7 +34,7 @@ class Mdl_Item_Amounts extends CI_Model
         $item_subtotal = $item->item_quantity * $item->item_price;
 
         // Discounts calculation - since v1.6.3
-        if(config_item('taxes_after_discounts'))
+        if(config_item('legacy_calculation'))
         {
             $item_tax_total = $item_subtotal * ($item->item_tax_rate_percent / 100);
             $item_discount_total = $item->item_discount_amount * $item->item_quantity;

--- a/application/modules/invoices/models/Mdl_item_amounts.php
+++ b/application/modules/invoices/models/Mdl_item_amounts.php
@@ -7,10 +7,10 @@ if (! defined('BASEPATH')) {
 /*
  * InvoicePlane
  *
- * @author		InvoicePlane Developers & Contributors
- * @copyright	Copyright (c) 2012 - 2018 InvoicePlane.com
- * @license		https://invoiceplane.com/license.txt
- * @link		https://invoiceplane.com
+ * @author      InvoicePlane Developers & Contributors
+ * @copyright   Copyright (c) 2012 - 2018 InvoicePlane.com
+ * @license     https://invoiceplane.com/license.txt
+ * @link        https://invoiceplane.com
  */
 
 #[AllowDynamicProperties]
@@ -24,26 +24,39 @@ class Mdl_Item_Amounts extends CI_Model
      * item_total ((item_quantity * item_price) + item_tax_total)
      *
      * @param $item_id
+     * @param $global_discount
      */
-    public function calculate($item_id)
+    public function calculate($item_id, & $global_discount)
     {
         $this->load->model('invoices/mdl_items');
         $item = $this->mdl_items->get_by_id($item_id);
 
+        $item_subtotal = $item->item_quantity * $item->item_price;
+
         // Discounts calculation - since v1.6.3
         if(config_item('taxes_after_discounts'))
         {
-            $item_subtotal = $item->item_quantity * $item->item_price;
             $item_tax_total = $item_subtotal * ($item->item_tax_rate_percent / 100);
             $item_discount_total = $item->item_discount_amount * $item->item_quantity;
             $item_total = $item_subtotal + $item_tax_total - $item_discount_total;
         }
         else
         {
-            $item_subtotal = $item->item_quantity * ($item->item_price - $item->item_discount_amount);
-            $item_tax_total = $item_subtotal * ($item->item_tax_rate_percent / 100);
+            $item_discount = 0.0; // For total & tax calculation after all discounts applied Proportionally by item
+            if($global_discount['percent'] > 0)
+            {
+                $item_discount = round(($item_subtotal * ($global_discount['percent'] / 100)), 2);
+            }
+
+            if($global_discount['amount'] > 0)
+            {
+                $item_discount = round($global_discount['amount'] * ($item_subtotal / $global_discount['items_subtotal']), 2);
+            }
+
+            $global_discount['item'] += $item_discount; // for Mdl_invoice_amounts calculation
             $item_discount_total = $item->item_discount_amount * $item->item_quantity;
-            $item_total = $item_subtotal + $item_tax_total;
+            $item_tax_total = ($item_subtotal - $item_discount - $item_discount_total) * ($item->item_tax_rate_percent / 100);
+            $item_total = $item_subtotal - $item_discount - $item_discount_total + $item_tax_total;
         }
 
         $db_array = array(

--- a/application/modules/invoices/views/partial_itemlist_responsive.php
+++ b/application/modules/invoices/views/partial_itemlist_responsive.php
@@ -69,7 +69,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                                 <div class="input-group-addon"><?php echo get_setting('currency_symbol'); ?></div>
                             </div>
 <?php
-                            if ( ! $taxes_after_discounts)
+                            if ( ! $legacy_calculation)
                             {
                                 $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_input');
                             }
@@ -87,7 +87,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                                 </select>
                             </div>
 <?php
-                            if ($taxes_after_discounts)
+                            if ($legacy_calculation)
                             {
                                 $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_input');
                             }
@@ -109,7 +109,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                                 </div>
                             </div>
 <?php
-                            if ( ! $taxes_after_discounts)
+                            if ( ! $legacy_calculation)
                             {
                                 $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_show');
                             }
@@ -123,7 +123,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                                 </div>
                             </div>
 <?php
-                            if ($taxes_after_discounts)
+                            if ($legacy_calculation)
                             {
                                 $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_show');
                             }
@@ -228,7 +228,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                                     <div class="input-group-addon"><?php echo get_setting('currency_symbol'); ?></div>
                                 </div>
 <?php
-                                if ( ! $taxes_after_discounts)
+                                if ( ! $legacy_calculation)
                                 {
                                     $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_input', ['item' => $item]);
                                 }
@@ -246,7 +246,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                                     </select>
                                 </div>
 <?php
-                                if ($taxes_after_discounts)
+                                if ($legacy_calculation)
                                 {
                                     $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_input', ['item' => $item]);
                                 }
@@ -262,7 +262,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                                     </div>
                                 </div>
 <?php
-                                if ( ! $taxes_after_discounts)
+                                if ( ! $legacy_calculation)
                                 {
                                     $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_show', ['item' => $item]);
                                 }
@@ -276,7 +276,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                                     </div>
                                 </div>
 <?php
-                                if ($taxes_after_discounts)
+                                if ($legacy_calculation)
                                 {
                                     $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_show', ['item' => $item]);
                                 }
@@ -328,7 +328,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                 class="amount"><?php echo format_currency($invoice->invoice_item_subtotal); ?></td>
             </tr>
 <?php
-            if ( ! $taxes_after_discounts)
+            if ( ! $legacy_calculation)
             {
                 $this->layout->load_view('invoices/partial_itemlist_table_invoice_discount');
             }
@@ -362,7 +362,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                 </td>
             </tr>
 <?php
-            if ($taxes_after_discounts)
+            if ($legacy_calculation)
             {
                 $this->layout->load_view('invoices/partial_itemlist_table_invoice_discount');
             }

--- a/application/modules/invoices/views/partial_itemlist_table.php
+++ b/application/modules/invoices/views/partial_itemlist_table.php
@@ -57,6 +57,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                 <div class="input-group">
                     <span class="input-group-addon"><?php _trans('price'); ?></span>
                     <input type="text" name="item_price" class="input-sm form-control amount" value="">
+                    <div class="input-group-addon"><?php echo get_setting('currency_symbol'); ?></div>
                 </div>
             </td>
 <?php
@@ -327,17 +328,17 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
 
     <div class="col-xs-12 col-md-6 col-md-offset-2 col-lg-4 col-lg-offset-4">
         <table class="table table-bordered text-right">
-            <tr>
-                <td style="width: 40%;"><?php _trans('subtotal'); ?></td>
-                <td style="width: 60%;"
-                    class="amount"><?php echo format_currency($invoice->invoice_item_subtotal); ?></td>
-            </tr>
 <?php
             if ( ! $taxes_after_discounts)
             {
                 $this->layout->load_view('invoices/partial_itemlist_table_invoice_discount');
             }
 ?>
+            <tr>
+                <td style="width: 40%;"><?php _trans('subtotal'); ?></td>
+                <td style="width: 60%;"
+                    class="amount"><?php echo format_currency($invoice->invoice_item_subtotal); ?></td>
+            </tr>
             <tr>
                 <td><?php _trans('item_tax'); ?></td>
                 <td class="amount"><?php echo format_currency($invoice->invoice_item_tax_total); ?></td>

--- a/application/modules/invoices/views/partial_itemlist_table.php
+++ b/application/modules/invoices/views/partial_itemlist_table.php
@@ -13,9 +13,9 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
 -->
             <th class="amount"><?php _trans('quantity'); ?></th>
             <th class="amount"><?php _trans('price'); ?></th>
-            <?php echo ! $taxes_after_discounts ? '<th class="amount">' . trans('item_discount') . '</th>' : '' ?>
+            <?php echo ! $legacy_calculation ? '<th class="amount">' . trans('item_discount') . '</th>' : '' ?>
             <th class="amount"><?php _trans('tax_rate'); ?></th>
-            <?php echo $taxes_after_discounts ? '<th class="amount">' . trans('item_discount') . '</th>' : '' ?>
+            <?php echo $legacy_calculation ? '<th class="amount">' . trans('item_discount') . '</th>' : '' ?>
 <!--
             <th class="amount"><?php _trans('subtotal'); ?></th>
             <th class="amount"><?php _trans('tax'); ?></th>
@@ -61,7 +61,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                 </div>
             </td>
 <?php
-            if ( ! $taxes_after_discounts)
+            if ( ! $legacy_calculation)
             {
                 $this->layout->load_view('layout/partial/itemlist_table_item_discount_input');
             }
@@ -81,7 +81,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                 </div>
             </td>
 <?php
-            if ($taxes_after_discounts)
+            if ($legacy_calculation)
             {
                 $this->layout->load_view('layout/partial/itemlist_table_item_discount_input');
             }
@@ -127,7 +127,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                 <span name="subtotal" class="amount"></span>
             </td>
 <?php
-            if ( ! $taxes_after_discounts)
+            if ( ! $legacy_calculation)
             {
                 $this->layout->load_view('layout/partial/itemlist_table_item_discount_show');
             }
@@ -137,7 +137,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                 <span name="item_tax_total" class="amount"></span>
             </td>
 <?php
-            if ($taxes_after_discounts)
+            if ($legacy_calculation)
             {
                 $this->layout->load_view('layout/partial/itemlist_table_item_discount_show');
             }
@@ -199,7 +199,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                     </div>
                 </td>
 <?php
-                if ( ! $taxes_after_discounts)
+                if ( ! $legacy_calculation)
                 {
                     $this->layout->load_view('layout/partial/itemlist_table_item_discount_input', ['item' => $item]);
                 }
@@ -219,7 +219,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                     </div>
                 </td>
 <?php
-                if ($taxes_after_discounts)
+                if ($legacy_calculation)
                 {
                     $this->layout->load_view('layout/partial/itemlist_table_item_discount_input', ['item' => $item]);
                 }
@@ -274,7 +274,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                     </span>
                 </td>
 <?php
-                if ( ! $taxes_after_discounts)
+                if ( ! $legacy_calculation)
                 {
                     $this->layout->load_view('layout/partial/itemlist_table_item_discount_show', ['item' => $item]);
                 }
@@ -286,7 +286,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                     </span>
                 </td>
 <?php
-                if ($taxes_after_discounts)
+                if ($legacy_calculation)
                 {
                     $this->layout->load_view('layout/partial/itemlist_table_item_discount_show', ['item' => $item]);
                 }
@@ -329,7 +329,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
     <div class="col-xs-12 col-md-6 col-md-offset-2 col-lg-4 col-lg-offset-4">
         <table class="table table-bordered text-right">
 <?php
-            if ( ! $taxes_after_discounts)
+            if ( ! $legacy_calculation)
             {
                 $this->layout->load_view('invoices/partial_itemlist_table_invoice_discount');
             }
@@ -369,7 +369,7 @@ $invoice_disabled = $invoice->is_read_only != 1 ? '' : ' disabled="disabled"';
                 </td>
             </tr>
 <?php
-            if ($taxes_after_discounts)
+            if ($legacy_calculation)
             {
                 $this->layout->load_view('invoices/partial_itemlist_table_invoice_discount');
             }

--- a/application/modules/quotes/controllers/Ajax.php
+++ b/application/modules/quotes/controllers/Ajax.php
@@ -43,7 +43,7 @@ class Ajax extends Admin_Controller
                     }
                 }
             }
-
+            // todo? on client side (only one) / server side (2 are possible)
             if ($this->input->post('quote_discount_percent') === '') {
                 $quote_discount_percent = floatval(0);
             } else {
@@ -97,9 +97,12 @@ class Ajax extends Admin_Controller
 
             $this->mdl_quotes->save($quote_id, $db_array, $global_discount);
 
-            // Recalculate for discounts (why?)
-            //~ $this->load->model('quotes/mdl_quote_amounts');
-            //~ $this->mdl_quote_amounts->calculate($quote_id, $global_discount);
+            if(config_item('legacy_calculation'))
+            {
+                // Recalculate for discounts
+                $this->load->model('quotes/mdl_quote_amounts');
+                $this->mdl_quote_amounts->calculate($quote_id, $global_discount);
+            }
 
             $response = [
                 'success' => 1,

--- a/application/modules/quotes/controllers/Quotes.php
+++ b/application/modules/quotes/controllers/Quotes.php
@@ -152,7 +152,7 @@ class Quotes extends Admin_Controller
                     'currency_symbol_placement' => get_setting('currency_symbol_placement'),
                     'decimal_point'             => get_setting('decimal_point')
                 ],
-                'taxes_after_discounts' => config_item('taxes_after_discounts'),
+                'legacy_calculation' => config_item('legacy_calculation'),
             ]
         );
 

--- a/application/modules/quotes/controllers/Quotes.php
+++ b/application/modules/quotes/controllers/Quotes.php
@@ -202,11 +202,13 @@ class Quotes extends Admin_Controller
      */
     public function delete_quote_tax($quote_id, $quote_tax_rate_id)
     {
-        $this->load->model('mdl_quote_tax_rates');
+        $this->load->model('quotes/mdl_quote_tax_rates');
         $this->mdl_quote_tax_rates->delete($quote_tax_rate_id);
 
-        $this->load->model('mdl_quote_amounts');
-        $this->mdl_quote_amounts->calculate($quote_id);
+        $this->load->model('quotes/mdl_quote_amounts');
+        $global_discount['item'] = $this->mdl_quote_amounts->get_global_discount($quote_id);
+        // Recalculate quote amounts
+        $this->mdl_quote_amounts->calculate($quote_id, $global_discount);
 
         redirect('quotes/view/' . $quote_id);
     }
@@ -219,7 +221,9 @@ class Quotes extends Admin_Controller
         $this->load->model('mdl_quote_amounts');
 
         foreach ($quote_ids as $quote_id) {
-            $this->mdl_quote_amounts->calculate($quote_id->quote_id);
+            $global_discount['item'] = $this->mdl_quote_amounts->get_global_discount($quote_id->quote_id);
+            // Recalculate quote amounts
+            $this->mdl_quote_amounts->calculate($quote_id->quote_id, $global_discount);
         }
     }
 

--- a/application/modules/quotes/models/Mdl_quote_amounts.php
+++ b/application/modules/quotes/models/Mdl_quote_amounts.php
@@ -52,7 +52,7 @@ class Mdl_Quote_Amounts extends CI_Model
         $quote_amounts = $query->row();
 
         // Discounts calculation - since v1.6.3
-        if(config_item('taxes_after_discounts'))
+        if(config_item('legacy_calculation'))
         {
             $quote_item_subtotal = $quote_amounts->quote_item_subtotal - $quote_amounts->quote_item_discount;
             $quote_subtotal = $quote_item_subtotal + $quote_amounts->quote_item_tax_total;
@@ -126,7 +126,7 @@ class Mdl_Quote_Amounts extends CI_Model
      */
     public function get_global_discount($quote_id)
     {
-        // The global_discount amounts is needed to recalculate quote amounts
+        // The global_discount amounts is needed to recalculate quote amounts (if legacy_calculation is false)
         $row = $this->db->query("
             SELECT SUM(item_subtotal) - (SUM(item_total) - SUM(item_tax_total) + SUM(item_discount)) AS global_discount
             FROM ip_quote_item_amounts
@@ -192,7 +192,7 @@ class Mdl_Quote_Amounts extends CI_Model
             $quote_total = $quote_amount->quote_item_subtotal + $quote_amount->quote_item_tax_total + $quote_amount->quote_tax_total;
 
             // Discounts calculation - since v1.6.3
-            if(config_item('taxes_after_discounts'))
+            if(config_item('legacy_calculation'))
             {
                 $quote_total = $this->calculate_discount($quote_id, $quote_total);
             }

--- a/application/modules/quotes/models/Mdl_quote_amounts.php
+++ b/application/modules/quotes/models/Mdl_quote_amounts.php
@@ -7,10 +7,10 @@ if (! defined('BASEPATH')) {
 /*
  * InvoicePlane
  *
- * @author		InvoicePlane Developers & Contributors
- * @copyright	Copyright (c) 2012 - 2018 InvoicePlane.com
- * @license		https://invoiceplane.com/license.txt
- * @link		https://invoiceplane.com
+ * @author      InvoicePlane Developers & Contributors
+ * @copyright   Copyright (c) 2012 - 2018 InvoicePlane.com
+ * @license     https://invoiceplane.com/license.txt
+ * @link        https://invoiceplane.com
  */
 
 #[AllowDynamicProperties]
@@ -34,15 +34,16 @@ class Mdl_Quote_Amounts extends CI_Model
      * item_total                item_subtotal + item_tax_total
      *
      * @param $quote_id
+     * @param $global_discount
      */
-    public function calculate($quote_id)
+    public function calculate($quote_id, $global_discount)
     {
         // Get the basic totals
         $query = $this->db->query("
-            SELECT SUM(item_subtotal) AS quote_item_subtotal,
-                SUM(item_tax_total) AS quote_item_tax_total,
-                SUM(item_subtotal) + SUM(item_tax_total) AS quote_total,
-                SUM(item_discount) AS quote_item_discount
+            SELECT  SUM(item_subtotal) AS quote_item_subtotal,
+                    SUM(item_tax_total) AS quote_item_tax_total,
+                    SUM(item_subtotal) + SUM(item_tax_total) AS quote_total,
+                    SUM(item_discount) AS quote_item_discount
             FROM ip_quote_item_amounts
             WHERE item_id
                 IN (SELECT item_id FROM ip_quote_items WHERE quote_id = " . $this->db->escape($quote_id) . ")
@@ -59,25 +60,27 @@ class Mdl_Quote_Amounts extends CI_Model
         }
         else
         {
-            $quote_item_subtotal = $quote_amounts->quote_item_subtotal;
-            $quote_subtotal = $this->calculate_discount($quote_id, $quote_item_subtotal);
-            $quote_total = $quote_subtotal + $quote_amounts->quote_item_tax_total;
+            $quote_item_subtotal = $quote_amounts->quote_item_subtotal - $quote_amounts->quote_item_discount - $global_discount['item'];
+            $quote_total = $quote_item_subtotal + $quote_amounts->quote_item_tax_total;
         }
 
         // Create the database array and insert or update
-        $db_array = array(
+        $db_array = [
             'quote_id' => $quote_id,
             'quote_item_subtotal' => $quote_item_subtotal,
             'quote_item_tax_total' => $quote_amounts->quote_item_tax_total,
             'quote_total' => $quote_total,
-        );
+        ];
 
         $this->db->where('quote_id', $quote_id);
-        if ($this->db->get('ip_quote_amounts')->num_rows()) {
+        if ($this->db->get('ip_quote_amounts')->num_rows())
+        {
             // The record already exists; update it
             $this->db->where('quote_id', $quote_id);
             $this->db->update('ip_quote_amounts', $db_array);
-        } else {
+        }
+        else
+        {
             // The record does not yet exist; insert it
             $this->db->insert('ip_quote_amounts', $db_array);
         }
@@ -96,11 +99,13 @@ class Mdl_Quote_Amounts extends CI_Model
         $this->db->where('quote_id', $quote_id);
         $quote_data = $this->db->get('ip_quotes')->row();
 
-        if ($quote_data->quote_discount_amount==null) {
+        if ($quote_data->quote_discount_amount==null)
+        {
             $quote_data->quote_discount_amount = 0.0;
         }
 
-        if ($quote_data->quote_discount_percent==null) {
+        if ($quote_data->quote_discount_percent==null)
+        {
             $quote_data->quote_discount_percent = 0.0;
         }
 
@@ -116,6 +121,24 @@ class Mdl_Quote_Amounts extends CI_Model
 
     /**
      * @param $quote_id
+     *
+     * return global_discount
+     */
+    public function get_global_discount($quote_id)
+    {
+        // The global_discount amounts is needed to recalculate quote amounts
+        $row = $this->db->query("
+            SELECT SUM(item_subtotal) - (SUM(item_total) - SUM(item_tax_total) + SUM(item_discount)) AS global_discount
+            FROM ip_quote_item_amounts
+            WHERE item_id
+                IN (SELECT item_id FROM ip_quote_items WHERE quote_id = " . $this->db->escape($quote_id) . ")
+            ")
+            ->row();
+        return $row->global_discount;
+    }
+
+    /**
+     * @param $quote_id
      */
     public function calculate_quote_taxes($quote_id)
     {
@@ -123,25 +146,30 @@ class Mdl_Quote_Amounts extends CI_Model
         $this->load->model('quotes/mdl_quote_tax_rates');
         $quote_tax_rates = $this->mdl_quote_tax_rates->where('quote_id', $quote_id)->get()->result();
 
-        if ($quote_tax_rates) {
+        if ($quote_tax_rates)
+        {
             // There are quote taxes applied
             // Get the current quote amount record
             $quote_amount = $this->db->where('quote_id', $quote_id)->get('ip_quote_amounts')->row();
 
             // Loop through the quote taxes and update the amount for each of the applied quote taxes
-            foreach ($quote_tax_rates as $quote_tax_rate) {
-                if ($quote_tax_rate->include_item_tax) {
+            foreach ($quote_tax_rates as $quote_tax_rate)
+            {
+                if ($quote_tax_rate->include_item_tax)
+                {
                     // The quote tax rate should include the applied item tax
                     $quote_tax_rate_amount = ($quote_amount->quote_item_subtotal + $quote_amount->quote_item_tax_total) * ($quote_tax_rate->quote_tax_rate_percent / 100);
-                } else {
+                }
+                else
+                {
                     // The quote tax rate should not include the applied item tax
                     $quote_tax_rate_amount = $quote_amount->quote_item_subtotal * ($quote_tax_rate->quote_tax_rate_percent / 100);
                 }
 
                 // Update the quote tax rate record
-                $db_array = array(
+                $db_array = [
                     'quote_tax_rate_amount' => $quote_tax_rate_amount
-                );
+                ];
                 $this->db->where('quote_tax_rate_id', $quote_tax_rate->quote_tax_rate_id);
                 $this->db->update('ip_quote_tax_rates', $db_array);
             }
@@ -163,7 +191,11 @@ class Mdl_Quote_Amounts extends CI_Model
             // Recalculate the quote total
             $quote_total = $quote_amount->quote_item_subtotal + $quote_amount->quote_item_tax_total + $quote_amount->quote_tax_total;
 
-            $quote_total = $this->calculate_discount($quote_id, $quote_total);
+            // Discounts calculation - since v1.6.3
+            if(config_item('taxes_after_discounts'))
+            {
+                $quote_total = $this->calculate_discount($quote_id, $quote_total);
+            }
 
             // Update the quote amount record
             $db_array = array(
@@ -172,12 +204,14 @@ class Mdl_Quote_Amounts extends CI_Model
 
             $this->db->where('quote_id', $quote_id);
             $this->db->update('ip_quote_amounts', $db_array);
-        } else {
+        }
+        else
+        {
             // No quote taxes applied
 
-            $db_array = array(
+            $db_array = [
                 'quote_tax_total' => '0.00'
-            );
+            ];
 
             $this->db->where('quote_id', $quote_id);
             $this->db->update('ip_quote_amounts', $db_array);
@@ -193,32 +227,32 @@ class Mdl_Quote_Amounts extends CI_Model
         switch ($period) {
             case 'month':
                 return $this->db->query("
-					SELECT SUM(quote_total) AS total_quoted
-					FROM ip_quote_amounts
-					WHERE quote_id IN
-					(SELECT quote_id FROM ip_quotes
-					WHERE MONTH(quote_date_created) = MONTH(NOW())
-					AND YEAR(quote_date_created) = YEAR(NOW()))")->row()->total_quoted;
+                    SELECT SUM(quote_total) AS total_quoted
+                    FROM ip_quote_amounts
+                    WHERE quote_id IN
+                    (SELECT quote_id FROM ip_quotes
+                    WHERE MONTH(quote_date_created) = MONTH(NOW())
+                    AND YEAR(quote_date_created) = YEAR(NOW()))")->row()->total_quoted;
             case 'last_month':
                 return $this->db->query("
-					SELECT SUM(quote_total) AS total_quoted
-					FROM ip_quote_amounts
-					WHERE quote_id IN
-					(SELECT quote_id FROM ip_quotes
-					WHERE MONTH(quote_date_created) = MONTH(NOW() - INTERVAL 1 MONTH)
-					AND YEAR(quote_date_created) = YEAR(NOW() - INTERVAL 1 MONTH))")->row()->total_quoted;
+                    SELECT SUM(quote_total) AS total_quoted
+                    FROM ip_quote_amounts
+                    WHERE quote_id IN
+                    (SELECT quote_id FROM ip_quotes
+                    WHERE MONTH(quote_date_created) = MONTH(NOW() - INTERVAL 1 MONTH)
+                    AND YEAR(quote_date_created) = YEAR(NOW() - INTERVAL 1 MONTH))")->row()->total_quoted;
             case 'year':
                 return $this->db->query("
-					SELECT SUM(quote_total) AS total_quoted
-					FROM ip_quote_amounts
-					WHERE quote_id IN
-					(SELECT quote_id FROM ip_quotes WHERE YEAR(quote_date_created) = YEAR(NOW()))")->row()->total_quoted;
+                    SELECT SUM(quote_total) AS total_quoted
+                    FROM ip_quote_amounts
+                    WHERE quote_id IN
+                    (SELECT quote_id FROM ip_quotes WHERE YEAR(quote_date_created) = YEAR(NOW()))")->row()->total_quoted;
             case 'last_year':
                 return $this->db->query("
-					SELECT SUM(quote_total) AS total_quoted
-					FROM ip_quote_amounts
-					WHERE quote_id IN
-					(SELECT quote_id FROM ip_quotes WHERE YEAR(quote_date_created) = YEAR(NOW() - INTERVAL 1 YEAR))")->row()->total_quoted;
+                    SELECT SUM(quote_total) AS total_quoted
+                    FROM ip_quote_amounts
+                    WHERE quote_id IN
+                    (SELECT quote_id FROM ip_quotes WHERE YEAR(quote_date_created) = YEAR(NOW() - INTERVAL 1 YEAR))")->row()->total_quoted;
             default:
                 return $this->db->query("SELECT SUM(quote_total) AS total_quoted FROM ip_quote_amounts")->row()->total_quoted;
         }
@@ -234,67 +268,67 @@ class Mdl_Quote_Amounts extends CI_Model
             default:
             case 'this-month':
                 $results = $this->db->query("
-					SELECT quote_status_id,
-					    SUM(quote_total) AS sum_total,
-					    COUNT(*) AS num_total
-					FROM ip_quote_amounts
-					JOIN ip_quotes ON ip_quotes.quote_id = ip_quote_amounts.quote_id
+                    SELECT quote_status_id,
+                        SUM(quote_total) AS sum_total,
+                        COUNT(*) AS num_total
+                    FROM ip_quote_amounts
+                    JOIN ip_quotes ON ip_quotes.quote_id = ip_quote_amounts.quote_id
                         AND MONTH(ip_quotes.quote_date_created) = MONTH(NOW())
                         AND YEAR(ip_quotes.quote_date_created) = YEAR(NOW())
-					GROUP BY ip_quotes.quote_status_id")->result_array();
+                    GROUP BY ip_quotes.quote_status_id")->result_array();
                 break;
             case 'last-month':
                 $results = $this->db->query("
-					SELECT quote_status_id,
-					    SUM(quote_total) AS sum_total,
-					    COUNT(*) AS num_total
-					FROM ip_quote_amounts
-					JOIN ip_quotes ON ip_quotes.quote_id = ip_quote_amounts.quote_id
+                    SELECT quote_status_id,
+                        SUM(quote_total) AS sum_total,
+                        COUNT(*) AS num_total
+                    FROM ip_quote_amounts
+                    JOIN ip_quotes ON ip_quotes.quote_id = ip_quote_amounts.quote_id
                         AND MONTH(ip_quotes.quote_date_created) = MONTH(NOW() - INTERVAL 1 MONTH)
                         AND YEAR(ip_quotes.quote_date_created) = YEAR(NOW())
-					GROUP BY ip_quotes.quote_status_id")->result_array();
+                    GROUP BY ip_quotes.quote_status_id")->result_array();
                 break;
             case 'this-quarter':
                 $results = $this->db->query("
-					SELECT quote_status_id,
-					    SUM(quote_total) AS sum_total,
-					    COUNT(*) AS num_total
-					FROM ip_quote_amounts
-					JOIN ip_quotes ON ip_quotes.quote_id = ip_quote_amounts.quote_id
+                    SELECT quote_status_id,
+                        SUM(quote_total) AS sum_total,
+                        COUNT(*) AS num_total
+                    FROM ip_quote_amounts
+                    JOIN ip_quotes ON ip_quotes.quote_id = ip_quote_amounts.quote_id
                         AND QUARTER(ip_quotes.quote_date_created) = QUARTER(NOW())
                         AND YEAR(ip_quotes.quote_date_created) = YEAR(NOW())
-					GROUP BY ip_quotes.quote_status_id")->result_array();
+                    GROUP BY ip_quotes.quote_status_id")->result_array();
                 break;
             case 'last-quarter':
                 $results = $this->db->query("
-					SELECT quote_status_id,
-					    SUM(quote_total) AS sum_total,
-					    COUNT(*) AS num_total
-					FROM ip_quote_amounts
-					JOIN ip_quotes ON ip_quotes.quote_id = ip_quote_amounts.quote_id
+                    SELECT quote_status_id,
+                        SUM(quote_total) AS sum_total,
+                        COUNT(*) AS num_total
+                    FROM ip_quote_amounts
+                    JOIN ip_quotes ON ip_quotes.quote_id = ip_quote_amounts.quote_id
                         AND QUARTER(ip_quotes.quote_date_created) = QUARTER(NOW() - INTERVAL 1 QUARTER)
                         AND YEAR(ip_quotes.quote_date_created) = YEAR(NOW())
-					GROUP BY ip_quotes.quote_status_id")->result_array();
+                    GROUP BY ip_quotes.quote_status_id")->result_array();
                 break;
             case 'this-year':
                 $results = $this->db->query("
-					SELECT quote_status_id,
-					    SUM(quote_total) AS sum_total,
-					    COUNT(*) AS num_total
-					FROM ip_quote_amounts
-					JOIN ip_quotes ON ip_quotes.quote_id = ip_quote_amounts.quote_id
+                    SELECT quote_status_id,
+                        SUM(quote_total) AS sum_total,
+                        COUNT(*) AS num_total
+                    FROM ip_quote_amounts
+                    JOIN ip_quotes ON ip_quotes.quote_id = ip_quote_amounts.quote_id
                         AND YEAR(ip_quotes.quote_date_created) = YEAR(NOW())
-					GROUP BY ip_quotes.quote_status_id")->result_array();
+                    GROUP BY ip_quotes.quote_status_id")->result_array();
                 break;
             case 'last-year':
                 $results = $this->db->query("
-					SELECT quote_status_id,
-					    SUM(quote_total) AS sum_total,
-					    COUNT(*) AS num_total
-					FROM ip_quote_amounts
-					JOIN ip_quotes ON ip_quotes.quote_id = ip_quote_amounts.quote_id
+                    SELECT quote_status_id,
+                        SUM(quote_total) AS sum_total,
+                        COUNT(*) AS num_total
+                    FROM ip_quote_amounts
+                    JOIN ip_quotes ON ip_quotes.quote_id = ip_quote_amounts.quote_id
                         AND YEAR(ip_quotes.quote_date_created) = YEAR(NOW() - INTERVAL 1 YEAR)
-					GROUP BY ip_quotes.quote_status_id")->result_array();
+                    GROUP BY ip_quotes.quote_status_id")->result_array();
                 break;
         }
 

--- a/application/modules/quotes/models/Mdl_quote_item_amounts.php
+++ b/application/modules/quotes/models/Mdl_quote_item_amounts.php
@@ -7,10 +7,10 @@ if (! defined('BASEPATH')) {
 /*
  * InvoicePlane
  *
- * @author		InvoicePlane Developers & Contributors
- * @copyright	Copyright (c) 2012 - 2018 InvoicePlane.com
- * @license		https://invoiceplane.com/license.txt
- * @link		https://invoiceplane.com
+ * @author      InvoicePlane Developers & Contributors
+ * @copyright   Copyright (c) 2012 - 2018 InvoicePlane.com
+ * @license     https://invoiceplane.com/license.txt
+ * @link        https://invoiceplane.com
  */
 
 #[AllowDynamicProperties]
@@ -24,26 +24,39 @@ class Mdl_Quote_Item_Amounts extends CI_Model
      * item_total ((item_quantity * item_price) + item_tax_total)
      *
      * @param $item_id
+     * @param $global_discount
      */
-    public function calculate($item_id)
+    public function calculate($item_id, & $global_discount)
     {
         $this->load->model('quotes/mdl_quote_items');
         $item = $this->mdl_quote_items->get_by_id($item_id);
 
+        $item_subtotal = $item->item_quantity * $item->item_price;
+
         // Discounts calculation - since v1.6.3
         if(config_item('taxes_after_discounts'))
         {
-            $item_subtotal = $item->item_quantity * $item->item_price;
             $item_tax_total = $item_subtotal * ($item->item_tax_rate_percent / 100);
             $item_discount_total = $item->item_discount_amount * $item->item_quantity;
             $item_total = $item_subtotal + $item_tax_total - $item_discount_total;
         }
         else
         {
-            $item_subtotal = $item->item_quantity * ($item->item_price - $item->item_discount_amount);
-            $item_tax_total = $item_subtotal * ($item->item_tax_rate_percent / 100);
+            $item_discount = 0.0; // For total & tax calculation after all discounts applied Proportionally by item
+            if($global_discount['percent'] > 0)
+            {
+                $item_discount = round(($item_subtotal * ($global_discount['percent'] / 100)), 2);
+            }
+
+            if($global_discount['amount'] > 0)
+            {
+                $item_discount = round($global_discount['amount'] * ($item_subtotal / $global_discount['items_subtotal']), 2);
+            }
+
+            $global_discount['item'] += $item_discount; // for Mdl_quote_amounts calculation
             $item_discount_total = $item->item_discount_amount * $item->item_quantity;
-            $item_total = $item_subtotal + $item_tax_total;
+            $item_tax_total = ($item_subtotal - $item_discount - $item_discount_total) * ($item->item_tax_rate_percent / 100);
+            $item_total = $item_subtotal - $item_discount - $item_discount_total + $item_tax_total;
         }
 
         $db_array = array(

--- a/application/modules/quotes/models/Mdl_quote_item_amounts.php
+++ b/application/modules/quotes/models/Mdl_quote_item_amounts.php
@@ -34,7 +34,7 @@ class Mdl_Quote_Item_Amounts extends CI_Model
         $item_subtotal = $item->item_quantity * $item->item_price;
 
         // Discounts calculation - since v1.6.3
-        if(config_item('taxes_after_discounts'))
+        if(config_item('legacy_calculation'))
         {
             $item_tax_total = $item_subtotal * ($item->item_tax_rate_percent / 100);
             $item_discount_total = $item->item_discount_amount * $item->item_quantity;

--- a/application/modules/quotes/models/Mdl_quote_tax_rates.php
+++ b/application/modules/quotes/models/Mdl_quote_tax_rates.php
@@ -1,6 +1,7 @@
 <?php
 
-if (! defined('BASEPATH')) {
+if (! defined('BASEPATH'))
+{
     exit('No direct script access allowed');
 }
 
@@ -42,10 +43,20 @@ class Mdl_Quote_Tax_Rates extends Response_Model
 
         $this->load->model('quotes/mdl_quote_amounts');
 
-        $quote_id = $this->input->post('quote_id');
+        if (isset($db_array['quote_id']))
+        {
+            $quote_id = $db_array['quote_id'];
+        }
+        else
+        {
+            $quote_id = $this->input->post('quote_id');
+        }
 
-        if ($quote_id) {
-            $this->mdl_quote_amounts->calculate($quote_id);
+        if ($quote_id)
+        {
+            $global_discount['item'] = $this->mdl_quote_amounts->get_global_discount($quote_id);
+            // Recalculate quote amounts
+            $this->mdl_quote_amounts->calculate($quote_id, $global_discount);
         }
     }
 

--- a/application/modules/quotes/models/Mdl_quotes.php
+++ b/application/modules/quotes/models/Mdl_quotes.php
@@ -66,14 +66,14 @@ class Mdl_Quotes extends Response_Model
         $this->db->select("
             SQL_CALC_FOUND_ROWS
             ip_users.*,
-			ip_clients.*,
-			ip_quote_amounts.quote_amount_id,
-			IFnull(ip_quote_amounts.quote_item_subtotal, '0.00') AS quote_item_subtotal,
-			IFnull(ip_quote_amounts.quote_item_tax_total, '0.00') AS quote_item_tax_total,
-			IFnull(ip_quote_amounts.quote_tax_total, '0.00') AS quote_tax_total,
-			IFnull(ip_quote_amounts.quote_total, '0.00') AS quote_total,
+            ip_clients.*,
+            ip_quote_amounts.quote_amount_id,
+            IFnull(ip_quote_amounts.quote_item_subtotal, '0.00') AS quote_item_subtotal,
+            IFnull(ip_quote_amounts.quote_item_tax_total, '0.00') AS quote_item_tax_total,
+            IFnull(ip_quote_amounts.quote_tax_total, '0.00') AS quote_tax_total,
+            IFnull(ip_quote_amounts.quote_total, '0.00') AS quote_total,
             ip_invoices.invoice_number,
-			ip_quotes.*", false);
+            ip_quotes.*", false);
     }
 
     public function default_order_by()

--- a/application/modules/quotes/views/partial_itemlist_responsive.php
+++ b/application/modules/quotes/views/partial_itemlist_responsive.php
@@ -52,7 +52,7 @@
                                 <div class="input-group-addon"><?php echo get_setting('currency_symbol'); ?></div>
                             </div>
 <?php
-                            if ( ! $taxes_after_discounts)
+                            if ( ! $legacy_calculation)
                             {
                                 $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_input');
                             }
@@ -70,7 +70,7 @@
                                 </select>
                             </div>
 <?php
-                            if ($taxes_after_discounts)
+                            if ($legacy_calculation)
                             {
                                 $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_input');
                             }
@@ -90,7 +90,7 @@
                                 </div>
                             </div>
 <?php
-                            if ( ! $taxes_after_discounts)
+                            if ( ! $legacy_calculation)
                             {
                                 $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_show');
                             }
@@ -104,7 +104,7 @@
                                 </div>
                             </div>
 <?php
-                            if ($taxes_after_discounts)
+                            if ($legacy_calculation)
                             {
                                 $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_show');
                             }
@@ -183,7 +183,7 @@
                                     <div class="input-group-addon"><?php echo get_setting('currency_symbol'); ?></div>
                                 </div>
 <?php
-                                if ( ! $taxes_after_discounts)
+                                if ( ! $legacy_calculation)
                                 {
                                     $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_input', ['item' => $item]);
                                 }
@@ -201,7 +201,7 @@
                                     </select>
                                 </div>
 <?php
-                                if ($taxes_after_discounts)
+                                if ($legacy_calculation)
                                 {
                                     $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_input', ['item' => $item]);
                                 }
@@ -218,7 +218,7 @@
                                     </div>
                                 </div>
 <?php
-                                if ( ! $taxes_after_discounts)
+                                if ( ! $legacy_calculation)
                                 {
                                     $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_show', ['item' => $item]);
                                 }
@@ -232,7 +232,7 @@
                                     </div>
                                 </div>
 <?php
-                                if ($taxes_after_discounts)
+                                if ($legacy_calculation)
                                 {
                                     $this->layout->load_view('layout/partial/itemlist_responsive_item_discount_show', ['item' => $item]);
                                 }
@@ -279,7 +279,7 @@
                 class="amount"><?php echo format_currency($quote->quote_item_subtotal); ?></td>
             </tr>
 <?php
-            if ( ! $taxes_after_discounts)
+            if ( ! $legacy_calculation)
             {
                 $this->layout->load_view('quotes/partial_itemlist_table_quote_discount');
             }
@@ -313,7 +313,7 @@
                 </td>
             </tr>
 <?php
-            if ($taxes_after_discounts)
+            if ($legacy_calculation)
             {
                 $this->layout->load_view('quotes/partial_itemlist_table_quote_discount');
             }

--- a/application/modules/quotes/views/partial_itemlist_table.php
+++ b/application/modules/quotes/views/partial_itemlist_table.php
@@ -46,6 +46,7 @@
                 <div class="input-group">
                     <span class="input-group-addon"><?php _trans('price'); ?></span>
                     <input type="text" name="item_price" class="input-sm form-control amount" value="">
+                    <div class="input-group-addon"><?php echo get_setting('currency_symbol'); ?></div>
                 </div>
             </td>
 <?php
@@ -270,16 +271,16 @@
 
     <div class="col-xs-12 col-md-6 col-md-offset-2 col-lg-4 col-lg-offset-4">
         <table class="table table-bordered text-right">
-            <tr>
-                <td style="width: 40%;"><?php _trans('subtotal'); ?></td>
-                <td style="width: 60%;" class="amount"><?php echo format_currency($quote->quote_item_subtotal); ?></td>
-            </tr>
 <?php
             if ( ! $taxes_after_discounts)
             {
                 $this->layout->load_view('quotes/partial_itemlist_table_quote_discount');
             }
 ?>
+            <tr>
+                <td style="width: 40%;"><?php _trans('subtotal'); ?></td>
+                <td style="width: 60%;" class="amount"><?php echo format_currency($quote->quote_item_subtotal); ?></td>
+            </tr>
             <tr>
                 <td><?php _trans('item_tax'); ?></td>
                 <td class="amount"><?php echo format_currency($quote->quote_item_tax_total); ?></td>

--- a/application/modules/quotes/views/partial_itemlist_table.php
+++ b/application/modules/quotes/views/partial_itemlist_table.php
@@ -11,9 +11,9 @@
 -->
             <th class="amount"><?php _trans('quantity'); ?></th>
             <th class="amount"><?php _trans('price'); ?></th>
-            <?php echo ! $taxes_after_discounts ? '<th class="amount">' . trans('item_discount') . '</th>' : '' ?>
+            <?php echo ! $legacy_calculation ? '<th class="amount">' . trans('item_discount') . '</th>' : '' ?>
             <th class="amount"><?php _trans('tax_rate'); ?></th>
-            <?php echo $taxes_after_discounts ? '<th class="amount">' . trans('item_discount') . '</th>' : '' ?>
+            <?php echo $legacy_calculation ? '<th class="amount">' . trans('item_discount') . '</th>' : '' ?>
 <!--
             <th class="amount"><?php _trans('subtotal'); ?></th>
             <th class="amount"><?php _trans('tax'); ?></th>
@@ -50,7 +50,7 @@
                 </div>
             </td>
 <?php
-            if ( ! $taxes_after_discounts)
+            if ( ! $legacy_calculation)
             {
                 $this->layout->load_view('layout/partial/itemlist_table_item_discount_input');
             }
@@ -69,7 +69,7 @@
                 </div>
             </td>
 <?php
-            if ($taxes_after_discounts)
+            if ($legacy_calculation)
             {
                 $this->layout->load_view('layout/partial/itemlist_table_item_discount_input');
             }
@@ -106,7 +106,7 @@
                 <span name="subtotal" class="amount"></span>
             </td>
 <?php
-            if ( ! $taxes_after_discounts)
+            if ( ! $legacy_calculation)
             {
                 $this->layout->load_view('layout/partial/itemlist_table_item_discount_show');
             }
@@ -116,7 +116,7 @@
                 <span name="item_tax_total" class="amount"></span>
             </td>
 <?php
-            if ($taxes_after_discounts)
+            if ($legacy_calculation)
             {
                 $this->layout->load_view('layout/partial/itemlist_table_item_discount_show');
             }
@@ -159,7 +159,7 @@
                     </div>
                 </td>
 <?php
-                if ( ! $taxes_after_discounts)
+                if ( ! $legacy_calculation)
                 {
                     $this->layout->load_view('layout/partial/itemlist_table_item_discount_input', ['item' => $item]);
                 }
@@ -179,7 +179,7 @@
                     </div>
                 </td>
 <?php
-                if ($taxes_after_discounts)
+                if ($legacy_calculation)
                 {
                     $this->layout->load_view('layout/partial/itemlist_table_item_discount_input', ['item' => $item]);
                 }
@@ -221,7 +221,7 @@
                     </span>
                 </td>
 <?php
-                if ( ! $taxes_after_discounts)
+                if ( ! $legacy_calculation)
                 {
                     $this->layout->load_view('layout/partial/itemlist_table_item_discount_show', ['item' => $item]);
                 }
@@ -233,7 +233,7 @@
                     </span>
                 </td>
 <?php
-                if ($taxes_after_discounts)
+                if ($legacy_calculation)
                 {
                     $this->layout->load_view('layout/partial/itemlist_table_item_discount_show', ['item' => $item]);
                 }
@@ -272,7 +272,7 @@
     <div class="col-xs-12 col-md-6 col-md-offset-2 col-lg-4 col-lg-offset-4">
         <table class="table table-bordered text-right">
 <?php
-            if ( ! $taxes_after_discounts)
+            if ( ! $legacy_calculation)
             {
                 $this->layout->load_view('quotes/partial_itemlist_table_quote_discount');
             }
@@ -311,7 +311,7 @@
                 </td>
             </tr>
 <?php
-            if ($taxes_after_discounts)
+            if ($legacy_calculation)
             {
                 $this->layout->load_view('quotes/partial_itemlist_table_quote_discount');
             }

--- a/application/views/invoice_templates/pdf/InvoicePlane.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane.php
@@ -230,19 +230,19 @@ if($add_table_and_head_for_sums)
 
         <tbody class="invoice-sums">
 
-        <tr>
-            <td class="text-right" colspan="<?php echo $colspan ?>">
-                <?php _trans('subtotal'); ?>
-            </td>
-            <td class="text-right"><?php echo format_currency($invoice->invoice_item_subtotal); ?></td>
-        </tr>
-
 <?php
         if ( ! $taxes_after_discounts)
         {
             discount_global_print_in_pdf($invoice, $show_item_discounts); // in helpers/pdf_helper
         }
 ?>
+
+        <tr>
+            <td class="text-right" colspan="<?php echo $colspan ?>">
+                <?php _trans('subtotal'); ?>
+            </td>
+            <td class="text-right"><?php echo format_currency($invoice->invoice_item_subtotal); ?></td>
+        </tr>
 
         <?php if ($invoice->invoice_item_tax_total > 0) { ?>
             <tr>

--- a/application/views/invoice_templates/pdf/InvoicePlane.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane.php
@@ -231,7 +231,7 @@ if($add_table_and_head_for_sums)
         <tbody class="invoice-sums">
 
 <?php
-        if ( ! $taxes_after_discounts)
+        if ( ! $legacy_calculation)
         {
             discount_global_print_in_pdf($invoice, $show_item_discounts); // in helpers/pdf_helper
         }
@@ -267,7 +267,7 @@ if($add_table_and_head_for_sums)
         <?php } ?>
 
 <?php
-        if ($taxes_after_discounts)
+        if ($legacy_calculation)
         {
             discount_global_print_in_pdf($invoice, $show_item_discounts); // in helpers/pdf_helper
         }

--- a/application/views/invoice_templates/public/InvoicePlane_Web.php
+++ b/application/views/invoice_templates/public/InvoicePlane_Web.php
@@ -190,7 +190,7 @@
                             </tr>
                         <?php endforeach ?>
 
-                        <?php if ( ! $taxes_after_discounts) : ?>
+                        <?php if ( ! $legacy_calculation) : ?>
                         <tr>
                             <td class="no-bottom-border" colspan="4"></td>
                             <td class="amount"><?php _trans('discount'); ?></td>
@@ -233,7 +233,7 @@
                             </tr>
                         <?php endforeach ?>
 
-                        <?php if ($taxes_after_discounts) : ?>
+                        <?php if ($legacy_calculation) : ?>
                         <tr>
                             <td class="no-bottom-border" colspan="4"></td>
                             <td class="amount"><?php _trans('discount'); ?></td>

--- a/application/views/invoice_templates/public/InvoicePlane_Web.php
+++ b/application/views/invoice_templates/public/InvoicePlane_Web.php
@@ -190,12 +190,6 @@
                             </tr>
                         <?php endforeach ?>
 
-                        <tr>
-                            <td colspan="4"></td>
-                            <td class="amount"><?php _trans('subtotal'); ?>:</td>
-                            <td class="amount"><?php echo format_currency($invoice->invoice_item_subtotal); ?></td>
-                        </tr>
-
                         <?php if ( ! $taxes_after_discounts) : ?>
                         <tr>
                             <td class="no-bottom-border" colspan="4"></td>
@@ -211,6 +205,12 @@
                             </td>
                         </tr>
                         <?php endif ?>
+
+                        <tr>
+                            <td colspan="4"></td>
+                            <td class="amount"><?php _trans('subtotal'); ?>:</td>
+                            <td class="amount"><?php echo format_currency($invoice->invoice_item_subtotal); ?></td>
+                        </tr>
 
                         <?php if ($invoice->invoice_item_tax_total > 0) { ?>
                             <tr>

--- a/application/views/quote_templates/pdf/InvoicePlane.php
+++ b/application/views/quote_templates/pdf/InvoicePlane.php
@@ -189,7 +189,7 @@ if($add_table_and_head_for_sums)
         <tbody class="invoice-sums">
 
 <?php
-        if ( ! $taxes_after_discounts)
+        if ( ! $legacy_calculation)
         {
             discount_global_print_in_pdf($quote, $show_item_discounts, 'quote'); // in helpers/pdf_helper
         }
@@ -225,7 +225,7 @@ if($add_table_and_head_for_sums)
         <?php endforeach ?>
 
 <?php
-        if ($taxes_after_discounts)
+        if ($legacy_calculation)
         {
             discount_global_print_in_pdf($quote, $show_item_discounts, 'quote'); // in helpers/pdf_helper
         }

--- a/application/views/quote_templates/pdf/InvoicePlane.php
+++ b/application/views/quote_templates/pdf/InvoicePlane.php
@@ -188,19 +188,19 @@ if($add_table_and_head_for_sums)
 ?>
         <tbody class="invoice-sums">
 
-        <tr>
-            <td class="text-right" colspan="<?php echo $colspan ?>">
-                <?php _trans('subtotal'); ?>
-            </td>
-            <td class="text-right"><?php echo format_currency($quote->quote_item_subtotal); ?></td>
-        </tr>
-
 <?php
         if ( ! $taxes_after_discounts)
         {
             discount_global_print_in_pdf($quote, $show_item_discounts, 'quote'); // in helpers/pdf_helper
         }
 ?>
+
+        <tr>
+            <td class="text-right" colspan="<?php echo $colspan ?>">
+                <?php _trans('subtotal'); ?>
+            </td>
+            <td class="text-right"><?php echo format_currency($quote->quote_item_subtotal); ?></td>
+        </tr>
 
         <?php if ($quote->quote_item_tax_total > 0) { ?>
             <tr>

--- a/application/views/quote_templates/public/InvoicePlane_Web.php
+++ b/application/views/quote_templates/public/InvoicePlane_Web.php
@@ -186,7 +186,7 @@
                             </tr>
                         <?php endforeach ?>
 
-                        <?php if ( ! $taxes_after_discounts) : ?>
+                        <?php if ( ! $legacy_calculation) : ?>
                         <tr>
                             <td class="no-bottom-border" colspan="4"></td>
                             <td class="amount"><?php _trans('discount'); ?></td>
@@ -229,7 +229,7 @@
                             </tr>
                         <?php endforeach ?>
 
-                        <?php if ($taxes_after_discounts) : ?>
+                        <?php if ($legacy_calculation) : ?>
                         <tr>
                             <td class="no-bottom-border" colspan="4"></td>
                             <td class="amount"><?php _trans('discount'); ?></td>

--- a/application/views/quote_templates/public/InvoicePlane_Web.php
+++ b/application/views/quote_templates/public/InvoicePlane_Web.php
@@ -185,11 +185,6 @@
                                 <td class="amount"><?php echo format_currency($item->item_subtotal); ?></td>
                             </tr>
                         <?php endforeach ?>
-                        <tr>
-                            <td colspan="4"></td>
-                            <td class="amount"><?php _trans('subtotal'); ?>:</td>
-                            <td class="amount"><?php echo format_currency($quote->quote_item_subtotal); ?></td>
-                        </tr>
 
                         <?php if ( ! $taxes_after_discounts) : ?>
                         <tr>
@@ -206,6 +201,12 @@
                             </td>
                         </tr>
                         <?php endif ?>
+
+                        <tr>
+                            <td colspan="4"></td>
+                            <td class="amount"><?php _trans('subtotal'); ?>:</td>
+                            <td class="amount"><?php echo format_currency($quote->quote_item_subtotal); ?></td>
+                        </tr>
 
                         <?php if ($quote->quote_item_tax_total > 0) { ?>
                             <tr>

--- a/ipconfig.php.example
+++ b/ipconfig.php.example
@@ -34,11 +34,11 @@ DB_PORT=
 SESS_EXPIRATION=864000
 SESS_MATCH_IP=true
 
-# Calculation of discounts - Since 1.6.3
-# Set to true if taxes applied before discounts (Default. Same as previous v1.6.3)
-# Set to false if taxes applied after discounts
-# Set to false if use e-invoices (Zugferd2, Factur-x or en-16931). Important to valid xml (embed in pdf) discount calculation amounts.
-TAXES_AFTER_DISCOUNTS=true
+# Amounts Calculation - Since 1.6.3
+# Set to true  to conserve same calculation as previous v1.6.3 (Default)
+# Set to false to calculate all discounts with item subtotal and calculate all taxes with discounted item subtotal
+# Set to false if use e-invoices (Zugferd2, Factur-x or en-16931). Important to valid xml (embed in pdf). New calculation amounts.
+LEGACY_CALCULATION=true
 
 # Enable the deletion of invoices
 ENABLE_INVOICE_DELETION=false


### PR DESCRIPTION
## Description

### Semantic: ipconfig : TAXES_AFTER_DISCOUNTS to LEGACY_CALCULATION

### Apply All discounts on item subtotal (Zugferd & Factur-X valid)

+ Return to item subtotal = quantity * price

+ Calculate item discount on item subtotal

+ Calculate global (Q&I) discount on item subtotal

+ All taxes calculation with item subtotal discounted (wip)

---

global (Q&I) discount dispatched Proportionally by item
And not apply in Mdl_invoice_amount->calculate_discount()

---

In mdl tax rate (invoice) removed:
$this->mdl_invoice_amounts->calculate_invoice_taxes($invoice_id);
It Called in calculate (in test, same as quote. Maybe old)

Fix missing currency_symbol on price (Add new item)
In partial_itemlist_table (quote & invoice)

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [ ] Bugfix
  * [x] Improvement of an existing (new) Feature
  * [ ] New Feature
