### PR TITLE
Encrypt invoice_password at rest and decrypt on load

### DIFF
--- a/application/helpers/pdf_helper.php
+++ b/application/helpers/pdf_helper.php
@@ -72,6 +72,7 @@ function generate_invoice_pdf($invoice_id, $stream = true, $invoice_template = n
 
     $invoice = $CI->mdl_invoices->get_by_id($invoice_id);
     $invoice = $CI->mdl_invoices->get_payments($invoice);
+    $invoice->invoice_password = $CI->mdl_invoices->decrypt_invoice_password($invoice->invoice_password);
 
     // Override system language with client language
     set_language($invoice->client_language);
@@ -219,6 +220,7 @@ function generate_invoice_sumex($invoice_id, $stream = true, $invoice_template =
 
     $CI->load->model('invoices/mdl_items');
     $invoice = $CI->mdl_invoices->get_by_id($invoice_id);
+    $invoice->invoice_password = $CI->mdl_invoices->decrypt_invoice_password($invoice->invoice_password);
 
     if ($invoice_template) {
         $CI->load->helper('template');

--- a/application/modules/invoices/controllers/Invoices.php
+++ b/application/modules/invoices/controllers/Invoices.php
@@ -156,6 +156,8 @@ class Invoices extends Admin_Controller
             show_404();
         }
 
+        $invoice->invoice_password = $this->mdl_invoices->decrypt_invoice_password($invoice->invoice_password);
+
         $custom_fields = $this->mdl_custom_fields->by_table('ip_invoice_custom')->get()->result();
         $custom_values = [];
         foreach ($custom_fields as $custom_field) {

--- a/application/modules/invoices/models/Mdl_invoices.php
+++ b/application/modules/invoices/models/Mdl_invoices.php
@@ -73,6 +73,38 @@ class Mdl_Invoices extends Response_Model
             ip_invoices.*", false);
     }
 
+    public function save($id = null, $db_array = null)
+    {
+        if (is_array($db_array) && array_key_exists('invoice_password', $db_array)) {
+            $db_array['invoice_password'] = $this->encrypt_invoice_password($db_array['invoice_password']);
+        }
+
+        return parent::save($id, $db_array);
+    }
+
+    public function encrypt_invoice_password($password): ?string
+    {
+        if ($password === null || $password === '') {
+            return null;
+        }
+
+        $this->load->library('crypt');
+
+        return $this->crypt->encode((string) $password);
+    }
+
+    public function decrypt_invoice_password($password): string
+    {
+        if ($password === null || $password === '') {
+            return '';
+        }
+
+        $this->load->library('crypt');
+        $decoded = $this->crypt->decode($password);
+
+        return is_string($decoded) ? $decoded : '';
+    }
+
     public function default_order_by()
     {
         $this->db->order_by('ip_invoices.invoice_date_created DESC, ip_invoices.invoice_number DESC, ip_invoices.invoice_id DESC');


### PR DESCRIPTION
### Motivation
- Ensure `invoice_password` is stored encrypted in the database and not in plaintext to improve data protection.
- Transparently decrypt the password when invoices are loaded for viewing or PDF generation so existing code can continue to use the property.

### Description
- Added `save()` override in `Mdl_Invoices` to encrypt `invoice_password` via `encrypt_invoice_password()` before persisting when present in the `$db_array`.
- Implemented `encrypt_invoice_password()` and `decrypt_invoice_password()` in `Mdl_Invoices` using the `crypt` library with safe null/empty handling and type checks.
- Updated code paths that load invoices to expose the decrypted password on the invoice object: `generate_invoice_pdf()`, `generate_invoice_sumex()`, and the `Invoices` controller view by setting `$invoice->invoice_password = $this->mdl_invoices->decrypt_invoice_password(...)` (or `$CI->mdl_invoices->decrypt_invoice_password(...)`).

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a155716ce9c8329bbfd77490513332b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced encryption handling for invoice passwords during creation, storage, and viewing operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InvoicePlane/InvoicePlane/pull/1557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->