### PR TITLE
[IP-1502]: added invoicing email to client

### DIFF
--- a/application/language/english/ip_lang.php
+++ b/application/language/english/ip_lang.php
@@ -202,6 +202,7 @@ $lang = [
     'elements'                                     => 'Elements',
     'email'                                        => 'Email',
     'email_address'                                => 'Email Address',
+    'invoice_email_address'                        => 'Invoice Email Address',
     'email_invoice'                                => 'Email Invoice',
     'email_not_configured'                         => 'Before you can send Email, you have to configure your Email settings in the System Settings area.',
     'email_pdf_attachment'                         => 'Attach Quote/Invoice on Email?',

--- a/application/modules/clients/models/Mdl_clients.php
+++ b/application/modules/clients/models/Mdl_clients.php
@@ -89,6 +89,9 @@ class Mdl_Clients extends Response_Model
             'client_email' => [
                 'field' => 'client_email',
             ],
+            'client_invoice_email' => [
+                'field' => 'client_invoice_email',
+            ],
             'client_web' => [
                 'field' => 'client_web',
             ],

--- a/application/modules/clients/views/form.php
+++ b/application/modules/clients/views/form.php
@@ -296,6 +296,15 @@ foreach ($custom_fields as $custom_field) {
                         </div>
 
                         <div class="form-group">
+                            <label for="client_invoice_email"><?php _trans('invoice_email_address'); ?></label>
+
+                            <div class="controls">
+                                <input type="text" name="client_invoice_email" id="client_invoice_email" class="form-control"
+                                       value="<?php echo $this->mdl_clients->form_value('client_invoice_email', true); ?>">
+                            </div>
+                        </div>
+
+                        <div class="form-group">
                             <label for="client_web"><?php _trans('web_address'); ?></label>
 
                             <div class="controls">

--- a/application/modules/clients/views/view.php
+++ b/application/modules/clients/views/view.php
@@ -168,6 +168,12 @@ $colClass = 'col-xs-12 col-sm-6' . ($req_einvoicing ? ' col-lg-4' : '');
                                     <td><?php _auto_link($client->client_email, 'email'); ?></td>
                                 </tr>
 <?php } ?>
+<?php if ($client->client_invoice_email) { ?>
+                                <tr>
+                                    <th><?php _trans('invoice_email_address'); ?></th>
+                                    <td><?php _auto_link($client->client_invoice_email, 'email'); ?></td>
+                                </tr>
+<?php } ?>
 <?php if ($client->client_phone) { ?>
                                 <tr>
                                     <th><?php _trans('phone'); ?></th>

--- a/application/modules/invoices/controllers/Cron.php
+++ b/application/modules/invoices/controllers/Cron.php
@@ -145,7 +145,7 @@ class Cron extends Base_Controller
                     : $tpl->email_template_subject;
 
                 $pdf_template = $tpl->email_template_pdf_template;
-                $to           = $invoice->client_email;
+                $to           = $invoice->client_invoice_email ?: $invoice->client_email;
                 $cc           = $tpl->email_template_cc;
                 $bcc          = $tpl->email_template_bcc;
 

--- a/application/modules/mailer/views/invoice.php
+++ b/application/modules/mailer/views/invoice.php
@@ -76,7 +76,7 @@ if (($invoice->client_einvoicing_version ?? '') != '' && ($invoice->client_einvo
                 <div class="form-group">
                     <label for="to_email"><?php _trans('to_email'); ?></label>
                     <input type="email" multiple name="to_email" id="to_email" class="form-control" required
-                           value="<?php echo $invoice->client_email; ?>">
+                           value="<?php echo $invoice->client_invoice_email ?: $invoice->client_email; ?>">
                 </div>
 
                 <hr>

--- a/application/modules/setup/sql/042_1.7.1.sql
+++ b/application/modules/setup/sql/042_1.7.1.sql
@@ -1,0 +1,3 @@
+# Feature Request IP-1502 Add invoice email address for clients
+ALTER TABLE `ip_clients`
+    ADD COLUMN client_invoice_email VARCHAR(100) DEFAULT NULL AFTER `client_email`,


### PR DESCRIPTION
# Pull Request Checklist

## Checklist
- [X] My code follows the code formatting guidelines.
- [X] I have tested my changes locally.
- [X] I selected the appropriate branch for this PR.
- [X] I have rebased my changes on top of the selected branch.
- [X] I included relevant documentation updates if necessary.
- [X] I have an accompanying issue ID for this pull request.

---

## Description
Added an additional invoicing email address for clients

---

## Related Issue(s)
#1502

---

## Motivation and Context
Saves time when invoicing

---

## Issue Type (Check one or more)
- [ ] Bugfix
- [ ] Improvement of an existing feature
- [X] New feature

---

## Screenshots (If Applicable)
<img width="843" height="324" alt="Screenshot 2026-04-03 at 23 33 22" src="https://github.com/user-attachments/assets/9f360037-09e0-4010-b1da-f1022ed7e99f" />
<img width="1417" height="147" alt="Screenshot 2026-04-03 at 23 33 37" src="https://github.com/user-attachments/assets/6297305c-8a08-4186-9cf0-01cc86ec8bcc" />


---

*Thank you for your contribution to InvoicePlane! We appreciate your time and effort.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for separate invoice email addresses on client profiles. Users can now specify a dedicated email address for receiving invoices, which takes precedence over the primary email address when sending invoice communications. If no invoice email is configured, the system defaults to the client's primary email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->