### PR TITLE
Encrypt quote passwords at rest and decrypt on read

### DIFF
--- a/application/helpers/pdf_helper.php
+++ b/application/helpers/pdf_helper.php
@@ -309,6 +309,7 @@ function generate_quote_pdf($quote_id, $stream = true, $quote_template = null)
     );
 
     $quote = $CI->mdl_quotes->get_by_id($quote_id);
+    $quote->quote_password = $CI->mdl_quotes->decrypt_quote_password($quote->quote_password);
 
     // Override language with system language
     set_language($quote->client_language);

--- a/application/modules/quotes/controllers/Quotes.php
+++ b/application/modules/quotes/controllers/Quotes.php
@@ -118,6 +118,8 @@ class Quotes extends Admin_Controller
             show_404();
         }
 
+        $quote->quote_password = $this->mdl_quotes->decrypt_quote_password($quote->quote_password);
+
         $custom_fields = $this->mdl_custom_fields->by_table('ip_quote_custom')->get()->result();
         $custom_values = [];
         foreach ($custom_fields as $custom_field) {

--- a/application/modules/quotes/models/Mdl_quotes.php
+++ b/application/modules/quotes/models/Mdl_quotes.php
@@ -76,6 +76,38 @@ class Mdl_Quotes extends Response_Model
             ip_quotes.*", false);
     }
 
+    public function save($id = null, $db_array = null)
+    {
+        if (is_array($db_array) && array_key_exists('quote_password', $db_array)) {
+            $db_array['quote_password'] = $this->encrypt_quote_password($db_array['quote_password']);
+        }
+
+        return parent::save($id, $db_array);
+    }
+
+    public function encrypt_quote_password($password): ?string
+    {
+        if ($password === null || $password === '') {
+            return null;
+        }
+
+        $this->load->library('crypt');
+
+        return $this->crypt->encode((string) $password);
+    }
+
+    public function decrypt_quote_password($password): string
+    {
+        if ($password === null || $password === '') {
+            return '';
+        }
+
+        $this->load->library('crypt');
+        $decoded = $this->crypt->decode($password);
+
+        return is_string($decoded) ? $decoded : '';
+    }
+
     public function default_order_by()
     {
         $this->db->order_by('ip_quotes.quote_date_created DESC, ip_quotes.quote_number DESC, ip_quotes.quote_id DESC');


### PR DESCRIPTION
### Motivation
- Prevent storing `quote_password` in plaintext in the database while keeping existing callers working the same way.

### Description
- Added a `save()` override in `Mdl_Quotes` to encrypt `quote_password` using `encrypt_quote_password()` when the key is present in the `$db_array` before persisting.
- Implemented `encrypt_quote_password()` and `decrypt_quote_password()` in `Mdl_Quotes` using the existing `crypt` library with safe null/empty handling and type checks.
- Updated quote-loading code paths to expose the decrypted password on the quote object by setting `quote->quote_password` after load in `Quotes::view()` and in `generate_quote_pdf()` in `application/helpers/pdf_helper.php`.
- Ensured the behavior is transparent to downstream code that expects a plaintext `quote_password` when rendering views or generating PDFs.

### Testing
- Ran PHP syntax checks with `php -l` on the modified files `application/modules/quotes/models/Mdl_quotes.php`, `application/modules/quotes/controllers/Quotes.php`, and `application/helpers/pdf_helper.php`, and all checks passed.
- Verified no syntax errors were introduced by the changes (lint succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d35c4c688329afc14bfcff6de6b8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quote passwords are now encrypted when saved and automatically decrypted when viewing quotes or generating PDFs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InvoicePlane/InvoicePlane/pull/1558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->