### PR TITLE
[IP-1333]: Add default_order_by method for recurring invoices

### DIFF
--- a/application/modules/invoices/models/Mdl_invoices_recurring.php
+++ b/application/modules/invoices/models/Mdl_invoices_recurring.php
@@ -61,6 +61,11 @@ class Mdl_Invoices_Recurring extends Response_Model
             IF(recur_end_date > date(NOW()) OR recur_end_date IS NULL, "active", "inactive") AS recur_status', false);
     }
 
+    public function default_order_by()
+    {
+      $this->db->order_by( 'recur_status ASC, recur_next_date ASC' );
+    }
+    
     public function default_join()
     {
         $this->db->join('ip_invoices', 'ip_invoices.invoice_id = ip_invoices_recurring.invoice_id');


### PR DESCRIPTION
refs #1333 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Introduced a consistent default sort order for recurring invoices, organizing lists by status and next run date. This improves readability and predictability across views that display recurring invoices.
  - Applies to list views and any screens showing recurring schedules.
  - No action required; sorting is applied automatically for a clearer overview of upcoming billing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->