### PR TITLE
Fix: Stripe online payments being wrongfully marked as successful

### DIFF
--- a/application/language/english/ip_lang.php
+++ b/application/language/english/ip_lang.php
@@ -747,3 +747,9 @@ $lang = [
     'true'  => 'True',
     'false' => 'False',
 ];
+
+// Stripe online payment messages
+$lang['online_payment_payment_successful'] = 'Payment successful for invoice %s';
+$lang['online_payment_payment_failed'] = 'Payment failed';
+$lang['online_payment_incomplete'] = 'Payment was not completed. Stripe session status: %s';
+$lang['online_payment_transaction_not_completed'] = 'Transaction not completed or canceled';

--- a/application/modules/guest/controllers/gateways/Stripe.php
+++ b/application/modules/guest/controllers/gateways/Stripe.php
@@ -87,8 +87,8 @@ public function callback($checkout_session_id)
 
         // 3) DEBUG LOGGING (optional but recommended)
         //    Make sure your PHP error log is set up (log_errors=On in php.ini)
-        error_log("Stripe callback reached. Checkout session id: " . $checkout_session_id);
-        error_log("Stripe session payment_status: " . $session->payment_status);
+        log_message('debug', 'Stripe callback reached. Checkout session id: ' . $checkout_session_id);
+		log_message('debug', 'Stripe session payment_status: ' . $session->payment_status);
 
         // 4) Check the session status before marking paid
         if ($session->payment_status === 'paid') {
@@ -134,10 +134,10 @@ public function callback($checkout_session_id)
             // a) Show an error or “payment not completed” notice to the user
             //    (Adjust text as you wish)
             $this->session->set_flashdata('alert_error',
-                sprintf(trans('online_payment_payment_failed')) .
-                '<br/>' .
-                'Payment was not completed. Stripe session status: ' . $session->payment_status
-            );
+    sprintf(trans('online_payment_payment_failed')) . '<br/>' .
+    sprintf(trans('online_payment_incomplete'), $session->payment_status)
+);
+
             $this->session->keep_flashdata('alert_error');
 
             // b) Optionally record a “failed” or “canceled” merchant response
@@ -147,7 +147,7 @@ public function callback($checkout_session_id)
                 'merchant_response_successful' => false,
                 'merchant_response_date'       => date('Y-m-d'),
                 'merchant_response_driver'     => 'stripe',
-                'merchant_response'            => 'Transaction not completed or canceled',
+                'merchant_response' => trans('online_payment_transaction_not_completed'),
                 'merchant_response_reference'  => 'payment intent ID: ' . $session->payment_intent,
             ]);
 
@@ -157,7 +157,7 @@ public function callback($checkout_session_id)
 
     } catch (Error|Exception|ErrorException $e) {
         // LOG THE ERROR so you can debug
-        error_log("Stripe callback exception: " . $e->getMessage());
+        log_message('error', 'Stripe callback exception: ' . $e->getMessage());
 
         // Show the user an error message
         $this->session->set_flashdata(


### PR DESCRIPTION
## Description
During checkout with Stripe, if the user selected a payment method that would redirect them out of InvoicePlane (ex. Revolut Pay, Klarna, etc..) the user could then cancel the transaction by clicking the "Back" or "Cancel" buttons and InvoicePlane would mark the invoice as paid due to incorrect callback handling.

## Related Issue
- https://github.com/InvoicePlane/InvoicePlane/issues/1208

## Motivation and Context
Fixes the very important open issue listed above.

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature
