### PR TITLE
Implement recipient determination logic in QrCode.php

### DIFF
--- a/application/libraries/QrCode.php
+++ b/application/libraries/QrCode.php
@@ -30,6 +30,19 @@ class QrCode
         $CI->load->helper('template');
 
         $this->invoice         = $params['invoice'];
+
+        // Determine recipient with the following priority:
+        // First priority: Get recipient from qr code settings
+        $recipient = $CI->mdl_settings->setting('qr_code_recipient');
+        // Second priority: If still empty, get recipient from invoice's user_company
+        if (empty($recipient)) {
+            $recipient = $this->invoice->user_company;
+        }
+        // Third priority: If still empty, get recipient from invoice's user_name
+        if (empty($recipient)) {
+            $recipient = $this->invoice->user_name;
+        }
+        $this->recipient = $recipient;
         $this->recipient       = $this->invoice->user_company ?: $CI->mdl_settings->setting('qr_code_recipient');
         $this->iban            = $this->invoice->user_iban ?: $CI->mdl_settings->setting('qr_code_iban');
         $this->bic             = $this->invoice->user_bic ?: $CI->mdl_settings->setting('qr_code_bic');

--- a/application/libraries/QrCode.php
+++ b/application/libraries/QrCode.php
@@ -43,7 +43,6 @@ class QrCode
             $recipient = $this->invoice->user_name;
         }
         $this->recipient = $recipient;
-        $this->recipient       = $this->invoice->user_company ?: $CI->mdl_settings->setting('qr_code_recipient');
         $this->iban            = $this->invoice->user_iban ?: $CI->mdl_settings->setting('qr_code_iban');
         $this->bic             = $this->invoice->user_bic ?: $CI->mdl_settings->setting('qr_code_bic');
         $this->currencyCode    = $CI->mdl_settings->setting('currency_code');


### PR DESCRIPTION
Added logic to determine recipient based on priority from QR code settings and invoice details.

# Pull Request Checklist

Please check the following steps before submitting your PR. If any items are incomplete, consider marking it as `[WIP]` (Work in Progress).

## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.
- [x] I included relevant documentation updates if necessary.
- [x] I have an accompanying issue ID for this pull request.

---

## Description
I added a small logic, which changes how the reciepment for the banking qr code is selected. I needed to use my own name. 
With this logic, you can enter the reciepment manually within the qr settings. If it's empty, the generator uses the company name. And if this is empty as well, the generator uses the user name value.

---


## Motivation and Context
As described above. I needed this for my own use and I think it's a good change.

---

## Issue Type (Check one or more)
- [ ] Bugfix
- [x] Improvement of an existing feature
- [ ] New feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR code recipient resolution: the system now prefers an explicitly configured recipient setting, then falls back to the invoice company, and finally to the invoice name, ensuring generated QR codes display the correct recipient information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->