### PR TITLE
Require POST and CSRF for invoice deletion endpoints

### DIFF
--- a/application/modules/invoices/controllers/Invoices.php
+++ b/application/modules/invoices/controllers/Invoices.php
@@ -24,7 +24,27 @@ class Invoices extends Admin_Controller
         parent::__construct();
 
         $this->load->helper('file_security');
+        $this->load->helper('security');
         $this->load->model('mdl_invoices');
+    }
+
+    private function ensure_valid_post_request(string $redirect_url): bool
+    {
+        if ($this->input->method(true) !== 'POST') {
+            $this->session->set_flashdata('alert_error', trans('invalid_request'));
+            redirect($redirect_url);
+
+            return false;
+        }
+
+        if ( ! verify_csrf_token()) {
+            $this->session->set_flashdata('alert_error', trans('invalid_request'));
+            redirect($redirect_url);
+
+            return false;
+        }
+
+        return true;
     }
 
     public function index(): void
@@ -229,8 +249,19 @@ class Invoices extends Admin_Controller
 
     public function delete($invoice_id): void
     {
+        if ( ! $this->ensure_valid_post_request('invoices/index')) {
+            return;
+        }
+
         // Get the status of the invoice
         $invoice        = $this->mdl_invoices->get_by_id($invoice_id);
+
+        if ( ! $invoice) {
+            show_404();
+
+            return;
+        }
+
         $invoice_status = $invoice->invoice_status_id;
 
         if ($invoice_status == 1 || $this->config->item('enable_invoice_deletion') === true) {
@@ -330,6 +361,10 @@ class Invoices extends Admin_Controller
 
     public function delete_invoice_tax(string $invoice_id, $invoice_tax_rate_id): void
     {
+        if ( ! $this->ensure_valid_post_request('invoices/view/' . $invoice_id)) {
+            return;
+        }
+
         $this->load->model('invoices/mdl_invoice_tax_rates');
         $this->mdl_invoice_tax_rates->delete($invoice_tax_rate_id);
 


### PR DESCRIPTION
### Motivation
- Prevent GET-triggered destructive actions on invoices and invoice tax rates which allowed CSRF-style attacks via a simple link or embedded resource.
- Ensure state-changing routes enforce request method and CSRF validation using the existing project CSRF helper.

### Description
- Load the `security` helper in `application/modules/invoices/controllers/Invoices.php` so `verify_csrf_token()` can be used within the controller.
- Add a shared guard method `ensure_valid_post_request(string $redirect_url)` which enforces `POST` requests and calls `verify_csrf_token()`, setting a flash error and redirecting on failure.
- Require the new guard in `delete($invoice_id)` and `delete_invoice_tax(string $invoice_id, $invoice_tax_rate_id)` so deletions only proceed for validated POST requests.
- Add a defensive `show_404()` check in `delete()` when the target invoice does not exist to avoid dereferencing a null invoice.

### Testing
- Ran `php -l application/modules/invoices/controllers/Invoices.php` which reported no syntax errors.
- No unit tests were modified or executed as part of this change; behavior relies on existing CSRF configuration and helper `verify_csrf_token()`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1637516f6083299cba7edeb7970ac4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security validation for invoice deletion operations to prevent unauthorized modifications
  * Added POST request verification and CSRF token checking to invoice deletion endpoints
  * Improved error handling for invalid deletion requests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InvoicePlane/InvoicePlane/pull/1559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->