### PR TITLE
Harden XML config include in invoice XML generation

### DIFF
--- a/application/modules/invoices/controllers/Invoices.php
+++ b/application/modules/invoices/controllers/Invoices.php
@@ -291,7 +291,8 @@ class Invoices extends Admin_Controller
         $options   = [];
         $generator = $xml_id;
         $path      = APPPATH . 'helpers/XMLconfigs/';
-        if ($xml_id && file_exists($path . $xml_id . '.php') && include $path . $xml_id . '.php') {
+        $is_valid_xml_id = is_string($xml_id) && preg_match('/^[A-Za-z0-9-]+$/', $xml_id) === 1;
+        if ($is_valid_xml_id && file_exists($path . $xml_id . '.php') && include $path . $xml_id . '.php') {
             $embed_xml = $xml_setting['embedXML'];
             $XMLname   = $xml_setting['XMLname'];
             $options   = (empty($xml_setting['options']) ? $options : $xml_setting['options']); // Optional


### PR DESCRIPTION
### Motivation
- Prevent local file inclusion (LFI) via user-influenced eInvoicing names by validating the config identifier before building and including a PHP config file.

### Description
- Add a strict whitelist check `is_string($xml_id) && preg_match('/^[A-Za-z0-9-]+$/', $xml_id) === 1` before calling `file_exists()` and `include` in `Invoices::generate_xml()` in `application/modules/invoices/controllers/Invoices.php`, preserving the existing optional config loading for valid IDs.

### Testing
- Ran `php -l application/modules/invoices/controllers/Invoices.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1637847bac8329ac8e43bcbcd422b9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved e-invoice XML generation reliability through enhanced validation of configuration identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InvoicePlane/InvoicePlane/pull/1560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->