### PR TITLE
Update number_helper.php to avoid empty string warning

### DIFF
--- a/application/helpers/number_helper.php
+++ b/application/helpers/number_helper.php
@@ -93,7 +93,11 @@ function standardize_amount($amount): float|int|string|array|false|null
             $amount[mb_strrpos($amount, '.')] = ','; // Replace last position of dot to comma
         }
 
-        $amount = strtr($amount, [$thousands_separator => '', $decimal_point => '.']);
+        if ($thousands_separator) {
+            $amount = strtr($amount, [$thousands_separator => '', $decimal_point => '.']);
+        } else {
+            $amount = strtr($amount, [$decimal_point => '.']);
+        }
     }
 
     return $amount;


### PR DESCRIPTION
In `standardize_amount`, `$thousands_separator` is read from the settings, and if it is empty, the error occurs. If I understand correctly, the settings value is not changed directly via UI, but depends on the chosen `number_format`. It is set in `settings.php`, line 78, just below `// Set thousands_separator and decimal_point according to number_format`. So `standardize_amount ` produces the error if a compact `number_format` is used, which resets the thousands separator settings value to an empty string. So the solution would be to simply not use the `thousands_separator` setting, if it is empty

# Pull Request Checklist
## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [ ] I selected the appropriate branch for this PR.
- [ ] I have rebased my changes on top of the selected branch.
- [ ] I included relevant documentation updates if necessary.
- [x] I have an accompanying issue ID for this pull request.

---

## Description
If `thousands_separator` is empty in the settings, it doesn't need to be replaced with an empty string.

---

## Related Issue(s)
Fixes #1301
Fixes #1297
Explains #1300

---

## Motivation and Context
Avoids error messages if a compact number format is used.

---

## Issue Type (Check one or more)
- [x] Bugfix
- [ ] Improvement of an existing feature
- [ ] New feature

---

*Thank you for your contribution to InvoicePlane! We appreciate your time and effort.*
