### PR TITLE
feat(mailing): add reply-to field to email templates

### DIFF
--- a/.github/improvements.md
+++ b/.github/improvements.md
@@ -1,0 +1,1007 @@
+# InvoicePlane v1.7.2 — Security Improvements
+
+This document explains every security problem found in the v1.7.2 release cycle, what the
+root cause was, and exactly what was changed to fix it. It is intended as an internal
+reference for developers and security reviewers.
+
+---
+
+## Table of Contents
+
+1. [Critical — Remote Code Execution (RCE) via Template System](#1-critical--remote-code-execution-rce-via-template-system)
+2. [High — Stored Cross-Site Scripting (XSS)](#2-high--stored-cross-site-scripting-xss)
+3. [High — IDOR + CSRF in Guest Quote Approve/Reject](#3-high--idor--csrf-in-guest-quote-approvereject)
+4. [High — Weak PRNG in Password Reset Tokens](#4-high--weak-prng-in-password-reset-tokens)
+5. [High — SQL / DDL Injection in Tax Rate Decimal Places](#5-high--sql--ddl-injection-in-tax-rate-decimal-places)
+6. [High — Configuration Injection in Database Setup](#6-high--configuration-injection-in-database-setup)
+7. [High — Arbitrary File Deletion via Path Traversal](#7-high--arbitrary-file-deletion-via-path-traversal)
+8. [Medium — Authorization Bypass in Guest Invoice / Payment Endpoints](#8-medium--authorization-bypass-in-guest-invoice--payment-endpoints)
+9. [Medium — Setup Wizard Accessible Post-Installation](#9-medium--setup-wizard-accessible-post-installation)
+10. [Medium — SSRF via PDF Footer Content](#10-medium--ssrf-via-pdf-footer-content)
+11. [Medium — File Path Traversal across Codebase](#11-medium--file-path-traversal-across-codebase)
+12. [Medium — Payment Gateway API Credential Exposure](#12-medium--payment-gateway-api-credential-exposure)
+13. [Medium — Open Redirect via Unvalidated `HTTP_REFERER`](#13-medium--open-redirect-via-unvalidated-http_referer)
+14. [Low–Medium — PHPMailer Debug Output Leaking into AJAX Responses](#14-lowmedium--phpmailer-debug-output-leaking-into-ajax-responses)
+15. [Low–Medium — Duplicate Payment Processing in Stripe / PayPal Callbacks](#15-lowmedium--duplicate-payment-processing-in-stripe--paypal-callbacks)
+16. [Low–Medium — Email Template Preview Rendered as Raw HTML](#16-lowmedium--email-template-preview-rendered-as-raw-html)
+17. [Low — EXIF Metadata in Uploaded Images](#17-low--exif-metadata-in-uploaded-images)
+18. [Low — Password Reset Tokens with No Expiry](#18-low--password-reset-tokens-with-no-expiry)
+19. [Review Follow-up — PR #1536 Hardening Pass](#19-review-follow-up--pr-1536-hardening-pass)
+20. [New Cross-Cutting Security Infrastructure](#20-new-cross-cutting-security-infrastructure)
+
+---
+
+## 1. Critical — Remote Code Execution (RCE) via Template System
+
+**PRs:** [#1505](https://github.com/InvoicePlane/InvoicePlane/pull/1505),
+[#1506](https://github.com/InvoicePlane/InvoicePlane/pull/1506)  
+**CVSS:** 9.9 Critical  
+**Advisory:** `SECURITY_ADVISORY_RCE_FIX.md`
+
+### What Was Wrong
+
+The v1.7.1 LFI fix had a critical bypass. The `validate_template_name()` function in
+`application/helpers/template_helper.php` existed in the codebase but its body was empty —
+only the docblock and closing brace were present. The function therefore returned nothing
+useful, so template names from the database were included without validation.
+
+More importantly, the `get_invoice_templates()` and `get_quote_templates()` methods in
+`application/modules/invoices/models/Mdl_templates.php` built the template "whitelist" by
+scanning the filesystem at runtime using CodeIgniter's `directory_map()`:
+
+```php
+// Vulnerable: whitelist built from whatever is on disk
+public function get_invoice_templates($type = 'pdf')
+{
+    $this->load->helper('directory');
+    $templates = directory_map(APPPATH . '/views/invoice_templates/pdf', true);
+    return $this->remove_extension($templates);
+}
+```
+
+Because the template directories were writable by the web server process, an authenticated
+admin could:
+
+1. Write a PHP webshell (`evil.php`) into `application/views/invoice_templates/public/`.
+2. On the next request, `directory_map()` found `evil.php` and it was automatically added to
+   the "allowed" whitelist.
+3. The admin set `public_invoice_template = evil` in Settings.
+4. Any unauthenticated visitor accessing a public invoice URL now triggered the webshell,
+   executing arbitrary PHP with web-server privileges.
+
+Additionally, the same PR uncovered five instances of unvalidated `$_SERVER['HTTP_REFERER']`
+redirects that allowed open-redirect / phishing attacks (CWE-601, CVSS 6.1).
+
+### What Was Improved
+
+**Static whitelist in `Mdl_templates.php`**  
+The filesystem scan was replaced with a hardcoded PHP constant. No matter what files exist
+on disk, only the names in the constant can ever be loaded:
+
+```php
+private const ALLOWED_INVOICE_TEMPLATES = [
+    'pdf'    => ['InvoicePlane', 'InvoicePlane - paid', 'InvoicePlane - overdue'],
+    'public' => ['InvoicePlane_Web'],
+];
+private const ALLOWED_QUOTE_TEMPLATES = [
+    'pdf'    => ['InvoicePlane'],
+    'public' => ['InvoicePlane_Web'],
+];
+
+public function get_invoice_templates($type = 'pdf')
+{
+    return $type === 'pdf'
+        ? self::ALLOWED_INVOICE_TEMPLATES['pdf']
+        : ($type === 'public' ? self::ALLOWED_INVOICE_TEMPLATES['public'] : []);
+}
+```
+
+**`validate_template_name()` implemented in `template_helper.php`**  
+The previously empty function was completed with seven independent validation layers:
+
+1. Reject empty or non-string input.
+2. Detect path traversal via `validate_safe_filename()`.
+3. Validate `$type` is `invoice` or `quote` (strict allowlist).
+4. Validate `$scope` is `pdf` or `public` (strict allowlist).
+5. Static whitelist check — the primary defence.
+6. Character validation (alphanumeric, spaces, hyphens, underscores only).
+7. Log all failures with sanitized values to prevent log injection.
+
+**Centralised validation helper in `View.php`**  
+A new `get_validated_template_path()` helper was added to `application/modules/guest/controllers/View.php`.
+It runs validation + path construction + file existence check in one call and falls back to
+the default template if anything fails, preventing arbitrary file inclusion even if all other
+layers were somehow bypassed.
+
+**Open-redirect fixes (`security_helper.php`)**  
+A new `application/helpers/security_helper.php` was created with `get_safe_referer()`,
+which rejects any redirect target that is not an internal URL before redirecting. All five
+vulnerable redirect sites were updated to use this helper.
+
+**`security_helper.php` correction (PR #1506)**  
+A CodeRabbit auto-fix corrected a minor issue in `security_helper.php` introduced by #1505.
+
+**Adding custom templates post-fix**  
+Custom templates now require two explicit steps: create the file AND add the name to
+`CUSTOM_INVOICE_TEMPLATES_PDF` (or equivalent) in `ipconfig.php`. The filesystem is never
+scanned. See `AGENTS.md` for instructions.
+
+---
+
+## 2. High — Stored Cross-Site Scripting (XSS)
+
+**PRs:** [#1500](https://github.com/InvoicePlane/InvoicePlane/pull/1500),
+[#1516](https://github.com/InvoicePlane/InvoicePlane/pull/1516)  
+**CVSS:** 8.0 High
+
+### What Was Wrong
+
+A comprehensive audit of all 147 view files found 32 locations where database values or
+`get_setting()` results were echoed directly into HTML `value` attributes and other contexts
+without output encoding. An attacker who could control any of these settings (e.g., through
+a compromised admin account or a malicious API response) could inject `"><script>` payloads
+that would execute in every administrator's browser session.
+
+Affected modules: Settings (7 files, 21 fixes), Invoice modals (3 files, 6 fixes), Quote
+modals (3 files, 4 fixes), and Projects form (1 file, 1 fix).
+
+Notable targets included: Stripe/PayPal API key fields, SMTP port, cron authentication key,
+QR code recipient/IBAN/BIC, password fields in copy-invoice and quote modals.
+
+### What Was Improved
+
+All vulnerable fields were wrapped with `htmlspecialchars($value, ENT_QUOTES | ENT_IGNORE)`
+or the project's existing `htmlsc()` wrapper (which uses the same flags):
+
+```php
+// Before — raw echo into HTML attribute
+value="<?= get_setting('gateway_stripe_apiKey') ?>"
+
+// After — HTML-encoded
+value="<?= get_setting('gateway_stripe_apiKey', '', true) ?>"
+// The third 'true' argument triggers html_escape() inside get_setting()
+```
+
+The same pattern was applied to modal form fields that pre-fill from database objects:
+
+```php
+// Before
+value="<?= $invoice->invoice_password ?>"
+
+// After
+value="<?= htmlsc($invoice->invoice_password) ?>"
+```
+
+---
+
+## 3. High — IDOR + CSRF in Guest Quote Approve/Reject
+
+**PRs:** [#1471](https://github.com/InvoicePlane/InvoicePlane/pull/1471),
+[#1482](https://github.com/InvoicePlane/InvoicePlane/pull/1482),
+[#1487](https://github.com/InvoicePlane/InvoicePlane/pull/1487)  
+**CVSS:** 7.5 High
+
+### What Was Wrong
+
+The `approve()` and `reject()` methods in `application/modules/guest/controllers/View.php`
+were accessible via GET request and performed no ownership check. Any authenticated guest
+user could approve or reject quotes belonging to other clients simply by knowing or guessing
+a `quote_url_key`. Because the endpoints accepted GET, a single malicious link (e.g., in an
+email) would trigger the action without user consent (CSRF).
+
+There was also a SQL injection risk in `application/modules/guest/controllers/Payments.php`
+where `invoice_id` from a URL parameter was concatenated directly into a query string.
+
+### What Was Improved
+
+**Endpoint hardening (applied in multiple passes across #1471, #1482, #1487)**
+
+*Method enforcement:* Both `approve()` and `reject()` now return 404 for non-POST requests,
+blocking simple CSRF via GET links.
+
+*CSRF token validation:* Hidden CSRF token fields (`_csrf_field()`) were added to the
+approve/reject forms. CodeIgniter's built-in CSRF protection validates the token on every
+POST.
+
+*Client-scope ownership check:* Every quote operation now runs a `where_in()` filter against
+the guest's assigned client list:
+
+```php
+$quote = $this->mdl_quotes
+    ->is_open()                                          // status 2 or 3 only
+    ->where('ip_quotes.quote_url_key', $quote_url_key)
+    ->where_in('ip_quotes.client_id', $this->user_clients) // ownership check
+    ->get()->row();
+
+if ($quote === null) { show_404(); }
+```
+
+*Duplicate email prevention:* Emails are only sent when `$this->db->affected_rows() > 0`,
+preventing duplicate notifications if the row was already updated by a concurrent request.
+
+*HTML escaping in form attributes:* All dynamic values in form `action` URLs and CSRF token
+outputs were wrapped in `htmlsc()` to prevent XSS in form attributes.
+
+*CSRF token regeneration in PayPal flow:* CodeIgniter regenerates the CSRF token after every
+POST. The two-step PayPal flow (createOrder → capturePayment) required the server to return
+the new token in the `createOrder` JSON response, and the client JavaScript to track and
+resend it with `capturePayment`. This was implemented in the PayPal gateway controller and
+JavaScript.
+
+*SQL injection fix:* The `invoice_id` URL parameter in `Payments.php` was cast to `(int)`
+before use and proper parameter binding was added.
+
+---
+
+## 4. High — Weak PRNG in Password Reset Tokens
+
+**PR:** [#1494](https://github.com/InvoicePlane/InvoicePlane/pull/1494)  
+**CVSS:** 7.5 High  
+**Related:** CVE-2021-29023
+
+### What Was Wrong
+
+Password reset tokens were generated as:
+
+```php
+$token = md5(time() . $email . sha1(mt_rand()));
+```
+
+This produces approximately 31 bits of effective entropy because `mt_rand()` is seeded from
+the Unix timestamp and `time()` is predictable. On a GPU the entire 32-character space can
+be brute-forced in under a second for a known email address and approximate token-generation
+time. An attacker who knew a target's email and the rough time of the reset request could
+enumerate all possible tokens.
+
+Additionally, the `Cryptor::salt()` method used `substr(sha1(mt_rand()), 0, 22)`, which has
+the same weakness.
+
+### What Was Improved
+
+A new helper file `application/helpers/ip_security_helper.php` was created (named `ip_security`
+to avoid shadowing CodeIgniter's built-in `security` helper):
+
+```php
+function generate_password_reset_token(): string
+{
+    return bin2hex(random_bytes(32)); // 256-bit cryptographic entropy → 64-char hex token
+}
+
+function generate_secure_salt(): string
+{
+    // random_bytes → base64 → crypt-compatible alphabet (translate + to ., strip =)
+    $raw    = random_bytes(16);
+    $base64 = base64_encode($raw);
+    return substr(strtr($base64, '+', '.'), 0, 22);
+}
+```
+
+The `Cryptor::salt()` method was updated to delegate to `generate_secure_salt()`.
+
+The token generation in `Mdl_users` was updated:
+
+```php
+// Before
+$token = md5(time() . $email . $this->crypt->salt());
+
+// After
+$this->load->helper('ip_security');
+$token = generate_password_reset_token();
+```
+
+The existing `VARCHAR(100)` column comfortably holds the new 64-character hex token, so no
+database migration was required.
+
+---
+
+## 5. High — SQL / DDL Injection in Tax Rate Decimal Places
+
+**PRs:** [#1481](https://github.com/InvoicePlane/InvoicePlane/pull/1481),
+[#1488](https://github.com/InvoicePlane/InvoicePlane/pull/1488)  
+**CVSS:** 7.2 High  
+**Linked Issue:** [#1479](https://github.com/InvoicePlane/InvoicePlane/issues/1479)
+
+### What Was Wrong
+
+The Settings controller executed a schema-altering DDL statement that incorporated the raw
+POST parameter `tax_rate_decimal_places` without any sanitization:
+
+```php
+$this->db->query("
+    ALTER TABLE `ip_tax_rates` CHANGE `tax_rate_percent` `tax_rate_percent`
+    DECIMAL( 5, {$settings['tax_rate_decimal_places']} ) NOT null");
+```
+
+An authenticated admin could submit `tax_rate_decimal_places=0) NOT NULL; DROP TABLE ip_tax_rates; --`
+and corrupt or destroy the database schema. PR #1481 applied an initial `(int)` cast with a
+range check; PR #1488 strengthened this further with a reusable processor class, a DB
+transaction, and unit tests.
+
+### What Was Improved
+
+**Initial fix (PR #1481):** Cast the parameter to `int` immediately on receipt and validate
+the range (2–3):
+
+```php
+$decimal_places = (int) $settings['tax_rate_decimal_places'];
+if ($decimal_places < 2 || $decimal_places > 3) {
+    $this->session->set_flashdata('alert_error', trans('invalid_tax_rate_decimal_places'));
+    redirect('settings');
+}
+```
+
+**Hardened fix (PR #1488):** Added `TaxRateDecimalPlacesProcessor` to encapsulate the
+validation and change-detection logic; the actual DDL is only executed if the value changed;
+the ALTER TABLE and the settings save are wrapped in a DB transaction to keep the schema and
+the stored setting in sync:
+
+```php
+$ddl = sprintf(
+    'ALTER TABLE `ip_tax_rates` CHANGE `tax_rate_percent` `tax_rate_percent` DECIMAL(5, %d) NOT NULL',
+    $decimal_places  // integer, validated — no injection possible
+);
+$this->db->trans_begin();
+$this->db->query($ddl);
+$this->mdl_settings->save('tax_rate_decimal_places', (string) $decimal_places);
+$this->db->trans_commit();
+```
+
+Unit tests cover acceptance of valid values (2 and 3), rejection of anything outside that
+range, and the change-detection logic.
+
+---
+
+## 6. High — Configuration Injection in Database Setup
+
+**PR:** [#1513](https://github.com/InvoicePlane/InvoicePlane/pull/1513)  
+**CVSS:** 7.2 High
+
+### What Was Wrong
+
+The Setup wizard wrote database configuration directly from POST parameters into
+`ipconfig.php` without stripping newlines or other control characters. An attacker who could
+reach the setup endpoint could inject additional configuration directives:
+
+```
+POST db_hostname=localhost%0AENABLE_DEBUG%3Dtrue%0ADB_HOSTNAME%3D
+```
+
+This would produce a config file entry like:
+
+```
+DB_HOSTNAME=localhost
+ENABLE_DEBUG=true
+DB_HOSTNAME=
+```
+
+Debug mode, alternate database servers, or other dangerous settings could be force-enabled
+this way.
+
+### What Was Improved
+
+Two new helper functions were added to `application/helpers/file_security_helper.php`:
+
+```php
+function validate_db_config_parameter(string $value, string $type): array
+{
+    // Reject newlines and null bytes immediately
+    if (preg_match('/[\r\n\0]/', $value)) {
+        return ['valid' => false, 'error' => 'control_character'];
+    }
+
+    $patterns = [
+        'hostname' => '/^[a-zA-Z0-9.\-_:\[\]]+$/',
+        'username' => '/^[a-zA-Z0-9.\-_@]+$/',
+        'database' => '/^[a-zA-Z0-9_\-]+$/',
+        'port'     => null, // handled as integer 1–65535
+    ];
+    // ... type-specific validation
+}
+
+function sanitize_db_config_value(string $value): string
+{
+    // Escape single quotes for defense-in-depth when writing to .php config file
+    return str_replace("'", "\\'", $value);
+}
+```
+
+The Setup controller now validates all five parameters (`hostname`, `username`, `password`,
+`database`, `port`) before writing the config file. If any parameter fails validation the
+user sees an error and the file is never written.
+
+---
+
+## 7. High — Arbitrary File Deletion via Path Traversal
+
+**PRs:** [#1512](https://github.com/InvoicePlane/InvoicePlane/pull/1512),
+[#1510](https://github.com/InvoicePlane/InvoicePlane/pull/1510),
+[#1529](https://github.com/InvoicePlane/InvoicePlane/pull/1529)  
+**CVSS:** 7.1 High  
+**Advisory:** `SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md`
+
+### What Was Wrong
+
+The `remove_logo()` method in `application/modules/settings/controllers/Settings.php`
+retrieved the logo filename from the database and passed it directly to `unlink()`:
+
+```php
+public function remove_logo($type)
+{
+    $logo_filename = get_setting($type . '_logo');
+    $logo_path     = './uploads/' . $logo_filename;
+    if (file_exists($logo_path)) {
+        unlink($logo_path);  // no validation — deletes whatever $logo_filename points to
+    }
+}
+```
+
+Because the settings save function also had no validation, an admin could store a path like
+`../../application/config/database.php` in `invoice_logo` and then trigger `remove_logo` to
+delete that file, taking down the entire application.
+
+### What Was Improved
+
+**Input validation at save time (PR #1512)**  
+When saving settings, every logo filename value is now validated with `validate_safe_filename()`
+before it reaches the database. Path traversal sequences (`../`, `..\`), absolute paths
+(`/etc/`), Windows drive letters (`C:`), and null bytes are all rejected:
+
+```php
+if ($key === 'invoice_logo' || $key === 'login_logo') {
+    if (!empty($value)) {
+        $validation = validate_safe_filename($value);
+        if (!$validation['valid']) {
+            log_message('error', sprintf(
+                'Path traversal blocked in %s (hash: %s)',
+                sanitize_for_logging($key),
+                $validation['hash']
+            ));
+            $this->session->set_flashdata('alert_error', trans('invalid_filename'));
+            redirect('settings');
+        }
+    }
+}
+```
+
+**Type-parameter whitelisting**  
+The `$type` parameter to `remove_logo()` is now checked against `['invoice', 'login']`.
+Any other value results in a logged error and a redirect.
+
+**Directory-confinement validation at deletion time (PR #1512)**  
+`validate_file_access()` is called before any file operation. It resolves the real path and
+checks that the result is within `./uploads/`. Even if the database was poisoned with a path
+that passed the save-time validation, the deletion is blocked:
+
+```php
+$validation = validate_file_access($logo_filename, './uploads/');
+if (!$validation['valid']) { /* log and redirect, no deletion */ }
+if (file_exists($validation['path'])) {
+    $deleted = unlink($validation['path']);
+}
+```
+
+**Codebase-wide path traversal fix (PR #1510)**  
+The same class of vulnerability was also present in `Mdl_uploads` (three methods) and the
+guest `View` controller (attachment download). A new `validate_db_filename()` helper was
+introduced to provide a single, shared validation function for any path constructed from a
+database value. It strips directory components with `basename()`, checks for traversal
+sequences, and validates the resolved path with `realpath()` + `validate_file_in_directory()`
+to catch symlink escapes.
+
+**CVE documentation (PR #1529)**  
+`SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md`, `CVE_REQUEST_SUMMARY.md`, and
+`verify_file_deletion_fix.php` were added to document the vulnerability for CVE allocation
+and provide operators with a verification script.
+
+---
+
+## 8. Medium — Authorization Bypass in Guest Invoice / Payment Endpoints
+
+**PRs:** [#1517](https://github.com/InvoicePlane/InvoicePlane/pull/1517),
+[#1537](https://github.com/InvoicePlane/InvoicePlane/pull/1537)  
+**CVSS:** 6.5 Medium
+
+### What Was Wrong
+
+The guest invoice `view()` method in `application/modules/guest/controllers/Invoices.php`
+looked up invoices by `invoice_id` + client ownership but did not apply the `guest_visible()`
+scope. This meant that draft invoices (status 1) were accessible to guest users, exposing
+`invoice_url_key` handles that could be passed to payment and attachment endpoints.
+
+The same problem existed in all five payment gateway methods across the Stripe and PayPal
+controllers: they looked up invoices by `invoice_url_key` without applying `guest_visible()`,
+so draft invoice payments could be initiated or captured.
+
+### What Was Improved
+
+A single-line addition of `->guest_visible()` was applied to every affected query:
+
+```php
+// Before — draft invoices accessible
+$invoice = $this->mdl_invoices
+    ->where('ip_invoices.invoice_id', $invoice_id)
+    ->where_in('ip_invoices.client_id', $this->user_clients)
+    ->get()->row();
+
+// After — only sent (2), viewed (3), paid (4)
+$invoice = $this->mdl_invoices
+    ->guest_visible()
+    ->where('ip_invoices.invoice_id', $invoice_id)
+    ->where_in('ip_invoices.client_id', $this->user_clients)
+    ->get()->row();
+```
+
+Null checks and explicit `show_404()` calls were also added after each retrieval, and
+security-logging statements were added for unauthorized access attempts.
+
+---
+
+## 9. Medium — Setup Wizard Accessible Post-Installation
+
+**PRs:** [#1491](https://github.com/InvoicePlane/InvoicePlane/pull/1491),
+[#1511](https://github.com/InvoicePlane/InvoicePlane/pull/1511),
+[#1518](https://github.com/InvoicePlane/InvoicePlane/pull/1518)  
+**CVSS:** 6.5 / 6.1 Medium
+
+### What Was Wrong
+
+After a successful installation, `SETUP_COMPLETED=true` was written to `ipconfig.php`, but
+the setup controller never read this flag. Any unauthenticated user could navigate to
+`/index.php/setup/` and overwrite the database configuration, causing an immediate denial-
+of-service or potentially redirecting the application to an attacker-controlled database.
+
+Additionally, database configuration parameters submitted through the setup form were not
+sanitized, creating newline-injection opportunities (see §6 above).
+
+### What Was Improved
+
+**Early 403 guard (PR #1511)**  
+The `Setup` controller constructor now checks `SETUP_COMPLETED` before loading any models
+or processing any input. If `true`, it immediately calls `show_error(..., 403)`:
+
+```php
+public function __construct()
+{
+    parent::__construct();
+    if (env_bool('SETUP_COMPLETED', false)) {
+        show_error('Setup already completed. Set SETUP_COMPLETED=false to re-run.', 403);
+    }
+}
+```
+
+**Database write lock (PR #1491)**  
+The `configure_database()` method was hardened so that even if the early guard is bypassed,
+the config file is only written after a successful connection test and only when
+`SETUP_COMPLETED` is `false`. Input sanitization helpers (`sanitize_database_config_value`,
+`sanitize_database_port`) were added to `file_security_helper.php`.
+
+**Automatic post-install lockdown (PR #1518)**  
+`post_setup_tasks()` now sets both `SETUP_COMPLETED=true` and `DISABLE_SETUP=true`
+automatically. Robust regex patterns handle whitespace variations, return values from
+`preg_replace()` are validated (null = failure), and file-write errors are caught and logged
+with `error_get_last()`. If the file write fails (e.g., read-only deployment), an admin
+warning banner is displayed on next login.
+
+---
+
+## 10. Medium — SSRF via PDF Footer Content
+
+**PR:** [#1492](https://github.com/InvoicePlane/InvoicePlane/pull/1492)  
+**CVSS:** 6.5 Medium
+
+### What Was Wrong
+
+The PDF invoice and quote footer accepted raw HTML that mPDF rendered faithfully. An admin
+could save a footer like `<img src="https://attacker.com/track.php?d=secret">` and the PDF
+renderer would make an outbound HTTP request to the attacker's server during PDF generation,
+potentially leaking internal network topology, server IP, or triggering SSRF attacks against
+internal services.
+
+### What Was Improved
+
+A new `sanitize_pdf_footer_content()` function was added to a helper. It strips all tags
+except a safe subset (`b`, `strong`, `i`, `em`, `u`, `p`, `br`, `span`, `small`, `div`)
+using `strip_tags()` with an allowlist, and removes any attribute that could reference an
+external resource (`src`, `href`, `action`, `background`, `style`, etc.).
+
+```php
+$invoiceFooter = sanitize_pdf_footer_content(
+    $CI->mdl_settings->settings['pdf_invoice_footer'] ?? ''
+);
+$mpdf->DefHTMLFooterByName('footer', '<div>' . $invoiceFooter . '</div>');
+```
+
+The Settings view help-text was also updated to inform admins which tags are allowed and
+that external resources are stripped.
+
+---
+
+## 11. Medium — File Path Traversal across Codebase
+
+**PR:** [#1510](https://github.com/InvoicePlane/InvoicePlane/pull/1510)  
+**CVSS:** 6.5 Medium
+
+### What Was Wrong
+
+Beyond the logo-file deletion (§7), the same class of path traversal existed in three
+methods of `Mdl_uploads` and in the guest attachment download handler (`View.php`). Each
+method constructed a filesystem path by concatenating `./uploads/` with a `file_name_new`
+column value from the database. While the upload controller validated new uploads, there was
+no defence-in-depth if the database was compromised or the value was otherwise manipulated.
+
+Additionally, `file_name_original` in the guest attachment view was echoed without HTML
+encoding, creating a stored XSS vector.
+
+### What Was Improved
+
+A `validate_db_filename()` function was added to `file_security_helper.php`. It:
+
+1. Validates no path traversal sequences are present.
+2. Applies `basename()` to strip any directory component.
+3. Constructs the candidate path.
+4. Calls `realpath()` and `validate_file_in_directory()` to catch symlink escapes — a
+   symlink inside `./uploads/` could otherwise point outside the directory.
+
+All four affected call sites were updated to use this helper. Failures are skipped
+gracefully (logging with a sanitized hash) rather than crashing. `file_name_original` is
+now wrapped in `html_escape()` in the view.
+
+---
+
+## 12. Medium — Payment Gateway API Credential Exposure
+
+**PR:** [#1515](https://github.com/InvoicePlane/InvoicePlane/pull/1515)  
+**CVSS:** 6.5 Medium
+
+### What Was Wrong
+
+The payment gateway settings partial view (`partial_settings_online_payment.php`) decrypted
+Stripe API keys and PayPal client secrets server-side and embedded the plaintext values in
+HTML `value` attributes:
+
+```php
+value="<?= $this->crypt->decode(get_setting('gateway_stripe_apiKey')) ?>"
+```
+
+Although the fields had `type="password"` so the browser masked the display, the cleartext
+secrets were visible in the HTML source and in browser DevTools. Any user who could open
+DevTools, or any XSS vector in the page, could extract the live production API credentials.
+
+### What Was Improved
+
+The field values were changed to empty strings. The controller already had logic to preserve
+the existing encrypted value when a field is submitted empty:
+
+```php
+// Before
+value="<?= $this->crypt->decode(get_setting('gateway_stripe_apiKey')) ?>"
+
+// After
+value="" autocomplete="new-password"
+```
+
+The `autocomplete="new-password"` attribute also prevents browser autofill from leaking
+stored credentials. This mirrors the existing pattern already used for the SMTP password
+field in `partial_settings_email.php`.
+
+---
+
+## 13. Medium — Open Redirect via Unvalidated `HTTP_REFERER`
+
+**PR:** [#1505](https://github.com/InvoicePlane/InvoicePlane/pull/1505)  
+**CVSS:** 6.1 Medium
+
+### What Was Wrong
+
+Five locations in the codebase used `$_SERVER['HTTP_REFERER']` directly as a redirect target:
+
+- `application/modules/payments/views/modal_add_payment.php` — post-payment redirect
+- `application/modules/custom_fields/controllers/Custom_fields.php` — after field deletion
+- `application/modules/filter/controllers/Ajax.php` — three AJAX filter operations
+
+An attacker could craft a link to the application that set the `Referer` header to an
+external phishing domain. Clicking the payment "Done" button would then redirect the user to
+the attacker's site.
+
+### What Was Improved
+
+`application/helpers/security_helper.php` was created with a `get_safe_referer()` function.
+It parses the `Referer` header and compares the scheme, host, and port against the current
+application's base URL. If they do not match, it falls back to the application home page:
+
+```php
+function get_safe_referer(): string
+{
+    $referer  = $_SERVER['HTTP_REFERER'] ?? '';
+    $base_url = base_url();
+
+    $referer_parts  = parse_url($referer);
+    $base_url_parts = parse_url($base_url);
+
+    if (($referer_parts['host']   ?? '') !== ($base_url_parts['host']   ?? '') ||
+        ($referer_parts['scheme'] ?? '') !== ($base_url_parts['scheme'] ?? '')) {
+        return $base_url;
+    }
+    return $referer;
+}
+```
+
+All five vulnerable redirect sites were updated to use `redirect(get_safe_referer())`.
+
+---
+
+## 14. Low–Medium — PHPMailer Debug Output Leaking into AJAX Responses
+
+**PR:** [#1495](https://github.com/InvoicePlane/InvoicePlane/pull/1495)  
+**CVSS:** 5.3
+
+### What Was Wrong
+
+When `ENABLE_DEBUG=true`, PHPMailer's `Debugoutput` was set to `'echo'`, which printed SMTP
+session transcripts directly to stdout. Because email sending is invoked during AJAX
+responses, this debug output was prepended to the JSON response, breaking JSON parsing and
+causing the fullpage-loader to hang indefinitely without any user-visible error.
+
+The non-debug mode used `'error_log'` which routed through PHP's error log rather than
+CodeIgniter's logging system, making it invisible in the application log viewer.
+
+In both modes, raw SMTP session data (which includes email addresses, authentication
+challenges, and message content previews) could end up in logs or HTTP responses without
+sanitization, creating a log-injection risk.
+
+### What Was Improved
+
+A custom callback function was registered as PHPMailer's debug handler:
+
+```php
+function phpmailer_debug_output(string $str, int $level = 0): void
+{
+    $sanitized = sanitize_for_logging($str);
+    log_message('debug', 'PHPMailer [lvl ' . $level . ']: ' . $sanitized);
+}
+
+$mail->Debugoutput = 'phpmailer_debug_output';
+```
+
+This applies regardless of `ENABLE_DEBUG`: all SMTP output now goes through
+`sanitize_for_logging()` (stripping newlines, control chars) and into the CodeIgniter log
+file — never to stdout. AJAX responses remain clean JSON. A custom error-state SVG and
+Bootstrap alert were added to give users visible feedback when email sending fails.
+
+---
+
+## 15. Low–Medium — Duplicate Payment Processing in Stripe / PayPal Callbacks
+
+**PR:** [#1496](https://github.com/InvoicePlane/InvoicePlane/pull/1496)  
+**CVSS:** 5.3
+
+### What Was Wrong
+
+Stripe and PayPal can (and do) fire their webhook callbacks more than once for the same
+transaction. Because there was no deduplication mechanism, each callback would insert a new
+payment record, resulting in invoices with a negative balance (payments totalling more than
+the invoice amount).
+
+### What Was Improved
+
+A `payment_external_id VARCHAR(255)` column was added to `ip_payments` with a unique
+database index (`idx_payment_external_id`). Before saving any payment, the callback handler
+now queries for an existing record with the same Stripe `payment_intent` or PayPal
+`capture_id`:
+
+```php
+$existing = $this->db
+    ->where('payment_external_id', $payment_intent)
+    ->get('ip_payments')->row();
+
+if ($existing) {
+    log_message('warning', 'Duplicate payment blocked: ' . sanitize_for_logging($payment_intent));
+    return;
+}
+
+if ($invoice->invoice_balance <= 0) {
+    return; // already fully paid
+}
+```
+
+The application-level check provides defence-in-depth; the unique database index enforces
+the constraint even under race conditions. The `payment_intent` / `capture_id` values are
+also validated for format and length before use.
+
+---
+
+## 16. Low–Medium — Email Template Preview Rendered as Raw HTML
+
+**PR:** [#1486](https://github.com/InvoicePlane/InvoicePlane/pull/1486)  
+**CVSS:** 5.4
+
+### What Was Wrong
+
+The email template preview endpoint returned raw HTML content from the database and rendered
+it directly in the browser. Because email templates can contain user-defined content, an
+admin who had previously stored a malicious template could trigger XSS against any user who
+opened the preview. The Grunt build configuration also had the incorrect `outputStyle`
+setting (`"extended"` instead of `"expanded"`), causing SCSS compilation failures.
+
+### What Was Improved
+
+The preview endpoint was updated to pass template content through a sanitisation function
+before returning it. The HTML is now rendered in a sandboxed context. The Grunt `outputStyle`
+typo was corrected to `"expanded"`.
+
+---
+
+## 17. Low — EXIF Metadata in Uploaded Images
+
+**PR:** [#1507](https://github.com/InvoicePlane/InvoicePlane/pull/1507)  
+**CVSS:** 4.3
+
+### What Was Wrong
+
+Images uploaded by users (client attachments, logos) retained their full EXIF metadata. EXIF
+data can include GPS coordinates, camera serial numbers, device identifiers, and creation
+timestamps. When these files are served to other users (e.g., guest invoice attachments),
+the metadata is visible to anyone who downloads the image.
+
+### What Was Improved
+
+A `strip_exif_metadata()` helper function was added to `file_security_helper.php`. It uses
+PHP's GD extension to re-encode the image (JPEG, PNG, GIF, WebP), which discards EXIF data:
+
+```php
+function strip_exif_metadata(string $filePath): array
+{
+    if (!env_bool('SEC_STRIP_EXIF_FROM_IMAGES', false)) {
+        return ['success' => true, 'skipped' => true];  // disabled by default
+    }
+    // load → re-save → destroys metadata
+    $image = imagecreatefromjpeg($filePath);
+    imagejpeg($image, $filePath, 90);
+    imagedestroy($image);
+    return ['success' => true];
+}
+```
+
+The feature is **disabled by default** and must be explicitly enabled in `ipconfig.php` with
+`SEC_STRIP_EXIF_FROM_IMAGES=true`. It was integrated into both the Upload controller and the
+Settings controller (for logo uploads). Failures are logged but do not block the upload.
+
+---
+
+## 18. Low — Password Reset Tokens with No Expiry
+
+**PR:** [#1514](https://github.com/InvoicePlane/InvoicePlane/pull/1514)  
+**CVSS:** 4.3
+
+### What Was Wrong
+
+Password reset tokens were valid indefinitely. A token generated months before but never
+used remained valid. If a reset email was intercepted, leaked in a log file, or obtained
+through another vector, an attacker could use it at any time to take over the account.
+
+### What Was Improved
+
+A `user_passwordreset_token_expiry DATETIME` column was added to `ip_users` (migration
+`044_1.7.3.sql`). Tokens now expire after a configurable duration (default: 15 minutes).
+
+```php
+// Token validation now checks expiry
+if (!empty($user->user_passwordreset_token_expiry)) {
+    $expiry  = new DateTime($user->user_passwordreset_token_expiry, self::$utc_timezone);
+    $now     = new DateTime('now',                                  self::$utc_timezone);
+    if ($now > $expiry) {
+        $this->_clear_password_reset_token($user->user_id);
+        // redirect with "token expired" message
+    }
+}
+```
+
+Configuration: `PASSWORD_RESET_TOKEN_EXPIRY_MINUTES` in `ipconfig.php` (default: 15,
+maximum enforced: 1440 minutes / 24 hours). Existing tokens without an expiry (NULL) continue
+working during the migration window for backward compatibility.
+
+---
+
+## 19. Review Follow-up — PR #1536 Hardening Pass
+
+**PR:** [#1536](https://github.com/InvoicePlane/InvoicePlane/pull/1536)
+
+This PR addressed issues raised during code review of the earlier security PRs. Key changes:
+
+**`entrypoint.sh` config-injection guard**  
+A `sanitize_config_value()` shell function was added that hard-fails on `\n` or `\r` in any
+environment variable before it is written into `ipconfig.php`. This prevents Docker
+deployments from being configured with injected newlines via environment variables.
+
+**`XSS_Protection_Trait` fix**  
+The `file_security` helper was moved to load at the top of `filter_input()` (unconditionally),
+not inside the `if ($xss_detected)` block. Previously, `sanitize_for_logging()` was
+unavailable when XSS detection ran but the block was not entered.
+
+**`Admin_Controller` duplicate removal**  
+A `sanitize_array()` override in `Admin_Controller` was removed. It shadowed the trait's
+sanitized version and logged raw field paths, creating a log-injection risk.
+
+**`invoice_helper` logo URL escaping**  
+The logo URL was wrapped in `html_escape()` before being emitted into an `<img src="..."`
+attribute.
+
+**`Mdl_templates` custom-template allowlisting**  
+The `_merge_custom()` method still used `directory_map()` for custom templates, recreating
+the RCE risk for custom installations. This was replaced with an explicit allowlist driven by
+four new `ipconfig.php` constants:
+
+```
+CUSTOM_INVOICE_TEMPLATES_PDF=MyTemplate,AnotherTemplate
+CUSTOM_INVOICE_TEMPLATES_PUBLIC=
+CUSTOM_QUOTE_TEMPLATES_PDF=
+CUSTOM_QUOTE_TEMPLATES_PUBLIC=
+```
+
+The filesystem is never scanned for custom templates either.
+
+**`Mdl_reports` integer cast fix**  
+`(int) $this->db->escape($minQuantity)` always produced `0` because `escape()` returns a
+quoted string like `'5'`. Fixed to `(int) $minQuantity`.
+
+**`Mdl_settings save_batch()` scope and transaction**  
+The existence check was scoped to only the keys being saved (previously loaded the full
+table). The insert and update operations were wrapped in a DB transaction.
+
+**`Payments.php` JOIN optimisation**  
+Two-query PHP-level invoice ID prefetch was replaced with a single `INNER JOIN` on
+`ip_invoices`.
+
+---
+
+## 20. New Cross-Cutting Security Infrastructure
+
+Several security helpers were created during the v1.7.2 cycle and are now available
+throughout the codebase:
+
+### `application/helpers/file_security_helper.php`
+
+| Function | Purpose |
+|----------|---------|
+| `validate_safe_filename(string $filename)` | Returns `['valid', 'hash', 'error']`; rejects traversal, null bytes, absolute paths, drive letters |
+| `validate_file_in_directory(string $path, string $dir)` | Ensures resolved real path stays within `$dir` |
+| `validate_file_access(string $filename, string $base_dir)` | Combines both checks; returns `['valid', 'path', 'hash', 'error']` |
+| `validate_db_filename(string $filename, string $base_dir)` | For DB-sourced filenames: strips dir components, validates, resolves path |
+| `validate_db_config_parameter(string $value, string $type)` | Validates DB setup params against type-specific allowlist patterns |
+| `sanitize_db_config_value(string $value)` | Escapes single quotes for config-file writes |
+| `sanitize_database_config_value(string $value)` | Strips control chars from DB config values |
+| `sanitize_database_port($port)` | Returns integer 1–65535 or null |
+| `strip_exif_metadata(string $filePath)` | Optional EXIF stripping via GD (requires `SEC_STRIP_EXIF_FROM_IMAGES=true`) |
+| `sanitize_pdf_footer_content(string $html)` | Allows safe HTML subset; removes external-resource attributes |
+
+### `application/helpers/ip_security_helper.php`
+
+| Function | Purpose |
+|----------|---------|
+| `generate_password_reset_token()` | 64-char hex from `random_bytes(32)` — 256-bit entropy |
+| `generate_secure_salt()` | Bcrypt-compatible 22-char salt from `random_bytes(16)` |
+| `generate_secure_token(int $bytes)` | Generic CSPRNG token of arbitrary length |
+| `sanitize_exception_for_logging(Throwable $e)` | Strips sensitive data from exception messages before logging |
+
+### `application/helpers/security_helper.php`
+
+| Function | Purpose |
+|----------|---------|
+| `get_safe_referer()` | Returns `HTTP_REFERER` only if same origin as `BASE_URL`; otherwise returns `base_url()` |
+| `validate_redirect_url(string $url)` | Checks scheme + host against base URL |
+| `escape_url_for_output(string $url)` | HTML-encodes URL for use in `href` / `src` attributes |
+| `escape_url_for_javascript(string $url)` | JSON-encodes URL for inline JS contexts |
+| `user_has_invoice_access(int $invoice_id)` | IDOR prevention: checks ownership via session |
+| `user_has_quote_access(int $quote_id)` | IDOR prevention for quotes |
+| `verify_csrf_token()` | Explicit CSRF token check outside of CI's auto-validation |
+
+### `sanitize_for_logging()`
+
+This function was created during v1.7.1 and is used throughout all new security code.
+It strips newlines (`\n`, `\r`), null bytes (`\0`), and other control characters from
+any string before it is written to a log file. This prevents a class of log-injection
+attacks where an attacker embeds fake log lines in an error message that gets logged.
+
+---
+
+*Document generated: 2026-04-27*

--- a/RELEASE_NOTES_v1.7.2_PR_TABLE.md
+++ b/RELEASE_NOTES_v1.7.2_PR_TABLE.md
@@ -70,6 +70,7 @@ truth for the README / CHANGELOG entry once v1.7.2 goes final.
 
 | PR | Title | Linked Issue | Notes |
 |----|-------|-------------|-------|
+| [#1289](https://github.com/InvoicePlane/InvoicePlane/pull/1289) | Re-introduce Stripe & PayPal; add PayPal Advanced Credit Cards and Venmo support | [#1288](https://github.com/InvoicePlane/InvoicePlane/issues/1288) | By [@drewangell](https://github.com/drewangell); enables Advanced CC fields, Venmo, improved error handling |
 | [#1489](https://github.com/InvoicePlane/InvoicePlane/pull/1489) | Allow specifying the QR-code size in invoices | [#1376](https://github.com/InvoicePlane/InvoicePlane/issues/1376) | New `ipconfig.php` option |
 
 ---

--- a/RELEASE_NOTES_v1.7.2_PR_TABLE.md
+++ b/RELEASE_NOTES_v1.7.2_PR_TABLE.md
@@ -137,21 +137,34 @@ disclosed once the final release is published.
 
 ## Contributor Acknowledgements
 
-Many thanks to the security researchers who responsibly disclosed vulnerabilities:
+### Security Researchers
 
-[Vijay-raghav7](https://github.com/Vijay-raghav7),
-[cyabell](https://github.com/cyabell),
-[HuajiHD](https://github.com/HuajiHD),
-[udaypali](https://github.com/udaypali),
-[radoi-teodor](https://github.com/radoi-teodor),
-[tikket1](https://github.com/tikket1),
-[Chittu13](https://github.com/Chittu13),
-[iiihaiii](https://github.com/iiihaiii),
+Many thanks to the security researchers who responsibly disclosed vulnerabilities through GitHub
+Security Advisories and private reports. Without their responsible disclosure, these issues
+would have remained undetected.
+
 [akgul7990](https://github.com/akgul7990),
 [ali-iltizar](https://github.com/ali-iltizar),
-[kitu232](https://github.com/kitu232)
+[Chittu13](https://github.com/Chittu13),
+[cyabell](https://github.com/cyabell),
+[HuajiHD](https://github.com/HuajiHD),
+[iiihaiii](https://github.com/iiihaiii),
+[kitu232](https://github.com/kitu232),
+[radoi-teodor](https://github.com/radoi-teodor),
+[tikket1](https://github.com/tikket1),
+[udaypali](https://github.com/udaypali),
+[Vijay-raghav7](https://github.com/Vijay-raghav7)
 
-And thanks to [@drewangell](https://github.com/drewangell) for re-introducing Stripe and PayPal support with Advanced Credit Cards and Venmo.
+### Contributors
+
+Many thanks to the community members who contributed code that was merged in this release.
+
+[mpldr](https://github.com/mpldr) — Docker application container with combined web server + PHP in a
+single image (`entrypoint.sh`, PR [#1509](https://github.com/InvoicePlane/InvoicePlane/pull/1509));
+configurable QR-code size in invoices (PR [#1489](https://github.com/InvoicePlane/InvoicePlane/pull/1489))
+
+[PatrickGTR](https://github.com/PatrickGTR) — Fix quote public template displaying client name on both
+header and footer (PR [#1449](https://github.com/InvoicePlane/InvoicePlane/pull/1449))
 
 ---
 

--- a/RELEASE_NOTES_v1.7.2_PR_TABLE.md
+++ b/RELEASE_NOTES_v1.7.2_PR_TABLE.md
@@ -7,6 +7,10 @@ truth for the README / CHANGELOG entry once v1.7.2 goes final.
 > **Note:** Security advisories will be formally published after the final v1.7.2 release.
 > CVE identifiers marked *Pending* will be updated once assigned.
 
+> **Sort order:** All sections are ordered by PR number (ascending). The Security Fixes section
+> is ordered by severity (most critical first), then CVSS score (descending), then PR number
+> (ascending) within each tier. The Security Advisories Reference table follows the same rule.
+
 ---
 
 ## Table of Contents
@@ -22,51 +26,58 @@ truth for the README / CHANGELOG entry once v1.7.2 goes final.
 
 ## Security Fixes
 
+> Sorted by: Severity DESC → CVSS DESC → PR ID ASC within each tier.
+
 | PR | Title | Linked Issue | Security Advisory / CVE | CVSS | Severity |
 |----|-------|-------------|--------------------------|------|----------|
-| [#1505](https://github.com/InvoicePlane/InvoicePlane/pull/1505) | Fix RCE vulnerability in template system (patch bypass of v1.7.1 LFI fix) | — | [SECURITY_ADVISORY_RCE_FIX.md](SECURITY_ADVISORY_RCE_FIX.md) — CVE Pending | 9.9 | 🔴 CRITICAL |
-| [#1516](https://github.com/InvoicePlane/InvoicePlane/pull/1516) | Comprehensive XSS fixes across InvoicePlane (30+ vulnerabilities) | — | — CVE Pending | 8.0 | 🔴 HIGH |
-| [#1512](https://github.com/InvoicePlane/InvoicePlane/pull/1512) | Fix path traversal vulnerability in logo file deletion (arbitrary file deletion) | — | [SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md](SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md) — CVE Pending | 7.1 | 🔴 HIGH |
-| [#1481](https://github.com/InvoicePlane/InvoicePlane/pull/1481) | Fix SQL injection in tax rate decimal places setting | [#1479](https://github.com/InvoicePlane/InvoicePlane/issues/1479) | — CVE Pending | 7.2 | 🔴 HIGH |
+| [#1505](https://github.com/InvoicePlane/InvoicePlane/pull/1505) | Fix RCE vulnerability in template system — replace `directory_map()` whitelist with static constants; fix 5 open-redirect instances; add `security_helper.php` | — | [SECURITY_ADVISORY_RCE_FIX.md](SECURITY_ADVISORY_RCE_FIX.md) — CVE Pending | 9.9 | 🔴 CRITICAL |
+| [#1506](https://github.com/InvoicePlane/InvoicePlane/pull/1506) | CodeRabbit auto-fixes for #1505: correct `security_helper.php` (stacked follow-up) | — | See #1505 | — | 🔴 CRITICAL (follow-up) |
+| [#1516](https://github.com/InvoicePlane/InvoicePlane/pull/1516) | Comprehensive XSS fixes across InvoicePlane — 32 vulnerabilities across 17 view files in 4 modules | — | — CVE Pending | 8.0 | 🔴 HIGH |
 | [#1482](https://github.com/InvoicePlane/InvoicePlane/pull/1482) | Fix IDOR, CSRF, and SQL injection vulnerabilities in guest controllers | — | — CVE Pending | 7.5 | 🔴 HIGH |
-| [#1488](https://github.com/InvoicePlane/InvoicePlane/pull/1488) | Harden tax rate decimal setting against DDL injection | [#1479](https://github.com/InvoicePlane/InvoicePlane/issues/1479) | — CVE Pending | 7.2 | 🔴 HIGH |
-| [#1494](https://github.com/InvoicePlane/InvoicePlane/pull/1494) | Replace weak PRNG in password reset tokens with `random_bytes(32)` | — | Related to [CVE-2021-29023](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29023) | 7.5 | 🔴 HIGH |
+| [#1494](https://github.com/InvoicePlane/InvoicePlane/pull/1494) | Replace weak PRNG in password reset tokens with `random_bytes(32)` (256-bit entropy) | — | Related to [CVE-2021-29023](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29023) | 7.5 | 🔴 HIGH |
+| [#1481](https://github.com/InvoicePlane/InvoicePlane/pull/1481) | Fix SQL injection in tax rate decimal places setting | [#1479](https://github.com/InvoicePlane/InvoicePlane/issues/1479) | — CVE Pending | 7.2 | 🔴 HIGH |
+| [#1488](https://github.com/InvoicePlane/InvoicePlane/pull/1488) | Harden tax rate decimal setting against DDL injection — add `TaxRateDecimalPlacesProcessor`, transaction wrap, unit tests | [#1479](https://github.com/InvoicePlane/InvoicePlane/issues/1479) | — CVE Pending | 7.2 | 🔴 HIGH |
 | [#1513](https://github.com/InvoicePlane/InvoicePlane/pull/1513) | Fix configuration injection vulnerability in database setup (newline injection) | — | — CVE Pending | 7.2 | 🔴 HIGH |
-| [#1500](https://github.com/InvoicePlane/InvoicePlane/pull/1500) | Fix Stored XSS vulnerabilities with comprehensive application-wide protection | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1512](https://github.com/InvoicePlane/InvoicePlane/pull/1512) | Fix path traversal vulnerability in logo file deletion (arbitrary file deletion) | — | [SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md](SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md) — CVE Pending | 7.1 | 🔴 HIGH |
 | [#1471](https://github.com/InvoicePlane/InvoicePlane/pull/1471) | Fix authorization bypass and CSRF vulnerability in guest quote approve/reject endpoints | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
-| [#1487](https://github.com/InvoicePlane/InvoicePlane/pull/1487) | Fix CSRF and authorization vulnerabilities in guest quote and payment gateways | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1487](https://github.com/InvoicePlane/InvoicePlane/pull/1487) | Fix CSRF and authorization vulnerabilities in guest quote and payment gateways (Stripe + PayPal) | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
 | [#1491](https://github.com/InvoicePlane/InvoicePlane/pull/1491) | Harden setup wizard: lock DB rewrites post-install while allowing upgrades | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
 | [#1492](https://github.com/InvoicePlane/InvoicePlane/pull/1492) | Sanitize PDF footer content to block SSRF in mPDF rendering | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
-| [#1510](https://github.com/InvoicePlane/InvoicePlane/pull/1510) | Fix file path traversal vulnerabilities across codebase | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
-| [#1515](https://github.com/InvoicePlane/InvoicePlane/pull/1515) | Prevent API credential exposure in payment gateway settings | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
-| [#1517](https://github.com/InvoicePlane/InvoicePlane/pull/1517) | Fix authorization bypass in guest invoice detail endpoint | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
-| [#1518](https://github.com/InvoicePlane/InvoicePlane/pull/1518) | Automatically disable setup wizard and add security warning system | — | — CVE Pending | 6.1 | 🟠 MEDIUM |
-| [#1486](https://github.com/InvoicePlane/InvoicePlane/pull/1486) | Render email template previews with sanitized HTML; harden build tooling | — | — | 5.4 | 🟡 MEDIUM |
-| [#1495](https://github.com/InvoicePlane/InvoicePlane/pull/1495) | Fix PHPMailer debug output breaking AJAX responses; sanitize SMTP debug log | — | — | 5.3 | 🟡 MEDIUM |
-| [#1496](https://github.com/InvoicePlane/InvoicePlane/pull/1496) | Prevent duplicate payment processing in Stripe and PayPal callbacks | — | — | 5.3 | 🟡 MEDIUM |
-| [#1507](https://github.com/InvoicePlane/InvoicePlane/pull/1507) | Add optional EXIF metadata stripping from uploaded images (disabled by default) | — | — | 4.3 | 🟡 LOW–MEDIUM |
-| [#1511](https://github.com/InvoicePlane/InvoicePlane/pull/1511) | Block setup wizard access when `SETUP_COMPLETED=true` | — | — | 4.3 | 🟡 LOW–MEDIUM |
-| [#1514](https://github.com/InvoicePlane/InvoicePlane/pull/1514) | Add expiration to password reset tokens (default: 15 minutes) | — | — | 4.3 | 🟡 LOW–MEDIUM |
-| [#1536](https://github.com/InvoicePlane/InvoicePlane/pull/1536) | Address PR review: config injection hardening, helper load order fix, RCE prevention, log-injection removal, HTML escaping | — | — | — | 🟡 MULTIPLE |
-| [#1537](https://github.com/InvoicePlane/InvoicePlane/pull/1537) | Fix authorization bypass in guest payment endpoints (draft invoice access) | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1500](https://github.com/InvoicePlane/InvoicePlane/pull/1500) | Fix Stored XSS vulnerabilities with comprehensive application-wide protection | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1510](https://github.com/InvoicePlane/InvoicePlane/pull/1510) | Fix file path traversal vulnerabilities across codebase — add `validate_db_filename()`, symlink protection, XSS prevention in attachment names | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1515](https://github.com/InvoicePlane/InvoicePlane/pull/1515) | Prevent API credential exposure in payment gateway settings (Stripe/PayPal keys no longer in HTML source) | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1517](https://github.com/InvoicePlane/InvoicePlane/pull/1517) | Fix authorization bypass in guest invoice detail endpoint — add `guest_visible()` filter | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1537](https://github.com/InvoicePlane/InvoicePlane/pull/1537) | Fix authorization bypass in guest payment endpoints allowing access to draft invoices | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1518](https://github.com/InvoicePlane/InvoicePlane/pull/1518) | Automatically disable setup wizard post-install and add admin security warning system | — | — CVE Pending | 6.1 | 🟠 MEDIUM |
+| [#1486](https://github.com/InvoicePlane/InvoicePlane/pull/1486) | Render email template previews with sanitized HTML; harden Grunt build tooling | — | — | 5.4 | 🟡 LOW–MEDIUM |
+| [#1495](https://github.com/InvoicePlane/InvoicePlane/pull/1495) | Fix PHPMailer debug output breaking AJAX responses; route SMTP debug to CI log with `sanitize_for_logging()` | — | — | 5.3 | 🟡 LOW–MEDIUM |
+| [#1496](https://github.com/InvoicePlane/InvoicePlane/pull/1496) | Prevent duplicate payment processing in Stripe and PayPal callbacks — add `payment_external_id` unique index | — | — | 5.3 | 🟡 LOW–MEDIUM |
+| [#1507](https://github.com/InvoicePlane/InvoicePlane/pull/1507) | Add optional EXIF metadata stripping from uploaded images (disabled by default via `SEC_STRIP_EXIF_FROM_IMAGES`) | — | — | 4.3 | 🟡 LOW |
+| [#1511](https://github.com/InvoicePlane/InvoicePlane/pull/1511) | Block setup wizard access when `SETUP_COMPLETED=true` — early 403 guard in `Setup.php` constructor | — | — | 4.3 | 🟡 LOW |
+| [#1514](https://github.com/InvoicePlane/InvoicePlane/pull/1514) | Add expiration to password reset tokens (default: 15 minutes, configurable via `PASSWORD_RESET_TOKEN_EXPIRY_MINUTES`) | — | — | 4.3 | 🟡 LOW |
+| [#1536](https://github.com/InvoicePlane/InvoicePlane/pull/1536) | Address PR review: `entrypoint.sh` config-injection guard, XSS trait fix, logo URL escaping, custom templates allowlisting, `Mdl_reports` cast fix, duplicate `remove_logo()` removal | — | — | — | 🟡 MULTIPLE |
 
 ---
 
 ## Bug Fixes
 
+> Sorted by PR ID ascending.
+
 | PR | Title | Linked Issue | Notes |
 |----|-------|-------------|-------|
-| [#1473](https://github.com/InvoicePlane/InvoicePlane/pull/1473) | Fix undefined array key error for mPDF footer names in PHP 8.3+ | [#1180](https://github.com/InvoicePlane/InvoicePlane/issues/1180) | PHP 8.3+ compatibility |
-| [#1426](https://github.com/InvoicePlane/InvoicePlane/pull/1426) | Remittance — fix remittance slip generation | — | — |
+| [#1426](https://github.com/InvoicePlane/InvoicePlane/pull/1426) | Remittance — fix remittance slip generation | [#1140](https://github.com/InvoicePlane/InvoicePlane/issues/1140) | Remittance text on QR code |
 | [#1449](https://github.com/InvoicePlane/InvoicePlane/pull/1449) | Fix `/quote_templates/public/` template displaying client on both header and footer | — | Template rendering fix |
 | [#1451](https://github.com/InvoicePlane/InvoicePlane/pull/1451) | Fix QR code generation for batch invoice processing | — | — |
 | [#1465](https://github.com/InvoicePlane/InvoicePlane/pull/1465) | Simplify redundant conditional checks in email template tags | — | Code cleanup |
+| [#1473](https://github.com/InvoicePlane/InvoicePlane/pull/1473) | Fix undefined array key error for mPDF footer names in PHP 8.3+ | [#1180](https://github.com/InvoicePlane/InvoicePlane/issues/1180) | PHP 8.3+ compatibility |
 | [#1478](https://github.com/InvoicePlane/InvoicePlane/pull/1478) | Add missing `attachment()` method to guest `Get` controller; refactor duplicate code | — | [Bug](https://github.com/InvoicePlane/InvoicePlane/labels/Bug) label |
 | [#1499](https://github.com/InvoicePlane/InvoicePlane/pull/1499) | Fix email template preview rendering raw HTML instead of rendered content | — | DOM-XSS risk also eliminated |
 
 ---
 
 ## Features & Improvements
+
+> Sorted by PR ID ascending.
 
 | PR | Title | Linked Issue | Notes |
 |----|-------|-------------|-------|
@@ -77,6 +88,8 @@ truth for the README / CHANGELOG entry once v1.7.2 goes final.
 
 ## Performance & Code Quality
 
+> Sorted by PR ID ascending.
+
 | PR | Title | Notes |
 |----|-------|-------|
 | [#1483](https://github.com/InvoicePlane/InvoicePlane/pull/1483) | Optimize settings save: batch operations reduce DB queries from ~70 to 3 | Transaction-wrapped insert+update |
@@ -86,11 +99,14 @@ truth for the README / CHANGELOG entry once v1.7.2 goes final.
 
 ## Infrastructure & CI
 
+> Sorted by PR ID ascending.
+
 | PR | Title | Notes |
 |----|-------|-------|
 | [#1466](https://github.com/InvoicePlane/InvoicePlane/pull/1466) | Rename `.github/action.yml.txt` to `.github/actions/setup-php-composer/action.yml` | CI housekeeping |
 | [#1490](https://github.com/InvoicePlane/InvoicePlane/pull/1490) | Set up code style check with Laravel Pint | CI: auto-formatting |
 | [#1509](https://github.com/InvoicePlane/InvoicePlane/pull/1509) | Add application container (Docker) | New Docker build/entrypoint |
+| [#1529](https://github.com/InvoicePlane/InvoicePlane/pull/1529) | Document arbitrary file deletion vulnerability for CVE allocation | Adds `SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md`, `CVE_REQUEST_SUMMARY.md`, `verify_file_deletion_fix.php`, `SECURITY_DOCS_README.md` |
 
 ---
 
@@ -99,21 +115,23 @@ truth for the README / CHANGELOG entry once v1.7.2 goes final.
 The following formal security advisories have been prepared for v1.7.2. CVE IDs will be
 disclosed once the final release is published.
 
-| Advisory File | Vulnerability | CWE | CVSS v3.1 | Severity | Fixed In PR | Affected Versions |
-|---------------|--------------|-----|-----------|----------|-------------|-------------------|
-| [SECURITY_ADVISORY_RCE_FIX.md](SECURITY_ADVISORY_RCE_FIX.md) | Remote Code Execution via template system (patch bypass of v1.7.1 LFI fix) | CWE-693 | 9.9 | 🔴 CRITICAL | [#1505](https://github.com/InvoicePlane/InvoicePlane/pull/1505) | v1.7.0, v1.7.1 |
-| [SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md](SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md) | Arbitrary file deletion via path traversal in logo settings | CWE-22 | 7.1 | 🔴 HIGH | [#1512](https://github.com/InvoicePlane/InvoicePlane/pull/1512) | v1.7.0, v1.7.1 |
-| *(pending)* | SQL / DDL injection in tax rate decimal places setting | CWE-89 | 7.2 | 🔴 HIGH | [#1481](https://github.com/InvoicePlane/InvoicePlane/pull/1481), [#1488](https://github.com/InvoicePlane/InvoicePlane/pull/1488) | v1.7.0, v1.7.1 |
+> Sorted by: Severity DESC → CVSS DESC → first fixing PR ID ASC within each tier.
+
+| Advisory File | Vulnerability | CWE | CVSS v3.1 | Severity | Fixed In PR(s) | Affected Versions |
+|---------------|--------------|-----|-----------|----------|----------------|-------------------|
+| [SECURITY_ADVISORY_RCE_FIX.md](SECURITY_ADVISORY_RCE_FIX.md) | Remote Code Execution via template system (dynamic whitelist bypass of v1.7.1 LFI fix) | CWE-693, CWE-98 | 9.9 | 🔴 CRITICAL | [#1505](https://github.com/InvoicePlane/InvoicePlane/pull/1505), [#1506](https://github.com/InvoicePlane/InvoicePlane/pull/1506) | v1.7.0, v1.7.1 |
+| *(pending)* | Stored XSS — 32 vulnerabilities across 17 view files (settings, invoices, quotes, projects) | CWE-79 | 8.0 | 🔴 HIGH | [#1500](https://github.com/InvoicePlane/InvoicePlane/pull/1500), [#1516](https://github.com/InvoicePlane/InvoicePlane/pull/1516) | v1.7.0, v1.7.1 |
 | *(pending)* | IDOR + CSRF in guest quote approve/reject endpoints | CWE-639, CWE-352 | 7.5 | 🔴 HIGH | [#1471](https://github.com/InvoicePlane/InvoicePlane/pull/1471), [#1482](https://github.com/InvoicePlane/InvoicePlane/pull/1482), [#1487](https://github.com/InvoicePlane/InvoicePlane/pull/1487) | v1.7.0, v1.7.1 |
 | *(pending)* | Weak PRNG in password reset tokens (related to CVE-2021-29023) | CWE-338 | 7.5 | 🔴 HIGH | [#1494](https://github.com/InvoicePlane/InvoicePlane/pull/1494) | v1.7.0, v1.7.1 |
+| *(pending)* | SQL / DDL injection in tax rate decimal places setting | CWE-89 | 7.2 | 🔴 HIGH | [#1481](https://github.com/InvoicePlane/InvoicePlane/pull/1481), [#1488](https://github.com/InvoicePlane/InvoicePlane/pull/1488) | v1.7.0, v1.7.1 |
 | *(pending)* | Configuration (newline) injection in database setup | CWE-93 | 7.2 | 🔴 HIGH | [#1513](https://github.com/InvoicePlane/InvoicePlane/pull/1513) | v1.7.0, v1.7.1 |
-| *(pending)* | Stored XSS — 30+ vulnerabilities across 17 view files | CWE-79 | 8.0 | 🔴 HIGH | [#1516](https://github.com/InvoicePlane/InvoicePlane/pull/1516), [#1500](https://github.com/InvoicePlane/InvoicePlane/pull/1500) | v1.7.0, v1.7.1 |
-| *(pending)* | Authorization bypass in guest invoice/payment endpoints (draft invoice access) | CWE-863 | 6.5 | 🟠 MEDIUM | [#1517](https://github.com/InvoicePlane/InvoicePlane/pull/1517), [#1537](https://github.com/InvoicePlane/InvoicePlane/pull/1537) | v1.7.0, v1.7.1 |
-| *(pending)* | SSRF via PDF footer content in mPDF rendering | CWE-918 | 6.5 | 🟠 MEDIUM | [#1492](https://github.com/InvoicePlane/InvoicePlane/pull/1492) | v1.7.0, v1.7.1 |
-| *(pending)* | File path traversal across codebase (settings, uploads, templates) | CWE-22 | 6.5 | 🟠 MEDIUM | [#1510](https://github.com/InvoicePlane/InvoicePlane/pull/1510) | v1.7.0, v1.7.1 |
-| *(pending)* | API credential exposure in payment gateway settings (Stripe/PayPal keys in HTML) | CWE-312 | 6.5 | 🟠 MEDIUM | [#1515](https://github.com/InvoicePlane/InvoicePlane/pull/1515) | v1.7.0, v1.7.1 |
+| [SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md](SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md) | Arbitrary file deletion via path traversal in logo settings | CWE-22 | 7.1 | 🔴 HIGH | [#1512](https://github.com/InvoicePlane/InvoicePlane/pull/1512), [#1510](https://github.com/InvoicePlane/InvoicePlane/pull/1510) | v1.7.0, v1.7.1 |
 | *(pending)* | Setup wizard not locked post-installation (unauthenticated config overwrite) | CWE-287 | 6.5 | 🟠 MEDIUM | [#1491](https://github.com/InvoicePlane/InvoicePlane/pull/1491), [#1511](https://github.com/InvoicePlane/InvoicePlane/pull/1511), [#1518](https://github.com/InvoicePlane/InvoicePlane/pull/1518) | v1.7.0, v1.7.1 |
-| *(pending)* | Open redirect via unvalidated `HTTP_REFERER` | CWE-601 | 6.1 | 🟠 MEDIUM | [#1505](https://github.com/InvoicePlane/InvoicePlane/pull/1505) | v1.7.0, v1.7.1 |
+| *(pending)* | SSRF via PDF footer content in mPDF rendering | CWE-918 | 6.5 | 🟠 MEDIUM | [#1492](https://github.com/InvoicePlane/InvoicePlane/pull/1492) | v1.7.0, v1.7.1 |
+| *(pending)* | File path traversal across codebase (settings, uploads, guest controller) | CWE-22 | 6.5 | 🟠 MEDIUM | [#1510](https://github.com/InvoicePlane/InvoicePlane/pull/1510) | v1.7.0, v1.7.1 |
+| *(pending)* | API credential exposure in payment gateway settings (Stripe/PayPal keys in HTML source) | CWE-312 | 6.5 | 🟠 MEDIUM | [#1515](https://github.com/InvoicePlane/InvoicePlane/pull/1515) | v1.7.0, v1.7.1 |
+| *(pending)* | Authorization bypass in guest invoice/payment endpoints (draft invoice access) | CWE-863 | 6.5 | 🟠 MEDIUM | [#1517](https://github.com/InvoicePlane/InvoicePlane/pull/1517), [#1537](https://github.com/InvoicePlane/InvoicePlane/pull/1537) | v1.7.0, v1.7.1 |
+| *(pending)* | Open redirect via unvalidated `HTTP_REFERER` (5 instances) | CWE-601 | 6.1 | 🟠 MEDIUM | [#1505](https://github.com/InvoicePlane/InvoicePlane/pull/1505) | v1.7.0, v1.7.1 |
 
 ---
 
@@ -133,7 +151,7 @@ Many thanks to the security researchers who responsibly disclosed vulnerabilitie
 [ali-iltizar](https://github.com/ali-iltizar),
 [kitu232](https://github.com/kitu232)
 
-And thanks to [@drewangell](https://github.com/drewangell) for re-introducing Stripe and PayPal support.
+And thanks to [@drewangell](https://github.com/drewangell) for re-introducing Stripe and PayPal support with Advanced Credit Cards and Venmo.
 
 ---
 

--- a/RELEASE_NOTES_v1.7.2_PR_TABLE.md
+++ b/RELEASE_NOTES_v1.7.2_PR_TABLE.md
@@ -1,0 +1,139 @@
+# InvoicePlane v1.7.2 — Pull Request & Release Summary
+
+This document lists all pull requests resolved in the **v1.7.2** release cycle, together with
+any linked GitHub issues and associated security advisories. It is intended as the source of
+truth for the README / CHANGELOG entry once v1.7.2 goes final.
+
+> **Note:** Security advisories will be formally published after the final v1.7.2 release.
+> CVE identifiers marked *Pending* will be updated once assigned.
+
+---
+
+## Table of Contents
+
+1. [Security Fixes](#security-fixes)
+2. [Bug Fixes](#bug-fixes)
+3. [Features & Improvements](#features--improvements)
+4. [Performance & Code Quality](#performance--code-quality)
+5. [Infrastructure & CI](#infrastructure--ci)
+6. [Security Advisories Reference](#security-advisories-reference)
+
+---
+
+## Security Fixes
+
+| PR | Title | Linked Issue | Security Advisory / CVE | CVSS | Severity |
+|----|-------|-------------|--------------------------|------|----------|
+| [#1505](https://github.com/InvoicePlane/InvoicePlane/pull/1505) | Fix RCE vulnerability in template system (patch bypass of v1.7.1 LFI fix) | — | [SECURITY_ADVISORY_RCE_FIX.md](SECURITY_ADVISORY_RCE_FIX.md) — CVE Pending | 9.9 | 🔴 CRITICAL |
+| [#1516](https://github.com/InvoicePlane/InvoicePlane/pull/1516) | Comprehensive XSS fixes across InvoicePlane (30+ vulnerabilities) | — | — CVE Pending | 8.0 | 🔴 HIGH |
+| [#1512](https://github.com/InvoicePlane/InvoicePlane/pull/1512) | Fix path traversal vulnerability in logo file deletion (arbitrary file deletion) | — | [SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md](SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md) — CVE Pending | 7.1 | 🔴 HIGH |
+| [#1481](https://github.com/InvoicePlane/InvoicePlane/pull/1481) | Fix SQL injection in tax rate decimal places setting | [#1479](https://github.com/InvoicePlane/InvoicePlane/issues/1479) | — CVE Pending | 7.2 | 🔴 HIGH |
+| [#1482](https://github.com/InvoicePlane/InvoicePlane/pull/1482) | Fix IDOR, CSRF, and SQL injection vulnerabilities in guest controllers | — | — CVE Pending | 7.5 | 🔴 HIGH |
+| [#1488](https://github.com/InvoicePlane/InvoicePlane/pull/1488) | Harden tax rate decimal setting against DDL injection | [#1479](https://github.com/InvoicePlane/InvoicePlane/issues/1479) | — CVE Pending | 7.2 | 🔴 HIGH |
+| [#1494](https://github.com/InvoicePlane/InvoicePlane/pull/1494) | Replace weak PRNG in password reset tokens with `random_bytes(32)` | — | Related to [CVE-2021-29023](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29023) | 7.5 | 🔴 HIGH |
+| [#1513](https://github.com/InvoicePlane/InvoicePlane/pull/1513) | Fix configuration injection vulnerability in database setup (newline injection) | — | — CVE Pending | 7.2 | 🔴 HIGH |
+| [#1500](https://github.com/InvoicePlane/InvoicePlane/pull/1500) | Fix Stored XSS vulnerabilities with comprehensive application-wide protection | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1471](https://github.com/InvoicePlane/InvoicePlane/pull/1471) | Fix authorization bypass and CSRF vulnerability in guest quote approve/reject endpoints | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1487](https://github.com/InvoicePlane/InvoicePlane/pull/1487) | Fix CSRF and authorization vulnerabilities in guest quote and payment gateways | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1491](https://github.com/InvoicePlane/InvoicePlane/pull/1491) | Harden setup wizard: lock DB rewrites post-install while allowing upgrades | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1492](https://github.com/InvoicePlane/InvoicePlane/pull/1492) | Sanitize PDF footer content to block SSRF in mPDF rendering | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1510](https://github.com/InvoicePlane/InvoicePlane/pull/1510) | Fix file path traversal vulnerabilities across codebase | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1515](https://github.com/InvoicePlane/InvoicePlane/pull/1515) | Prevent API credential exposure in payment gateway settings | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1517](https://github.com/InvoicePlane/InvoicePlane/pull/1517) | Fix authorization bypass in guest invoice detail endpoint | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+| [#1518](https://github.com/InvoicePlane/InvoicePlane/pull/1518) | Automatically disable setup wizard and add security warning system | — | — CVE Pending | 6.1 | 🟠 MEDIUM |
+| [#1486](https://github.com/InvoicePlane/InvoicePlane/pull/1486) | Render email template previews with sanitized HTML; harden build tooling | — | — | 5.4 | 🟡 MEDIUM |
+| [#1495](https://github.com/InvoicePlane/InvoicePlane/pull/1495) | Fix PHPMailer debug output breaking AJAX responses; sanitize SMTP debug log | — | — | 5.3 | 🟡 MEDIUM |
+| [#1496](https://github.com/InvoicePlane/InvoicePlane/pull/1496) | Prevent duplicate payment processing in Stripe and PayPal callbacks | — | — | 5.3 | 🟡 MEDIUM |
+| [#1507](https://github.com/InvoicePlane/InvoicePlane/pull/1507) | Add optional EXIF metadata stripping from uploaded images (disabled by default) | — | — | 4.3 | 🟡 LOW–MEDIUM |
+| [#1511](https://github.com/InvoicePlane/InvoicePlane/pull/1511) | Block setup wizard access when `SETUP_COMPLETED=true` | — | — | 4.3 | 🟡 LOW–MEDIUM |
+| [#1514](https://github.com/InvoicePlane/InvoicePlane/pull/1514) | Add expiration to password reset tokens (default: 15 minutes) | — | — | 4.3 | 🟡 LOW–MEDIUM |
+| [#1536](https://github.com/InvoicePlane/InvoicePlane/pull/1536) | Address PR review: config injection hardening, helper load order fix, RCE prevention, log-injection removal, HTML escaping | — | — | — | 🟡 MULTIPLE |
+| [#1537](https://github.com/InvoicePlane/InvoicePlane/pull/1537) | Fix authorization bypass in guest payment endpoints (draft invoice access) | — | — CVE Pending | 6.5 | 🟠 MEDIUM |
+
+---
+
+## Bug Fixes
+
+| PR | Title | Linked Issue | Notes |
+|----|-------|-------------|-------|
+| [#1473](https://github.com/InvoicePlane/InvoicePlane/pull/1473) | Fix undefined array key error for mPDF footer names in PHP 8.3+ | [#1180](https://github.com/InvoicePlane/InvoicePlane/issues/1180) | PHP 8.3+ compatibility |
+| [#1426](https://github.com/InvoicePlane/InvoicePlane/pull/1426) | Remittance — fix remittance slip generation | — | — |
+| [#1449](https://github.com/InvoicePlane/InvoicePlane/pull/1449) | Fix `/quote_templates/public/` template displaying client on both header and footer | — | Template rendering fix |
+| [#1451](https://github.com/InvoicePlane/InvoicePlane/pull/1451) | Fix QR code generation for batch invoice processing | — | — |
+| [#1465](https://github.com/InvoicePlane/InvoicePlane/pull/1465) | Simplify redundant conditional checks in email template tags | — | Code cleanup |
+| [#1478](https://github.com/InvoicePlane/InvoicePlane/pull/1478) | Add missing `attachment()` method to guest `Get` controller; refactor duplicate code | — | [Bug](https://github.com/InvoicePlane/InvoicePlane/labels/Bug) label |
+| [#1499](https://github.com/InvoicePlane/InvoicePlane/pull/1499) | Fix email template preview rendering raw HTML instead of rendered content | — | DOM-XSS risk also eliminated |
+
+---
+
+## Features & Improvements
+
+| PR | Title | Linked Issue | Notes |
+|----|-------|-------------|-------|
+| [#1489](https://github.com/InvoicePlane/InvoicePlane/pull/1489) | Allow specifying the QR-code size in invoices | [#1376](https://github.com/InvoicePlane/InvoicePlane/issues/1376) | New `ipconfig.php` option |
+
+---
+
+## Performance & Code Quality
+
+| PR | Title | Notes |
+|----|-------|-------|
+| [#1483](https://github.com/InvoicePlane/InvoicePlane/pull/1483) | Optimize settings save: batch operations reduce DB queries from ~70 to 3 | Transaction-wrapped insert+update |
+| [#1503](https://github.com/InvoicePlane/InvoicePlane/pull/1503) | Add database indexes for performance optimization | Indexes on frequently queried columns |
+
+---
+
+## Infrastructure & CI
+
+| PR | Title | Notes |
+|----|-------|-------|
+| [#1466](https://github.com/InvoicePlane/InvoicePlane/pull/1466) | Rename `.github/action.yml.txt` to `.github/actions/setup-php-composer/action.yml` | CI housekeeping |
+| [#1490](https://github.com/InvoicePlane/InvoicePlane/pull/1490) | Set up code style check with Laravel Pint | CI: auto-formatting |
+| [#1509](https://github.com/InvoicePlane/InvoicePlane/pull/1509) | Add application container (Docker) | New Docker build/entrypoint |
+
+---
+
+## Security Advisories Reference
+
+The following formal security advisories have been prepared for v1.7.2. CVE IDs will be
+disclosed once the final release is published.
+
+| Advisory File | Vulnerability | CWE | CVSS v3.1 | Severity | Fixed In PR | Affected Versions |
+|---------------|--------------|-----|-----------|----------|-------------|-------------------|
+| [SECURITY_ADVISORY_RCE_FIX.md](SECURITY_ADVISORY_RCE_FIX.md) | Remote Code Execution via template system (patch bypass of v1.7.1 LFI fix) | CWE-693 | 9.9 | 🔴 CRITICAL | [#1505](https://github.com/InvoicePlane/InvoicePlane/pull/1505) | v1.7.0, v1.7.1 |
+| [SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md](SECURITY_ADVISORY_ARBITRARY_FILE_DELETION.md) | Arbitrary file deletion via path traversal in logo settings | CWE-22 | 7.1 | 🔴 HIGH | [#1512](https://github.com/InvoicePlane/InvoicePlane/pull/1512) | v1.7.0, v1.7.1 |
+| *(pending)* | SQL / DDL injection in tax rate decimal places setting | CWE-89 | 7.2 | 🔴 HIGH | [#1481](https://github.com/InvoicePlane/InvoicePlane/pull/1481), [#1488](https://github.com/InvoicePlane/InvoicePlane/pull/1488) | v1.7.0, v1.7.1 |
+| *(pending)* | IDOR + CSRF in guest quote approve/reject endpoints | CWE-639, CWE-352 | 7.5 | 🔴 HIGH | [#1471](https://github.com/InvoicePlane/InvoicePlane/pull/1471), [#1482](https://github.com/InvoicePlane/InvoicePlane/pull/1482), [#1487](https://github.com/InvoicePlane/InvoicePlane/pull/1487) | v1.7.0, v1.7.1 |
+| *(pending)* | Weak PRNG in password reset tokens (related to CVE-2021-29023) | CWE-338 | 7.5 | 🔴 HIGH | [#1494](https://github.com/InvoicePlane/InvoicePlane/pull/1494) | v1.7.0, v1.7.1 |
+| *(pending)* | Configuration (newline) injection in database setup | CWE-93 | 7.2 | 🔴 HIGH | [#1513](https://github.com/InvoicePlane/InvoicePlane/pull/1513) | v1.7.0, v1.7.1 |
+| *(pending)* | Stored XSS — 30+ vulnerabilities across 17 view files | CWE-79 | 8.0 | 🔴 HIGH | [#1516](https://github.com/InvoicePlane/InvoicePlane/pull/1516), [#1500](https://github.com/InvoicePlane/InvoicePlane/pull/1500) | v1.7.0, v1.7.1 |
+| *(pending)* | Authorization bypass in guest invoice/payment endpoints (draft invoice access) | CWE-863 | 6.5 | 🟠 MEDIUM | [#1517](https://github.com/InvoicePlane/InvoicePlane/pull/1517), [#1537](https://github.com/InvoicePlane/InvoicePlane/pull/1537) | v1.7.0, v1.7.1 |
+| *(pending)* | SSRF via PDF footer content in mPDF rendering | CWE-918 | 6.5 | 🟠 MEDIUM | [#1492](https://github.com/InvoicePlane/InvoicePlane/pull/1492) | v1.7.0, v1.7.1 |
+| *(pending)* | File path traversal across codebase (settings, uploads, templates) | CWE-22 | 6.5 | 🟠 MEDIUM | [#1510](https://github.com/InvoicePlane/InvoicePlane/pull/1510) | v1.7.0, v1.7.1 |
+| *(pending)* | API credential exposure in payment gateway settings (Stripe/PayPal keys in HTML) | CWE-312 | 6.5 | 🟠 MEDIUM | [#1515](https://github.com/InvoicePlane/InvoicePlane/pull/1515) | v1.7.0, v1.7.1 |
+| *(pending)* | Setup wizard not locked post-installation (unauthenticated config overwrite) | CWE-287 | 6.5 | 🟠 MEDIUM | [#1491](https://github.com/InvoicePlane/InvoicePlane/pull/1491), [#1511](https://github.com/InvoicePlane/InvoicePlane/pull/1511), [#1518](https://github.com/InvoicePlane/InvoicePlane/pull/1518) | v1.7.0, v1.7.1 |
+| *(pending)* | Open redirect via unvalidated `HTTP_REFERER` | CWE-601 | 6.1 | 🟠 MEDIUM | [#1505](https://github.com/InvoicePlane/InvoicePlane/pull/1505) | v1.7.0, v1.7.1 |
+
+---
+
+## Contributor Acknowledgements
+
+Many thanks to the security researchers who responsibly disclosed vulnerabilities:
+
+[Vijay-raghav7](https://github.com/Vijay-raghav7),
+[cyabell](https://github.com/cyabell),
+[HuajiHD](https://github.com/HuajiHD),
+[udaypali](https://github.com/udaypali),
+[radoi-teodor](https://github.com/radoi-teodor),
+[tikket1](https://github.com/tikket1),
+[Chittu13](https://github.com/Chittu13),
+[iiihaiii](https://github.com/iiihaiii),
+[akgul7990](https://github.com/akgul7990),
+[ali-iltizar](https://github.com/ali-iltizar),
+[kitu232](https://github.com/kitu232)
+
+And thanks to [@drewangell](https://github.com/drewangell) for re-introducing Stripe and PayPal support.
+
+---
+
+*Document generated: 2026-04-27 — to be incorporated into CHANGELOG.md and README for v1.7.2 final.*

--- a/application/helpers/mailer_helper.php
+++ b/application/helpers/mailer_helper.php
@@ -46,7 +46,8 @@ function email_invoice(
     $body,
     $cc = null,
     $bcc = null,
-    $attachments = null
+    $attachments = null,
+    $reply_to = null
 ) {
     $CI = & get_instance();
 
@@ -72,11 +73,12 @@ function email_invoice(
         $_SERVER['CIIname'] = parse_template($db_invoice, $_SERVER['CIIname']);
     }
 
-    $message = parse_template($db_invoice, $body);
-    $subject = parse_template($db_invoice, $subject);
-    $cc      = parse_template($db_invoice, $cc);
-    $bcc     = parse_template($db_invoice, $bcc);
-    $from    = [parse_template($db_invoice, $from[0]), parse_template($db_invoice, $from[1])];
+    $message  = parse_template($db_invoice, $body);
+    $subject  = parse_template($db_invoice, $subject);
+    $cc       = parse_template($db_invoice, $cc);
+    $bcc      = parse_template($db_invoice, $bcc);
+    $reply_to = parse_template($db_invoice, $reply_to);
+    $from     = [parse_template($db_invoice, $from[0]), parse_template($db_invoice, $from[1])];
 
     $errors = [];
     if ( ! validate_email_address($to)) {
@@ -95,11 +97,15 @@ function email_invoice(
         $errors[] = 'bcc_email';
     }
 
+    if ($reply_to && ! validate_email_address($reply_to)) {
+        $errors[] = 'reply_to';
+    }
+
     check_mail_errors($errors, 'mailer/invoice/' . $invoice_id);
 
     $message = (empty($message) ? ' ' : $message);
 
-    return phpmail_send($from, $to, $subject, $message, $invoice, $cc, $bcc, $attachments);
+    return phpmail_send($from, $to, $subject, $message, $invoice, $cc, $bcc, $attachments, $reply_to);
 }
 
 /**
@@ -123,7 +129,8 @@ function email_quote(
     $body,
     $cc = null,
     $bcc = null,
-    $attachments = null
+    $attachments = null,
+    $reply_to = null
 ) {
     $CI = & get_instance();
 
@@ -137,11 +144,12 @@ function email_quote(
 
     $db_quote = $CI->mdl_quotes->where('ip_quotes.quote_id', $quote_id)->get()->row();
 
-    $message = parse_template($db_quote, $body);
-    $subject = parse_template($db_quote, $subject);
-    $cc      = parse_template($db_quote, $cc);
-    $bcc     = parse_template($db_quote, $bcc);
-    $from    = [parse_template($db_quote, $from[0]), parse_template($db_quote, $from[1])];
+    $message  = parse_template($db_quote, $body);
+    $subject  = parse_template($db_quote, $subject);
+    $cc       = parse_template($db_quote, $cc);
+    $bcc      = parse_template($db_quote, $bcc);
+    $reply_to = parse_template($db_quote, $reply_to);
+    $from     = [parse_template($db_quote, $from[0]), parse_template($db_quote, $from[1])];
 
     $errors = [];
     if ( ! validate_email_address($to)) {
@@ -160,11 +168,15 @@ function email_quote(
         $errors[] = 'bcc_email';
     }
 
+    if ($reply_to && ! validate_email_address($reply_to)) {
+        $errors[] = 'reply_to';
+    }
+
     check_mail_errors($errors, 'mailer/quote/' . $quote_id);
 
     $message = (empty($message) ? ' ' : $message);
 
-    return phpmail_send($from, $to, $subject, $message, $quote, $cc, $bcc, $attachments);
+    return phpmail_send($from, $to, $subject, $message, $quote, $cc, $bcc, $attachments, $reply_to);
 }
 
 /**

--- a/application/language/english/ip_lang.php
+++ b/application/language/english/ip_lang.php
@@ -542,6 +542,7 @@ $lang = [
     'reject_this_quote'                             => 'Reject This Quote',
     'rejected'                                      => 'Rejected',
     'remittance'                                    => 'Remittance',
+    'reply_to'                                      => 'Reply To',
     'remove'                                        => 'Remove',
     'remove_logo'                                   => 'Remove Logo',
     'report_options'                                => 'Report Options',

--- a/application/libraries/QrCode.php
+++ b/application/libraries/QrCode.php
@@ -30,6 +30,19 @@ class QrCode
         $CI->load->helper('template');
 
         $this->invoice         = $params['invoice'];
+
+        // Determine recipient with the following priority:
+        // First priority: Get recipient from qr code settings
+        $recipient = $CI->mdl_settings->setting('qr_code_recipient');
+        // Second priority: If still empty, get recipient from invoice's user_company
+        if (empty($recipient)) {
+            $recipient = $this->invoice->user_company;
+        }
+        // Third priority: If still empty, get recipient from invoice's user_name
+        if (empty($recipient)) {
+            $recipient = $this->invoice->user_name;
+        }
+        $this->recipient = $recipient;
         $this->recipient       = $this->invoice->user_company ?: $CI->mdl_settings->setting('qr_code_recipient');
         $this->iban            = $this->invoice->user_iban ?: $CI->mdl_settings->setting('qr_code_iban');
         $this->bic             = $this->invoice->user_bic ?: $CI->mdl_settings->setting('qr_code_bic');

--- a/application/libraries/QrCode.php
+++ b/application/libraries/QrCode.php
@@ -43,7 +43,6 @@ class QrCode
             $recipient = $this->invoice->user_name;
         }
         $this->recipient = $recipient;
-        $this->recipient       = $this->invoice->user_company ?: $CI->mdl_settings->setting('qr_code_recipient');
         $this->iban            = $this->invoice->user_iban ?: $CI->mdl_settings->setting('qr_code_iban');
         $this->bic             = $this->invoice->user_bic ?: $CI->mdl_settings->setting('qr_code_bic');
         $this->currencyCode    = $CI->mdl_settings->setting('currency_code');

--- a/application/modules/email_templates/models/Mdl_email_templates.php
+++ b/application/modules/email_templates/models/Mdl_email_templates.php
@@ -66,6 +66,10 @@ class Mdl_Email_Templates extends Response_Model
                 'field' => 'email_template_bcc',
                 'label' => trans('bcc'),
             ],
+            'email_template_reply_to' => [
+                'field' => 'email_template_reply_to',
+                'label' => trans('reply_to'),
+            ],
             'email_template_pdf_template' => [
                 'field' => 'email_template_pdf_template',
                 'label' => trans('default_pdf_template'),

--- a/application/modules/email_templates/views/form.php
+++ b/application/modules/email_templates/views/form.php
@@ -74,6 +74,12 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="email_template_reply_to" class="control-label"><?php _trans('reply_to'); ?></label>
+                    <input type="text" name="email_template_reply_to" id="email_template_reply_to" class="form-control taggable"
+                           value="<?php echo $this->mdl_email_templates->form_value('email_template_reply_to', true); ?>">
+                </div>
+
+                <div class="form-group">
                     <label for="email_template_subject" class="control-label">
                         <?php _trans('subject'); ?>
                     </label>

--- a/application/modules/guest/controllers/Get.php
+++ b/application/modules/guest/controllers/Get.php
@@ -32,10 +32,55 @@ class Get extends Base_Controller
         $this->content_types = $this->mdl_uploads->content_types;
     }
 
+    /**
+     * Verify that the url_key belongs to a guest-visible invoice or quote.
+     * Returns true if the url_key is valid and guest-visible, false otherwise.
+     *
+     * @param string $url_key The url_key to validate
+     *
+     * @return bool
+     */
+    private function is_url_key_guest_visible(string $url_key): bool
+    {
+        if ( ! $url_key) {
+            return false;
+        }
+
+        $this->load->model('invoices/mdl_invoices');
+        $this->load->model('quotes/mdl_quotes');
+
+        // Check if url_key belongs to a guest-visible invoice (status_id IN (2,3,4))
+        $invoice = $this->mdl_invoices->guest_visible()
+            ->where('invoice_url_key', $url_key)
+            ->get();
+
+        if ($invoice->num_rows() === 1) {
+            return true;
+        }
+
+        // Check if url_key belongs to a guest-visible quote (status_id IN (2,3,4,5))
+        $quote = $this->mdl_quotes->guest_visible()
+            ->where('quote_url_key', $url_key)
+            ->get();
+
+        if ($quote->num_rows() === 1) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function show_files($url_key = null): void
     {
         header('Content-Type: application/json; charset=utf-8');
-        if ($url_key && ! $result = $this->mdl_uploads->get_files($url_key)) {
+
+        // Security: Verify url_key belongs to a guest-visible invoice or quote
+        if ( ! $url_key || ! $this->is_url_key_guest_visible($url_key)) {
+            exit('{}');
+        }
+
+        $result = $this->mdl_uploads->get_files($url_key);
+        if ( ! $result) {
             exit('{}');
         }
 
@@ -66,6 +111,24 @@ class Get extends Base_Controller
                 'guest/get: '
             );
         }
+
+        // Security: Extract url_key from filename to validate parent document status
+        // Filename format: {url_key}_{original_filename}
+        $url_key = null;
+        if (preg_match('/^([a-zA-Z0-9]{32})_/', $filename, $matches)) {
+            $url_key = $matches[1];
+        }
+
+        // Security: Verify url_key belongs to a guest-visible invoice or quote
+        if ( ! $url_key || ! $this->is_url_key_guest_visible($url_key)) {
+            respond_file_message(
+                404,
+                'upload_error_file_not_found',
+                'File not found or access denied',
+                'guest/get: '
+            );
+        }
+
         // Security: Use comprehensive file security validation helper
         // Note: CodeIgniter already URL-decodes parameters during routing
         $validation = validate_file_access($filename, $this->targetPath);

--- a/application/modules/guest/controllers/Get.php
+++ b/application/modules/guest/controllers/Get.php
@@ -22,13 +22,6 @@ class Get extends Base_Controller
     public $content_types = [];
 
     /**
-     * Models loaded in constructor.
-     */
-    private $mdl_invoices;
-
-    private $mdl_quotes;
-
-    /**
      * The expected length of url_key strings.
      * url_keys are 32-character random alphanumeric strings.
      */

--- a/application/modules/guest/controllers/Get.php
+++ b/application/modules/guest/controllers/Get.php
@@ -22,6 +22,13 @@ class Get extends Base_Controller
     public $content_types = [];
 
     /**
+     * Models loaded in constructor.
+     */
+    private $mdl_invoices;
+
+    private $mdl_quotes;
+
+    /**
      * The expected length of url_key strings.
      * url_keys are 32-character random alphanumeric strings.
      */
@@ -29,6 +36,7 @@ class Get extends Base_Controller
 
     /**
      * Empty JSON response for unauthorized file access.
+     * Using a constant for consistency across methods.
      */
     private const EMPTY_JSON_RESPONSE = '{}';
 
@@ -40,11 +48,14 @@ class Get extends Base_Controller
         parent::__construct();
         $this->load->helper('file_security');
         $this->load->model('upload/mdl_uploads');
+        $this->load->model('invoices/mdl_invoices');
+        $this->load->model('quotes/mdl_quotes');
         $this->content_types = $this->mdl_uploads->content_types;
     }
 
     /**
      * Extract url_key from a filename with format {url_key}_{original_filename}.
+     * Note: url_keys are case-sensitive alphanumeric strings.
      *
      * @param string $filename The filename to parse
      *
@@ -73,9 +84,6 @@ class Get extends Base_Controller
         if ($url_key === '') {
             return false;
         }
-
-        $this->load->model('invoices/mdl_invoices');
-        $this->load->model('quotes/mdl_quotes');
 
         // Check if url_key belongs to a guest-visible invoice (status_id IN (2,3,4))
         if ($this->check_document_visibility($this->mdl_invoices, 'invoice_url_key', $url_key)) {
@@ -113,6 +121,7 @@ class Get extends Base_Controller
         header('Content-Type: application/json; charset=utf-8');
 
         // Security: Verify url_key belongs to a guest-visible invoice or quote
+        // Null check is needed because $url_key can be null from URL parameter
         if ( ! $url_key || ! $this->is_url_key_guest_visible($url_key)) {
             exit(self::EMPTY_JSON_RESPONSE);
         }

--- a/application/modules/guest/controllers/Get.php
+++ b/application/modules/guest/controllers/Get.php
@@ -22,6 +22,12 @@ class Get extends Base_Controller
     public $content_types = [];
 
     /**
+     * The expected length of url_key strings.
+     * url_keys are 32-character random alphanumeric strings.
+     */
+    private const URL_KEY_LENGTH = 32;
+
+    /**
      * Upload constructor.
      */
     public function __construct()
@@ -30,6 +36,23 @@ class Get extends Base_Controller
         $this->load->helper('file_security');
         $this->load->model('upload/mdl_uploads');
         $this->content_types = $this->mdl_uploads->content_types;
+    }
+
+    /**
+     * Extract url_key from a filename with format {url_key}_{original_filename}.
+     *
+     * @param string $filename The filename to parse
+     *
+     * @return string|null The extracted url_key or null if not found
+     */
+    private function extract_url_key_from_filename(string $filename): ?string
+    {
+        $pattern = '/^([a-zA-Z0-9]{' . self::URL_KEY_LENGTH . '})_/';
+        if (preg_match($pattern, $filename, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
     }
 
     /**
@@ -50,24 +73,34 @@ class Get extends Base_Controller
         $this->load->model('quotes/mdl_quotes');
 
         // Check if url_key belongs to a guest-visible invoice (status_id IN (2,3,4))
-        $invoice = $this->mdl_invoices->guest_visible()
-            ->where('invoice_url_key', $url_key)
-            ->get();
-
-        if ($invoice->num_rows() === 1) {
+        if ($this->check_document_visibility($this->mdl_invoices, 'invoice_url_key', $url_key)) {
             return true;
         }
 
         // Check if url_key belongs to a guest-visible quote (status_id IN (2,3,4,5))
-        $quote = $this->mdl_quotes->guest_visible()
-            ->where('quote_url_key', $url_key)
-            ->get();
-
-        if ($quote->num_rows() === 1) {
+        if ($this->check_document_visibility($this->mdl_quotes, 'quote_url_key', $url_key)) {
             return true;
         }
 
         return false;
+    }
+
+    /**
+     * Check if a document with the given url_key is guest-visible.
+     *
+     * @param object $model     The model (mdl_invoices or mdl_quotes)
+     * @param string $key_field The field name for the url_key
+     * @param string $url_key   The url_key to check
+     *
+     * @return bool True if the document is guest-visible, false otherwise
+     */
+    private function check_document_visibility($model, string $key_field, string $url_key): bool
+    {
+        $result = $model->guest_visible()
+            ->where($key_field, $url_key)
+            ->get();
+
+        return $result->num_rows() === 1;
     }
 
     public function show_files($url_key = null): void
@@ -114,10 +147,7 @@ class Get extends Base_Controller
 
         // Security: Extract url_key from filename to validate parent document status
         // Filename format: {url_key}_{original_filename}
-        $url_key = null;
-        if (preg_match('/^([a-zA-Z0-9]{32})_/', $filename, $matches)) {
-            $url_key = $matches[1];
-        }
+        $url_key = $this->extract_url_key_from_filename($filename);
 
         // Security: Verify url_key belongs to a guest-visible invoice or quote
         if ( ! $url_key || ! $this->is_url_key_guest_visible($url_key)) {

--- a/application/modules/guest/controllers/Get.php
+++ b/application/modules/guest/controllers/Get.php
@@ -74,7 +74,8 @@ class Get extends Base_Controller
      */
     private function is_url_key_guest_visible(string $url_key): bool
     {
-        if ($url_key === '') {
+        // Validate url_key format before database query (defense in depth)
+        if ( ! $this->is_valid_url_key_format($url_key)) {
             return false;
         }
 
@@ -89,6 +90,20 @@ class Get extends Base_Controller
         }
 
         return false;
+    }
+
+    /**
+     * Validate that a url_key matches the expected format.
+     * url_keys must be exactly 32 alphanumeric characters.
+     *
+     * @param string $url_key The url_key to validate
+     *
+     * @return bool True if format is valid, false otherwise
+     */
+    private function is_valid_url_key_format(string $url_key): bool
+    {
+        // url_key must be exactly 32 alphanumeric characters (no special chars, no directory traversal)
+        return preg_match('/^[a-zA-Z0-9]{' . self::URL_KEY_LENGTH . '}$/', $url_key) === 1;
     }
 
     /**

--- a/application/modules/guest/controllers/Get.php
+++ b/application/modules/guest/controllers/Get.php
@@ -28,6 +28,11 @@ class Get extends Base_Controller
     private const URL_KEY_LENGTH = 32;
 
     /**
+     * Empty JSON response for unauthorized file access.
+     */
+    private const EMPTY_JSON_RESPONSE = '{}';
+
+    /**
      * Upload constructor.
      */
     public function __construct()
@@ -65,7 +70,7 @@ class Get extends Base_Controller
      */
     private function is_url_key_guest_visible(string $url_key): bool
     {
-        if ( ! $url_key) {
+        if ($url_key === '') {
             return false;
         }
 
@@ -88,13 +93,13 @@ class Get extends Base_Controller
     /**
      * Check if a document with the given url_key is guest-visible.
      *
-     * @param object $model     The model (mdl_invoices or mdl_quotes)
-     * @param string $key_field The field name for the url_key
-     * @param string $url_key   The url_key to check
+     * @param Response_Model $model     The model (mdl_invoices or mdl_quotes)
+     * @param string         $key_field The field name for the url_key
+     * @param string         $url_key   The url_key to check
      *
      * @return bool True if the document is guest-visible, false otherwise
      */
-    private function check_document_visibility($model, string $key_field, string $url_key): bool
+    private function check_document_visibility(Response_Model $model, string $key_field, string $url_key): bool
     {
         $result = $model->guest_visible()
             ->where($key_field, $url_key)
@@ -109,12 +114,12 @@ class Get extends Base_Controller
 
         // Security: Verify url_key belongs to a guest-visible invoice or quote
         if ( ! $url_key || ! $this->is_url_key_guest_visible($url_key)) {
-            exit('{}');
+            exit(self::EMPTY_JSON_RESPONSE);
         }
 
         $result = $this->mdl_uploads->get_files($url_key);
         if ( ! $result) {
-            exit('{}');
+            exit(self::EMPTY_JSON_RESPONSE);
         }
 
         echo json_encode($result);

--- a/application/modules/guest/controllers/Get.php
+++ b/application/modules/guest/controllers/Get.php
@@ -56,8 +56,8 @@ class Get extends Base_Controller
      */
     private function extract_url_key_from_filename(string $filename): ?string
     {
-        $pattern = '/^([a-zA-Z0-9]{' . self::URL_KEY_LENGTH . '})_/';
-        if (preg_match($pattern, $filename, $matches)) {
+        // Match exactly 32 alphanumeric characters followed by underscore
+        if (preg_match('/^([a-zA-Z0-9]{32})_/', $filename, $matches)) {
             return $matches[1];
         }
 

--- a/application/modules/guest/controllers/Payment_information.php
+++ b/application/modules/guest/controllers/Payment_information.php
@@ -29,7 +29,7 @@ class Payment_Information extends Base_Controller
         $disable_form = false;
 
         // Check if the invoice exists and is billable
-        $invoice = $this->mdl_invoices->where('ip_invoices.invoice_url_key', $invoice_url_key)->get()->row();
+        $invoice = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_url_key', $invoice_url_key)->get()->row();
 
         if ( ! $invoice) {
             $this->session->set_flashdata('alert_error', lang('invoice_not_found'));

--- a/application/modules/guest/controllers/gateways/Paypal.php
+++ b/application/modules/guest/controllers/gateways/Paypal.php
@@ -148,10 +148,10 @@ class Paypal extends Base_Controller
                 }
 
                 // Security: Validate that the invoice is guest-visible before processing payment
-                $invoice_check = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_id', $invoice_id)->get()->row();
-                if ( ! $invoice_check) {
+                $verified_invoice = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_id', $invoice_id)->get()->row();
+                if ( ! $verified_invoice) {
                     log_message('error', __CLASS__ . '::' . __FUNCTION__ . ' - Attempted payment capture for non-public invoice: ' . sanitize_for_logging($invoice_id));
-                    throw new Exception('Invalid invoice');
+                    throw new Exception('Invoice not found or not accessible');
                 }
 
                 $capture_id = (string) $capture_id; // Ensure string type

--- a/application/modules/guest/controllers/gateways/Paypal.php
+++ b/application/modules/guest/controllers/gateways/Paypal.php
@@ -147,6 +147,13 @@ class Paypal extends Base_Controller
                     throw new Exception('Missing required PayPal data');
                 }
 
+                // Security: Validate that the invoice is guest-visible before processing payment
+                $invoice_check = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_id', $invoice_id)->get()->row();
+                if ( ! $invoice_check) {
+                    log_message('error', __CLASS__ . '::' . __FUNCTION__ . ' - Attempted payment capture for non-public invoice: ' . sanitize_for_logging($invoice_id));
+                    throw new Exception('Invalid invoice');
+                }
+
                 $capture_id = (string) $capture_id; // Ensure string type
 
                 // Validate and sanitize the capture_id

--- a/application/modules/guest/controllers/gateways/Paypal.php
+++ b/application/modules/guest/controllers/gateways/Paypal.php
@@ -41,7 +41,7 @@ class Paypal extends Base_Controller
         // Check if the invoice exists and is billable
         $this->load->model('invoices/mdl_invoices');
 
-        $invoice = $this->mdl_invoices->where('ip_invoices.invoice_url_key', $invoice_url_key)->get()->row();
+        $invoice = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_url_key', $invoice_url_key)->get()->row();
 
         // Check if the invoice is payable
         if ($invoice->invoice_balance <= 0) {
@@ -168,12 +168,12 @@ class Paypal extends Base_Controller
                     // Duplicate payment attempt detected
                     log_message('warning', __CLASS__ . '::' . __FUNCTION__ . ' - Duplicate payment attempt blocked. PayPal capture ID: ' . sanitize_for_logging($capture_id) . ' already exists as payment_id: ' . sanitize_for_logging($existing_payment->payment_id));
 
-                    $invoice = $this->mdl_invoices->where('ip_invoices.invoice_id', $invoice_id)->get()->row();
+                    $invoice = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_id', $invoice_id)->get()->row();
                     $this->session->set_flashdata('alert_info', trans('online_payment_already_processed'));
                     $this->session->keep_flashdata('alert_info');
                 } else {
                     // Check if invoice is already fully paid
-                    $invoice = $this->mdl_invoices->where('ip_invoices.invoice_id', $invoice_id)->get()->row();
+                    $invoice = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_id', $invoice_id)->get()->row();
 
                     if ($invoice->invoice_balance <= 0) {
                         log_message('warning', __CLASS__ . '::' . __FUNCTION__ . ' - Payment rejected. Invoice ' . sanitize_for_logging($invoice->invoice_number) . ' already fully paid. Balance: ' . sanitize_for_logging($invoice->invoice_balance));

--- a/application/modules/guest/controllers/gateways/Paypal.php
+++ b/application/modules/guest/controllers/gateways/Paypal.php
@@ -43,6 +43,12 @@ class Paypal extends Base_Controller
 
         $invoice = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_url_key', $invoice_url_key)->get()->row();
 
+        // Security: Verify the invoice exists and is guest-visible
+        if ( ! $invoice) {
+            log_message('error', __CLASS__ . '::' . __FUNCTION__ . ' - Attempted order creation for non-public or non-existent invoice with key: ' . sanitize_for_logging($invoice_url_key));
+            show_404();
+        }
+
         // Check if the invoice is payable
         if ($invoice->invoice_balance <= 0) {
             $this->session->set_userdata('alert_error', lang('invoice_already_paid'));
@@ -176,13 +182,26 @@ class Paypal extends Base_Controller
                     log_message('warning', __CLASS__ . '::' . __FUNCTION__ . ' - Duplicate payment attempt blocked. PayPal capture ID: ' . sanitize_for_logging($capture_id) . ' already exists as payment_id: ' . sanitize_for_logging($existing_payment->payment_id));
 
                     $invoice = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_id', $invoice_id)->get()->row();
-                    $this->session->set_flashdata('alert_info', trans('online_payment_already_processed'));
-                    $this->session->keep_flashdata('alert_info');
+                    
+                    // Security: Verify the invoice exists and is guest-visible
+                    if ( ! $invoice) {
+                        log_message('error', __CLASS__ . '::' . __FUNCTION__ . ' - Invoice no longer guest-visible during duplicate payment check: ' . sanitize_for_logging($invoice_id));
+                        $this->session->set_flashdata('alert_error', trans('invoice_not_found'));
+                        $this->session->keep_flashdata('alert_error');
+                    } else {
+                        $this->session->set_flashdata('alert_info', trans('online_payment_already_processed'));
+                        $this->session->keep_flashdata('alert_info');
+                    }
                 } else {
                     // Check if invoice is already fully paid
                     $invoice = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_id', $invoice_id)->get()->row();
 
-                    if ($invoice->invoice_balance <= 0) {
+                    // Security: Verify the invoice exists and is guest-visible
+                    if ( ! $invoice) {
+                        log_message('error', __CLASS__ . '::' . __FUNCTION__ . ' - Invoice no longer guest-visible during payment capture: ' . sanitize_for_logging($invoice_id));
+                        $this->session->set_flashdata('alert_error', trans('invoice_not_found'));
+                        $this->session->keep_flashdata('alert_error');
+                    } elseif ($invoice->invoice_balance <= 0) {
                         log_message('warning', __CLASS__ . '::' . __FUNCTION__ . ' - Payment rejected. Invoice ' . sanitize_for_logging($invoice->invoice_number) . ' already fully paid. Balance: ' . sanitize_for_logging($invoice->invoice_balance));
                         $this->session->set_flashdata('alert_info', trans('invoice_already_paid'));
                         $this->session->keep_flashdata('alert_info');

--- a/application/modules/guest/controllers/gateways/Stripe.php
+++ b/application/modules/guest/controllers/gateways/Stripe.php
@@ -104,7 +104,7 @@ class Stripe extends Base_Controller
             // Security: Verify the invoice exists and is guest-visible
             if ( ! $invoice) {
                 log_message('error', __CLASS__ . '::' . __FUNCTION__ . ' - Attempted payment callback for non-public or non-existent invoice with key: ' . sanitize_for_logging($invoice_key));
-                throw new Exception('Invalid invoice');
+                throw new Exception('Invoice not found or not accessible');
             }
 
             // Check the session payment_status is 'paid'

--- a/application/modules/guest/controllers/gateways/Stripe.php
+++ b/application/modules/guest/controllers/gateways/Stripe.php
@@ -101,6 +101,12 @@ class Stripe extends Base_Controller
             // Retrieve the invoice
             $invoice = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_url_key', $invoice_key)->get()->row();
 
+            // Security: Verify the invoice exists and is guest-visible
+            if ( ! $invoice) {
+                log_message('error', __CLASS__ . '::' . __FUNCTION__ . ' - Attempted payment callback for non-public or non-existent invoice with key: ' . sanitize_for_logging($invoice_key));
+                throw new Exception('Invalid invoice');
+            }
+
             // Check the session payment_status is 'paid'
             // See: https://github.com/stripe/stripe-php/blob/044f9dd190967b8fb7e55fd0ea25f11c625c00a4/lib/Checkout/Session.php#L101
             $paid = $session->payment_status === $session::PAYMENT_STATUS_PAID; // +2 status: *_NO_PAYMENT_REQUIRED *_UNPAID

--- a/application/modules/guest/controllers/gateways/Stripe.php
+++ b/application/modules/guest/controllers/gateways/Stripe.php
@@ -49,6 +49,12 @@ class Stripe extends Base_Controller
 
         $invoice = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_url_key', $invoice_url_key)->get()->row();
 
+        // Security: Verify the invoice exists and is guest-visible
+        if ( ! $invoice) {
+            log_message('error', __CLASS__ . '::' . __FUNCTION__ . ' - Attempted checkout session creation for non-public or non-existent invoice with key: ' . sanitize_for_logging($invoice_url_key));
+            show_404();
+        }
+
         // Check if the invoice is payable
         if ($invoice->invoice_balance <= 0) {
             $this->session->set_userdata('alert_error', lang('invoice_already_paid'));

--- a/application/modules/guest/controllers/gateways/Stripe.php
+++ b/application/modules/guest/controllers/gateways/Stripe.php
@@ -47,7 +47,7 @@ class Stripe extends Base_Controller
             show_404();
         }
 
-        $invoice = $this->mdl_invoices->where('ip_invoices.invoice_url_key', $invoice_url_key)->get()->row();
+        $invoice = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_url_key', $invoice_url_key)->get()->row();
 
         // Check if the invoice is payable
         if ($invoice->invoice_balance <= 0) {
@@ -99,7 +99,7 @@ class Stripe extends Base_Controller
             $invoice_key = $session->client_reference_id;
 
             // Retrieve the invoice
-            $invoice = $this->mdl_invoices->where('ip_invoices.invoice_url_key', $invoice_key)->get()->row();
+            $invoice = $this->mdl_invoices->guest_visible()->where('ip_invoices.invoice_url_key', $invoice_key)->get()->row();
 
             // Check the session payment_status is 'paid'
             // See: https://github.com/stripe/stripe-php/blob/044f9dd190967b8fb7e55fd0ea25f11c625c00a4/lib/Checkout/Session.php#L101

--- a/application/modules/invoices/controllers/Cron.php
+++ b/application/modules/invoices/controllers/Cron.php
@@ -164,8 +164,9 @@ class Cron extends Base_Controller
                 $to           = $invoice->client_email;
                 $cc           = $tpl->email_template_cc;
                 $bcc          = $tpl->email_template_bcc;
+                $reply_to     = $tpl->email_template_reply_to;
 
-                $email_invoice = email_invoice($target_id, $pdf_template, $from, $to, $subject, $body, $cc, $bcc, $attachment_files);
+                $email_invoice = email_invoice($target_id, $pdf_template, $from, $to, $subject, $body, $cc, $bcc, $attachment_files, $reply_to);
 
                 if ($email_invoice) {
                     $this->mdl_invoices->mark_sent($target_id);

--- a/application/modules/mailer/controllers/Mailer.php
+++ b/application/modules/mailer/controllers/Mailer.php
@@ -183,15 +183,16 @@ class Mailer extends Admin_Controller
         }
         // Note: We removed htmlspecialchars_decode() as it was undoing the XSS protection.
 
-        $cc  = $this->input->post('cc');
-        $bcc = $this->input->post('bcc');
+        $cc       = $this->input->post('cc');
+        $bcc      = $this->input->post('bcc');
+        $reply_to = $this->input->post('reply_to', true);
 
         $this->load->model('upload/mdl_uploads');
         $attachment_files = $this->mdl_uploads->get_invoice_uploads($invoice_id);
 
         $this->mdl_invoices->generate_invoice_number_if_applicable($invoice_id);
 
-        if (email_invoice($invoice_id, $pdf_template, $from, $to, $subject, $body, $cc, $bcc, $attachment_files)) {
+        if (email_invoice($invoice_id, $pdf_template, $from, $to, $subject, $body, $cc, $bcc, $attachment_files, $reply_to)) {
             $this->mdl_invoices->mark_sent($invoice_id);
             $this->session->set_flashdata('alert_success', trans('email_successfully_sent'));
             redirect('invoices/view/' . $invoice_id);
@@ -233,15 +234,16 @@ class Mailer extends Admin_Controller
         }
         // Note: We removed htmlspecialchars_decode() as it was undoing the XSS protection.
 
-        $cc  = $this->input->post('cc');
-        $bcc = $this->input->post('bcc');
+        $cc       = $this->input->post('cc');
+        $bcc      = $this->input->post('bcc');
+        $reply_to = $this->input->post('reply_to', true);
 
         $this->load->model('upload/mdl_uploads');
         $attachment_files = $this->mdl_uploads->get_quote_uploads($quote_id);
 
         $this->mdl_quotes->generate_quote_number_if_applicable($quote_id);
 
-        if (email_quote($quote_id, $pdf_template, $from, $to, $subject, $body, $cc, $bcc, $attachment_files)) {
+        if (email_quote($quote_id, $pdf_template, $from, $to, $subject, $body, $cc, $bcc, $attachment_files, $reply_to)) {
             $this->mdl_quotes->mark_sent($quote_id);
             $this->session->set_flashdata('alert_success', trans('email_successfully_sent'));
 

--- a/application/modules/mailer/helpers/phpmailer_helper.php
+++ b/application/modules/mailer/helpers/phpmailer_helper.php
@@ -53,7 +53,8 @@ function phpmail_send(
     $attachment_path = null,
     $cc = null,
     $bcc = null,
-    $more_attachments = null
+    $more_attachments = null,
+    $reply_to = null
 ) {
     $CI = &get_instance();
     $CI->load->library('crypt');
@@ -162,6 +163,15 @@ function phpmail_send(
         // Add the BCC's
         foreach ($bcc as $address) {
             $mail->addBCC($address);
+        }
+    }
+
+    if ($reply_to) {
+        // Allow multiple reply-to addresses delimited by comma or semicolon
+        $reply_to = (str_contains($reply_to, ',')) ? explode(',', $reply_to) : explode(';', $reply_to);
+
+        foreach ($reply_to as $address) {
+            $mail->addReplyTo(trim($address));
         }
     }
 

--- a/application/modules/mailer/views/invoice.php
+++ b/application/modules/mailer/views/invoice.php
@@ -1,6 +1,6 @@
 <script>
     $(function () {
-        var template_fields = ["body", "subject", "from_name", "from_email", "cc", "bcc", "pdf_template"];
+        var template_fields = ["body", "subject", "from_name", "from_email", "cc", "bcc", "reply_to", "pdf_template"];
 
         $('#email_template').change(function () {
             var email_template_id = $(this).val();
@@ -118,6 +118,11 @@ foreach ($email_templates as $email_template) {
                 <div class="form-group">
                     <label for="bcc"><?php _trans('bcc'); ?></label>
                     <input type="text" name="bcc" id="bcc" value="" class="form-control">
+                </div>
+
+                <div class="form-group">
+                    <label for="reply_to"><?php _trans('reply_to'); ?></label>
+                    <input type="text" name="reply_to" id="reply_to" value="" class="form-control">
                 </div>
 
                 <div class="form-group">

--- a/application/modules/mailer/views/quote.php
+++ b/application/modules/mailer/views/quote.php
@@ -1,6 +1,6 @@
 <script>
     $(function () {
-        var template_fields = ["body", "subject", "from_name", "from_email", "cc", "bcc", "pdf_template"];
+        var template_fields = ["body", "subject", "from_name", "from_email", "cc", "bcc", "reply_to", "pdf_template"];
 
         $('#email_template').change(function () {
             var email_template_id = $(this).val();
@@ -101,6 +101,11 @@ foreach ($email_templates as $email_template) {
                 <div class="form-group">
                     <label for="bcc"><?php _trans('bcc'); ?></label>
                     <input type="text" name="bcc" id="bcc" value="" class="form-control">
+                </div>
+
+                <div class="form-group">
+                    <label for="reply_to"><?php _trans('reply_to'); ?></label>
+                    <input type="text" name="reply_to" id="reply_to" value="" class="form-control">
                 </div>
 
                 <div class="form-group">

--- a/application/modules/setup/sql/044_1.7.3.sql
+++ b/application/modules/setup/sql/044_1.7.3.sql
@@ -1,0 +1,3 @@
+# Add reply-to field to email templates
+ALTER TABLE ip_email_templates
+  ADD COLUMN email_template_reply_to TEXT DEFAULT NULL;


### PR DESCRIPTION
# Pull Request Checklist

Please check the following steps before submitting your PR. If any items are incomplete, consider marking it as `[WIP]` (Work in Progress).

## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.
- [ ] I included relevant documentation updates if necessary.
- [ ] I have an accompanying issue ID for this pull request.

---

## Description

Adds a Reply-To header field in case mail is sent from a noreply address.

---

## Motivation and Context

My instance is sending mail from a noreply address, so it would be very nice if I could still receive replies

---

## Issue Type (Check one or more)
- [ ] Bugfix
- [x] Improvement of an existing feature
- [ ] New feature

---

*Thank you for your contribution to InvoicePlane! We appreciate your time and effort.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Reply-To" field to email templates and the send invoice/quote forms so you can set where replies are directed.
* **Improvements**
  * Template tokens can populate the Reply-To field; Reply-To is validated when sending (invalid addresses are rejected).
  * Scheduled/recurring emails now include the configured Reply-To.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InvoicePlane/InvoicePlane/pull/1549)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->