### PR TITLE
Add CI3+MX integration test harness (full index.php lifecycle)

### DIFF
--- a/phpunit.integration.xml
+++ b/phpunit.integration.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    bootstrap="tests/Integration/bootstrap.php"
+    colors="true"
+    backupGlobals="false"
+    backupStaticProperties="false"
+>
+    <testsuites>
+        <testsuite name="CI3 MX Integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Integration/CiIntegrationTestCase.php
+++ b/tests/Integration/CiIntegrationTestCase.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Tests\Integration\Support\HttpResponse;
+
+abstract class CiIntegrationTestCase extends TestCase
+{
+    protected function get(string $uri, array $query = []): HttpResponse
+    {
+        return $this->request('GET', $uri, $query, []);
+    }
+
+    protected function post(string $uri, array $data = [], array $query = []): HttpResponse
+    {
+        return $this->request('POST', $uri, $query, $data);
+    }
+
+    protected function request(string $method, string $uri, array $query = [], array $post = []): HttpResponse
+    {
+        $payload = [
+            'method' => strtoupper($method),
+            'uri'    => '/' . mb_ltrim($uri, '/'),
+            'query'  => $query,
+            'post'   => $post,
+        ];
+
+        $command = sprintf('php %s', escapeshellarg(dirname(__DIR__) . '/Integration/bin/request.php'));
+
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open(
+            $command,
+            $descriptorSpec,
+            $pipes,
+            dirname(__DIR__, 2),
+            [
+                'CI_TEST_REQUEST' => base64_encode((string) json_encode($payload, JSON_THROW_ON_ERROR)),
+            ],
+        );
+
+        if ( ! is_resource($process)) {
+            throw new RuntimeException('Unable to start request process.');
+        }
+
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+
+        $exitCode = proc_close($process);
+
+        preg_match('/__CI_TEST_RESULT_START__(.*?)__CI_TEST_RESULT_END__/s', $stdout ?: '', $matches);
+
+        if ($exitCode !== 0 || ! isset($matches[1])) {
+            throw new RuntimeException(
+                "CI request runner failed for [{$payload['method']}] {$payload['uri']}" . PHP_EOL
+                . 'Exit code: ' . $exitCode . PHP_EOL
+                . 'STDOUT: ' . ($stdout ?: '[empty]') . PHP_EOL
+                . 'STDERR: ' . ($stderr ?: '[empty]')
+            );
+        }
+
+        $result = json_decode(base64_decode($matches[1], true), true, 512, JSON_THROW_ON_ERROR);
+
+        if (($result['exception'] ?? null) !== null) {
+            throw new RuntimeException(
+                "Unhandled exception during CI request [{$payload['method']}] {$payload['uri']}: "
+                . $result['exception']
+            );
+        }
+
+        return new HttpResponse(
+            $result['output'] ?? '',
+            (int) ($result['status'] ?? 200),
+            $result['headers'] ?? [],
+            (string) $stderr,
+        );
+    }
+}

--- a/tests/Integration/HmvcRouteLifecycleTest.php
+++ b/tests/Integration/HmvcRouteLifecycleTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\Attributes\Test;
+
+class HmvcRouteLifecycleTest extends CiIntegrationTestCase
+{
+    #[Test]
+    public function it_executes_clients_index_through_full_ci_and_mx_lifecycle(): void
+    {
+        $response = $this->get('/clients/index');
+
+        $this->assertNotSame('', trim($response->body));
+    }
+
+    #[Test]
+    public function it_executes_invoices_index_through_full_ci_and_mx_lifecycle(): void
+    {
+        $response = $this->get('/invoices/index');
+
+        $this->assertNotSame('', trim($response->body));
+    }
+}

