### PR TITLE
1340: Wrong quote/invoice guest download attachment button default te…

### DIFF
--- a/application/views/invoice_templates/public/InvoicePlane_Web.php
+++ b/application/views/invoice_templates/public/InvoicePlane_Web.php
@@ -368,7 +368,7 @@ if (count($attachments) > 0) {
                                 <tr class="attachments">
                                     <td><?php echo $attachment['name']; ?></td>
                                     <td>
-                                        <a href="<?php echo site_url('guest/get/attachment/' . $attachment['fullname']); ?>"
+                                        <a href="<?php echo site_url('guest/get/get_file/' . $attachment['fullname']); ?>"
                                            class="btn btn-primary btn-sm">
                                             <i class="fa fa-download"></i> <?php _trans('download') ?>
                                         </a>

--- a/application/views/quote_templates/public/InvoicePlane_Web.php
+++ b/application/views/quote_templates/public/InvoicePlane_Web.php
@@ -306,7 +306,7 @@ if (count($attachments) > 0) {
                                     <tr class="attachments">
                                         <td><?php echo $attachment['name']; ?></td>
                                         <td>
-                                            <a href="<?php echo site_url('guest/get/attachment/' . $attachment['fullname']); ?>"
+                                            <a href="<?php echo site_url('guest/get/get_file/' . $attachment['fullname']); ?>"
                                                class="btn btn-primary btn-sm">
                                                 <i class="fa fa-download"></i> <?php _trans('download') ?>
                                             </a>


### PR DESCRIPTION
@SimplyPancake I got around to fixing it again, can you take another look please?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected attachment download links in invoice views to use the current download route, ensuring files open and download reliably.
  * Corrected attachment download links in quote views to use the current download route, ensuring files open and download reliably.
  * No visual changes; existing buttons/links remain the same while routing behind them has been updated for consistency and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->