### PR TITLE
Add pagination to invoice and quote templates

### DIFF
--- a/application/views/invoice_templates/pdf/InvoicePlane - overdue.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane - overdue.php
@@ -277,14 +277,20 @@
 
 <watermarktext content="<?php _trans('overdue'); ?>" alpha="0.3" />
 
-<footer>
+<div class="invoice-terms">
     <?php if ($invoice->invoice_terms) : ?>
         <div class="notes">
             <b><?php _trans('terms'); ?></b><br/>
             <?php echo nl2br(htmlsc($invoice->invoice_terms)); ?>
         </div>
     <?php endif; ?>
-</footer>
+</div>
+
+<htmlpagefooter name="footer">
+    <footer>
+        <?php _trans('page'); ?> {PAGENO} / {nbpg}
+    </footer>
+</htmlpagefooter>
 
 </body>
 </html>

--- a/application/views/invoice_templates/pdf/InvoicePlane - paid.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane - paid.php
@@ -249,14 +249,20 @@
 
 <watermarktext content="<?php _trans('paid'); ?>" alpha="0.3" />
 
-<footer>
+<div class="invoice-terms">
     <?php if ($invoice->invoice_terms) : ?>
         <div class="notes">
             <b><?php _trans('terms'); ?></b><br/>
             <?php echo nl2br(htmlsc($invoice->invoice_terms)); ?>
         </div>
     <?php endif; ?>
-</footer>
+</div>
+
+<htmlpagefooter name="footer">
+    <footer>
+        <?php _trans('page'); ?> {PAGENO} / {nbpg}
+    </footer>
+</htmlpagefooter>
 
 </body>
 </html>

--- a/application/views/invoice_templates/pdf/InvoicePlane.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane.php
@@ -274,14 +274,20 @@
     </table>
 <?php } ?>
 
-<footer>
+<div class="invoice-terms">
     <?php if ($invoice->invoice_terms) { ?>
         <div class="notes">
             <b><?php _trans('terms'); ?></b><br/>
             <?php echo nl2br(htmlsc($invoice->invoice_terms)); ?>
         </div>
     <?php } ?>
-</footer>
+</div>
+
+<htmlpagefooter name="footer">
+    <footer>
+        <?php _trans('page'); ?> {PAGENO} / {nbpg}
+    </footer>
+</htmlpagefooter>
 
 </body>
 </html>

--- a/application/views/quote_templates/pdf/InvoicePlane.php
+++ b/application/views/quote_templates/pdf/InvoicePlane.php
@@ -224,14 +224,20 @@
     </table>
 </main>
 
-<footer>
+<div class="invoice-terms">
     <?php if ($quote->notes) : ?>
         <div class="notes">
             <b><?php _trans('notes'); ?></b><br/>
             <?php echo nl2br(htmlsc($quote->notes)); ?>
         </div>
     <?php endif; ?>
-</footer>
+</div>
+
+<htmlpagefooter name="footer">
+    <footer>
+        <?php _trans('page'); ?> {PAGENO} / {nbpg}
+    </footer>
+</htmlpagefooter>
 
 </body>
 </html>

--- a/assets/invoiceplane/sass/templates.scss
+++ b/assets/invoiceplane/sass/templates.scss
@@ -133,11 +133,20 @@ img#invoice-qr-code {
   height: auto;
 }
 
-footer {
+.invoice-terms {
   color: $color_base_lighter;
   width: 100%;
   border-top: 2px solid $color_base_lighter;
   padding: 8px 0;
+}
+
+@page {
+  footer: html_footer;
+}
+
+.footer {
+  text-align: center;
+  font-size: 12px;
 }
 
 .text-right {


### PR DESCRIPTION
## Description

This will add pagination to the default invoice and quote pdf templates

![image](https://github.com/user-attachments/assets/61dd7f50-25cd-4031-9ec4-cbf7ccccab89)

By doing it this way, one could still modify the template to remove pagination or move it to a different place inside the document.

## Related Issue

Fixes https://github.com/InvoicePlane/InvoicePlane/issues/1234

## Motivation and Context
<!--- Why would you like this change? Does it solve a provlem or is it an improvement? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Pull Request Checklist

  * [ ] My code follows the code formatting guidelines.
  * [x] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [ ] Bugfix
  * [ ] Improvement of an existing Feature
  * [x] New Feature