--- a/tests/Integration/Support/HttpResponse.php
+++ b/tests/Integration/Support/HttpResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Support;
+
+final class HttpResponse
+{
+    /**
+     * @param list<string> $headers
+     */
+    public function __construct(
+        public readonly string $body,
+        public readonly int $statusCode,
+        public readonly array $headers,
+        public readonly string $stderr,
+    ) {
+    }
+
+    public function header(string $name): ?string
+    {
+        $needle = mb_strtolower($name) . ':';
+
+        foreach ($this->headers as $header) {
+            if (str_starts_with(mb_strtolower($header), $needle)) {
+                return mb_trim(substr($header, strlen($name) + 1));
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Integration/bin/request.php
+++ b/tests/Integration/bin/request.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+$encodedRequest = getenv('CI_TEST_REQUEST') ?: '';
+$decodedRequest = base64_decode($encodedRequest, true);
+
+if ($decodedRequest === false) {
+    fwrite(STDERR, 'Invalid CI_TEST_REQUEST payload.' . PHP_EOL);
+    exit(2);
+}
+
+$request = json_decode($decodedRequest, true);
+
+if ( ! is_array($request)) {
+    fwrite(STDERR, 'Unable to decode CI_TEST_REQUEST JSON payload.' . PHP_EOL);
+    exit(3);
+}
+
+$method = strtoupper((string) ($request['method'] ?? 'GET'));
+$uri    = '/' . ltrim((string) ($request['uri'] ?? '/'), '/');
+$query  = is_array($request['query'] ?? null) ? $request['query'] : [];
+$post   = is_array($request['post'] ?? null) ? $request['post'] : [];
+
+$queryString = http_build_query($query);
+$requestUri  = '/index.php' . $uri . ($queryString !== '' ? '?' . $queryString : '');
+
+$_GET    = $query;
+$_POST   = $post;
+$_COOKIE = [];
+$_FILES  = [];
+$_REQUEST = $method === 'POST' ? array_merge($query, $post) : $query;
+
+$_SERVER['REQUEST_METHOD']     = $method;
+$_SERVER['REQUEST_URI']        = $requestUri;
+$_SERVER['QUERY_STRING']       = $queryString;
+$_SERVER['SCRIPT_NAME']        = '/index.php';
+$_SERVER['PHP_SELF']           = '/index.php' . $uri;
+$_SERVER['PATH_INFO']          = $uri;
+$_SERVER['SERVER_PROTOCOL']    = 'HTTP/1.1';
+$_SERVER['HTTP_HOST']          = 'localhost';
+$_SERVER['SERVER_NAME']        = 'localhost';
+$_SERVER['SERVER_PORT']        = '80';
+$_SERVER['HTTPS']              = 'off';
+$_SERVER['REMOTE_ADDR']        = '127.0.0.1';
+$_SERVER['HTTP_USER_AGENT']    = 'PHPUnit CI3 Integration Runner';
+$_SERVER['HTTP_ACCEPT']        = 'text/html,application/xhtml+xml';
+$_SERVER['DOCUMENT_ROOT']      = dirname(__DIR__, 3);
+$_SERVER['SCRIPT_FILENAME']    = dirname(__DIR__, 3) . '/index.php';
+$_SERVER['REQUEST_TIME']       = time();
+$_SERVER['REQUEST_TIME_FLOAT'] = microtime(true);
+
+ob_start();
+$exception = null;
+
+try {
+    require dirname(__DIR__, 3) . '/index.php';
+} catch (Throwable $throwable) {
+    $exception = $throwable::class . ': ' . $throwable->getMessage() . ' @ ' . $throwable->getFile() . ':' . $throwable->getLine();
+}
+
+$output = ob_get_clean();
+
+$result = [
+    'status'    => http_response_code() ?: 200,
+    'headers'   => headers_list(),
+    'output'    => $output,
+    'exception' => $exception,
+];
+
+echo '__CI_TEST_RESULT_START__';
+echo base64_encode((string) json_encode($result, JSON_THROW_ON_ERROR));
+echo '__CI_TEST_RESULT_END__';
+
+exit($exception === null ? 0 : 1);

--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Dotenv\Dotenv;
+
+define('CI_INTEGRATION_TESTING', true);
+
+$basePath = dirname(__DIR__, 2);
+
+require_once $basePath . '/vendor/autoload.php';
+
+if (file_exists($basePath . '/ipconfig.php')) {
+    Dotenv::createImmutable($basePath, 'ipconfig.php')->safeLoad();
+}


### PR DESCRIPTION
### Motivation

- Provide a real integration test harness that executes the full CodeIgniter 3 + Wiredesignz MX request lifecycle through the real `index.php` bootstrap so routes are resolved exactly as in production.  
- Ensure tests behave like an HTTP client (set server globals, capture output/headers/status) while preserving MX module loading, `MX_Controller` inheritance and `Modules::run()` behavior.  

### Description

- Add a dedicated PHPUnit integration configuration `phpunit.integration.xml` that bootstraps integration tests with `tests/Integration/bootstrap.php`.  
- Add `tests/Integration/bootstrap.php` which loads Composer autoloading and optional `ipconfig.php` environment values for integration runs.  
- Add `tests/Integration/CiIntegrationTestCase.php` which exposes HTTP-style helpers (`get`, `post`, `request`) and spawns an isolated PHP process to execute the real `index.php` entrypoint per request (no manual controller instantiation and no custom dispatcher).  
- Add `tests/Integration/bin/request.php` to set request superglobals, require `index.php`, capture buffered output/status/headers and serialize results back to the PHPUnit process, plus `tests/Integration/Support/HttpResponse.php` and `tests/Integration/HmvcRouteLifecycleTest.php` containing example route tests for `/clients/index` and `/invoices/index`.  

### Testing

- All new PHP files were verified for syntax (`php -l`) and reported `No syntax errors detected` for `CiIntegrationTestCase.php`, `request.php`, `HttpResponse.php`, `HmvcRouteLifecycleTest.php`, and `bootstrap.php`.  
- Attempted to run the integration suite with `vendor/bin/phpunit -c phpunit.integration.xml`, but execution failed in this environment because `vendor/bin/phpunit` is not available.  
- The harness is designed to be executed by `vendor/bin/phpunit -c phpunit.integration.xml` in a developer/CI environment with project dependencies installed and will run full CI3+MX lifecycle tests once `phpunit` is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75121202083298cf55939b45bb4f4)