### PR TITLE
Improve test helpers, add TestUris, and update tests to use unified assertions

### DIFF
--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -30,11 +30,25 @@ abstract class AbstractTestCase extends PhpUnitTestCase
         $this->sessionData = [];
     }
 
+    protected function actingAs(object|array $user): void
+    {
+        $data = is_array($user) ? $user : get_object_vars($user);
+
+        $this->sessionData = [
+            'user_id'       => (int) ($data['user_id'] ?? 1),
+            'user_type'     => (int) ($data['user_type'] ?? 1),
+            'user_email'    => (string) ($data['user_email'] ?? 'admin@test.local'),
+            'user_name'     => (string) ($data['user_name'] ?? 'Test User'),
+            'user_company'  => (string) ($data['user_company'] ?? 'Test Company'),
+            'user_language' => (string) ($data['user_language'] ?? 'system'),
+        ];
+    }
+
     protected function request(string $method, string $uri, array $query = [], array $post = []): HttpResponse
     {
         $payload = [
             'method'  => mb_strtoupper($method),
-            'uri'     => '/' . mb_ltrim($uri, '/'),
+            'uri'     => $this->normalizeUri($uri),
             'query'   => $query,
             'post'    => $post,
             'session' => $this->sessionData,
@@ -102,6 +116,31 @@ abstract class AbstractTestCase extends PhpUnitTestCase
         return $this->request('POST', $uri, $query, $data);
     }
 
+    protected function delete(string $uri, array $data = [], array $query = []): HttpResponse
+    {
+        return $this->request('DELETE', $uri, $query, $data);
+    }
+
+    protected function assertResponseOk(HttpResponse $response): void
+    {
+        self::assertSame(200, $response->statusCode());
+    }
+
+    protected function assertResponseSuccessful(HttpResponse $response): void
+    {
+        self::assertGreaterThanOrEqual(200, $response->statusCode());
+        self::assertLessThan(300, $response->statusCode());
+    }
+
+    protected function assertResponseRedirectTo(HttpResponse $response, string $expectedUrl): void
+    {
+        self::assertTrue(
+            $response->isRedirect(),
+            sprintf('Expected redirect status code, got [%d].', $response->statusCode())
+        );
+        self::assertSame($expectedUrl, $response->redirectUrl());
+    }
+
     protected function assertResponseBodyContains(HttpResponse $response, string $needle): void
     {
         self::assertStringContainsString($needle, $response->body());
@@ -140,5 +179,12 @@ abstract class AbstractTestCase extends PhpUnitTestCase
         }
 
         self::assertSame((string) file_get_contents($path), $response->body());
+    }
+
+    private function normalizeUri(string $uri): string
+    {
+        $trimmed = ltrim($uri, '/');
+
+        return '/' . $trimmed;
     }
 }

--- a/tests/Feature/Core/WelcomeControllerTest.php
+++ b/tests/Feature/Core/WelcomeControllerTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Feature\Core;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\AbstractTestCase;
+use Tests\Support\TestUris;
 
-#[CoversClass(Tests\Feature\Core\WelcomeController::class)]
+#[CoversClass(\Welcome::class)]
 class WelcomeControllerTest extends AbstractTestCase
 {
     #[Test]
@@ -15,10 +17,10 @@ class WelcomeControllerTest extends AbstractTestCase
         /* (no setup needed) */
 
         /* Act */
-        $response = $this->get(route('welcome'));
+        $response = $this->get(TestUris::HOME);
 
         /* Assert */
-        $response->assertStatus(200);
-        $response->assertViewIs('welcome');
+        $this->assertResponseOk($response);
+        $this->assertResponseHasNoPhpErrors($response);
     }
 }

--- a/tests/Integration/CiIntegrationTestCase.php
+++ b/tests/Integration/CiIntegrationTestCase.php
@@ -2,4 +2,6 @@
 
 namespace Tests\Integration;
 
+use Tests\AbstractTestCase;
+
 abstract class CiIntegrationTestCase extends AbstractTestCase {}

--- a/tests/Integration/HmvcRouteLifecycleTest.php
+++ b/tests/Integration/HmvcRouteLifecycleTest.php
@@ -2,24 +2,31 @@
 
 namespace Tests\Integration;
 
+use Modules\Clients\Controllers\Clients;
+use Modules\Invoices\Controllers\Invoices;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\Support\TestUris;
 
-#[CoversClass(Tests\Integration\HmvcRouteLifecycle::class)]
+#[CoversClass(Clients::class)]
+#[CoversClass(Invoices::class)]
 class HmvcRouteLifecycleTest extends CiIntegrationTestCase
 {
     #[Test]
     public function it_executes_clients_index_through_full_ci_and_mx_lifecycle(): void
     {
-        $response = $this->get('/clients/index');
+        $response = $this->get(TestUris::CLIENTS_INDEX);
 
-        $this->assertNotSame('', trim($response->body));
+        $this->assertResponseOk($response);
+        $this->assertNotSame('', trim($response->body()));
     }
 
     #[Test]
     public function it_executes_invoices_index_through_full_ci_and_mx_lifecycle(): void
     {
-        $response = $this->get('/invoices/index');
+        $response = $this->get(TestUris::INVOICES_INDEX);
 
-        $this->assertNotSame('', trim($response->body));
+        $this->assertResponseOk($response);
+        $this->assertNotSame('', trim($response->body()));
     }
 }

--- a/tests/Support/TestUris.php
+++ b/tests/Support/TestUris.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Support;
+
+final class TestUris
+{
+    public const HOME = '/';
+    public const CLIENTS_INDEX = '/clients/index';
+    public const INVOICES_INDEX = '/invoices/index';
+
+    private function __construct() {}
+}


### PR DESCRIPTION
### Motivation
- Provide richer and more reusable test utilities for integration tests by centralizing URIs, normalizing request URIs, and adding common response assertions and user fixtures.
- Reduce repetition and fragile hardcoded strings in tests by introducing a single source of truth for test endpoints.

### Description
- Added `actingAs(object|array)` to `AbstractTestCase` to build session data from a user object or array and kept `actingAsAdmin`/`actingAsGuest` for convenience.
- Introduced `normalizeUri()` and switched request URI handling to use it, added `delete()` helper, and added response assertions `assertResponseOk()`, `assertResponseSuccessful()`, and `assertResponseRedirectTo()` to `AbstractTestCase`.
- Created `Tests\Support\TestUris` with constants (`HOME`, `CLIENTS_INDEX`, `INVOICES_INDEX`) and updated tests to reference these constants instead of hardcoded paths.
- Updated tests to use the new assertions and adjusted `#[CoversClass]` attributes and imports, and added the `use Tests\AbstractTestCase;` import to `CiIntegrationTestCase`.

### Testing
- Ran the test suite with `vendor/bin/phpunit` and verified the modified feature and integration tests (`WelcomeControllerTest`, `HmvcRouteLifecycleTest`, and related integration tests) execute using the new helpers and assertions without failures.
- Confirmed that response assertions (`assertResponseOk` and `assertResponseHasNoPhpErrors`) pass for the updated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef310b23c832991344ea0247f0dca)