### PR TITLE
prevent the format_number returning other than numbers

### DIFF
--- a/application/helpers/number_helper.php
+++ b/application/helpers/number_helper.php
@@ -52,7 +52,7 @@ function format_amount($amount = null)
         $thousands_separator = $CI->mdl_settings->setting('thousands_separator');
         $decimal_point       = $CI->mdl_settings->setting('decimal_point');
         $decimals            = $decimal_point ? (int) $CI->mdl_settings->setting('tax_rate_decimal_places') : 0;
-        $amount              = is_numeric($amount) ? $amount : standardize_amount($amount);
+        $amount              = (float) (is_numeric($amount) ? $amount : standardize_amount($amount));
 
         return number_format($amount, $decimals, $decimal_point, $thousands_separator);
     }


### PR DESCRIPTION
Fixes issue #1367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved numeric type handling in amount formatting to ensure more reliable and consistent calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->