### PR TITLE
Fix email address verification to allow both comma and semicolon separators

### DIFF
--- a/application/helpers/mailer_helper.php
+++ b/application/helpers/mailer_helper.php
@@ -220,7 +220,7 @@ function email_quote_status(string $quote_id, $status)
  */
 function validate_email_address(string $email): bool
 {
-    $emails = (mb_strpos($email, ',')) ? explode(',', $email) : explode(';', $email);
+    $emails = (str_contains($email, ',')) ? explode(',', $email) : explode(';', $email);
 
     foreach ($emails as $emailItem) {
         if ( ! filter_var($emailItem, FILTER_VALIDATE_EMAIL)) {

--- a/application/modules/mailer/helpers/phpmailer_helper.php
+++ b/application/modules/mailer/helpers/phpmailer_helper.php
@@ -98,7 +98,7 @@ function phpmail_send(
     }
 
     // Allow multiple recipients delimited by comma or semicolon
-    $to = (mb_strpos($to, ',')) ? explode(',', $to) : explode(';', $to);
+    $to = (str_contains($to, ',')) ? explode(',', $to) : explode(';', $to);
 
     // Add the addresses
     foreach ($to as $address) {
@@ -107,7 +107,7 @@ function phpmail_send(
 
     if ($cc) {
         // Allow multiple CC's delimited by comma or semicolon
-        $cc = (mb_strpos($cc, ',')) ? explode(',', $cc) : explode(';', $cc);
+        $cc = (str_contains($cc, ',')) ? explode(',', $cc) : explode(';', $cc);
 
         // Add the CC's
         foreach ($cc as $address) {
@@ -117,7 +117,7 @@ function phpmail_send(
 
     if ($bcc) {
         // Allow multiple BCC's delimited by comma or semicolon
-        $bcc = (mb_strpos($bcc, ',')) ? explode(',', $bcc) : explode(';', $bcc);
+        $bcc = (str_contains($bcc, ',')) ? explode(',', $bcc) : explode(';', $bcc);
         // Add the BCC's
         foreach ($bcc as $address) {
             $mail->addBCC($address);


### PR DESCRIPTION
Allow both comma and semicolon to be valid separators for $emails to be in sync with phpmail_send() function.

# Pull Request Checklist

Please check the following steps before submitting your PR. If any items are incomplete, consider marking it as `[WIP]` (Work in Progress).

## Checklist
- [X] My code follows the code formatting guidelines.
- [X] I have tested my changes locally.
- [X] I selected the appropriate branch for this PR.
- [X] I have rebased my changes on top of the selected branch.
- [X] I included relevant documentation updates if necessary.
- [X] I have an accompanying issue ID for this pull request.

---

## Description
Current implementation of email verification only allowed for comma separated email lists. While phpmail_send function allowed both comma and semicolon separators.

---

## Related Issue(s)
List any related issues or discussions. If applicable, link to an accompanying thread on the forums.
Fixes #1307

---

## Motivation and Context
Why was this change necessary? Does it solve a problem or improve an existing feature? If this PR fixes an open issue, link to it here.

---

## Issue Type (Check one or more)
- [X] Bugfix
- [X] Improvement of an existing feature
- [ ] New feature

---

## Screenshots (If Applicable)
Attach relevant screenshots that demonstrate your changes.

---

*Thank you for your contribution to InvoicePlane! We appreciate your time and effort.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email handling now accepts both comma- and semicolon-separated lists across To, CC, and BCC fields, and email validation recognizes either separator for multiple addresses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->