### PR TITLE
1322: Show open invoices on guest index

### DIFF
--- a/application/modules/guest/views/index.php
+++ b/application/modules/guest/views/index.php
@@ -48,7 +48,7 @@ if ($overdue_invoices) {
         <div class="panel-body no-padding">
 
 <?php
-if ($overdue_invoices) {
+if ($open_invoices) {
     echo $this->layout->load_view('guest/partial_invoices_table', ['invoices' => $open_invoices]);
 } else {
 ?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - The Open Invoices panel now correctly displays open invoices instead of overdue ones.
  - The invoices table in this panel is populated from the appropriate data source, ensuring accurate items and counts.
  - The empty state now consistently shows the “No open invoices” message when applicable.
  - Overall, the dashboard’s Open Invoices section reflects the correct data, improving clarity and reducing confusion for users viewing their current outstanding invoices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->