### PR TITLE
fix: Client overview shows wrong e-Invoicing state

### DIFF
--- a/application/modules/clients/controllers/Clients.php
+++ b/application/modules/clients/controllers/Clients.php
@@ -47,6 +47,16 @@ class Clients extends Admin_Controller
         $this->mdl_clients->with_total_balance()->paginate(site_url('clients/status/' . $status), $page);
         $clients = $this->mdl_clients->result();
 
+        $req_einvoicing = get_setting('einvoicing');
+        if ($req_einvoicing) {
+            $this->load->helper('e-invoice'); // eInvoicing++
+
+            foreach ($clients as &$client) {
+                $client = $this->check_client_einvoice_active($client);
+            }
+            unset($client);
+        }
+
         $this->layout->set(
             [
                 'records'            => $clients,
@@ -233,23 +243,7 @@ class Clients extends Admin_Controller
         $req_einvoicing = get_setting('einvoicing');
         if ($req_einvoicing) {
             $this->load->helper('e-invoice'); // eInvoicing++
-            // Get a check of filled Required (client and users) fields for eInvoicing
-            $req_einvoicing = get_req_fields_einvoice($client);
-
-            // Update active eInvoicing client
-            $o = $client->client_einvoicing_active;
-            if ( ! empty($client->client_einvoicing_version) && $req_einvoicing->clients[$client->client_id]->einvoicing_empty_fields == 0) {
-                $client->client_einvoicing_active = 1; // update view
-            } else {
-                $client->client_einvoicing_active = 0; // update view
-            }
-
-            // Update db if need
-            if ($o != $client->client_einvoicing_active) {
-                $this->db->where('client_id', $client_id);
-                $this->db->set('client_einvoicing_active', $client->client_einvoicing_active);
-                $this->db->update('ip_clients');
-            }
+            $client = $this->check_client_einvoice_active($client);
         }
 
         // Change page only for one url (tab) system
@@ -341,5 +335,27 @@ class Clients extends Admin_Controller
             fn ($clientTitleEnum) => $clientTitleEnum->value,
             ClientTitleEnum::cases()
         );
+    }
+
+    private function check_client_einvoice_active($client) {
+        // Get a check of filled Required (client and users) fields for eInvoicing
+        $req_einvoicing = get_req_fields_einvoice($client);
+
+        // Update active eInvoicing client
+        $o = $client->client_einvoicing_active;
+        if ( ! empty($client->client_einvoicing_version) && $req_einvoicing->clients[$client->client_id]->einvoicing_empty_fields == 0) {
+            $client->client_einvoicing_active = 1; // update view
+        } else {
+            $client->client_einvoicing_active = 0; // update view
+        }
+
+        // Update db if need
+        if ($o != $client->client_einvoicing_active) {
+            $this->db->where('client_id', $client->client_id);
+            $this->db->set('client_einvoicing_active', $client->client_einvoicing_active);
+            $this->db->update('ip_clients');
+        }
+
+        return $client;
     }
 }


### PR DESCRIPTION
# Pull Request Checklist

## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.
- [ ] I included relevant documentation updates if necessary.
- [ ] I have an accompanying issue ID for this pull request.

---

## Description
In 1.6.3 we got a new Column in the client overview that shows the current state if invoicing is active. This column shows not the correct value if there is an issue in the client data and e-Invoice can't be active. If you visit the client detail, the data automatic correct by itself.

---

## Related Issue(s)
It is very tedious to go into every customer detail to have the status adjusted automatically. The initial view of client list should automatically show the right state based on client data that the user knows how data must be corrected.

---

## Motivation and Context
Give the user of Invoice Plane a better Workflow to change her current data to get fast e-Invoice ready

---

## Issue Type (Check one or more)
- [ ] Bugfix
- [x] Improvement of an existing feature
- [ ] New feature

