### PR TITLE
ci: replace disallowed setup-php action usage

### DIFF
--- a/.github/actions/setup-php-composer/action.yml
+++ b/.github/actions/setup-php-composer/action.yml
@@ -25,12 +25,51 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Set up PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ inputs.php-version }}
-        extensions: ${{ inputs.php-extensions }}
-        coverage: none
+    - name: Install PHP and required extensions
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        PHP_MAJOR_MINOR="${{ inputs.php-version }}"
+        sudo add-apt-repository ppa:ondrej/php -y
+        sudo apt-get update
+
+        EXTENSIONS_RAW="${{ inputs.php-extensions }}"
+        EXTENSIONS_CSV="$(echo "$EXTENSIONS_RAW" | tr -d '[:space:]')"
+        EXTENSION_PACKAGES=""
+        if [ -n "$EXTENSIONS_CSV" ]; then
+          IFS=',' read -ra EXTS <<< "$EXTENSIONS_CSV"
+          for ext in "${EXTS[@]}"; do
+            [ -n "$ext" ] || continue
+            EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-${ext}"
+          done
+        fi
+
+        sudo apt-get install -y software-properties-common ca-certificates curl unzip \
+          php${PHP_MAJOR_MINOR} php${PHP_MAJOR_MINOR}-cli php${PHP_MAJOR_MINOR}-common \
+          php${PHP_MAJOR_MINOR}-mbstring php${PHP_MAJOR_MINOR}-xml php${PHP_MAJOR_MINOR}-curl \
+          php${PHP_MAJOR_MINOR}-zip php${PHP_MAJOR_MINOR}-mysql php${PHP_MAJOR_MINOR}-sqlite3 \
+          php${PHP_MAJOR_MINOR}-bcmath php${PHP_MAJOR_MINOR}-intl php${PHP_MAJOR_MINOR}-gd \
+          ${EXTENSION_PACKAGES}
+
+        sudo update-alternatives --set php /usr/bin/php${PHP_MAJOR_MINOR}
+        php -v
+
+    - name: Install Composer
+      shell: bash
+      run: |
+        set -euo pipefail
+        EXPECTED_SIGNATURE=$(curl -s https://composer.github.io/installer.sig)
+        php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+        ACTUAL_SIGNATURE=$(php -r "echo hash_file('sha384', 'composer-setup.php');")
+        if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]; then
+          echo 'ERROR: Invalid Composer installer signature' >&2
+          rm composer-setup.php
+          exit 1
+        fi
+        php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
+        rm composer-setup.php
+        composer --version
 
     - name: Get Composer Cache Directory
       id: composer-cache

--- a/.github/actions/setup-php-composer/action.yml
+++ b/.github/actions/setup-php-composer/action.yml
@@ -34,78 +34,68 @@ runs:
       run: |
         set -euo pipefail
 
-        PHP_MAJOR_MINOR="${{ inputs.php-version }}"
-        sudo add-apt-repository ppa:ondrej/php -y
+        php_version="${{ inputs.php-version }}"
+
+        # software-properties-common provides add-apt-repository itself, so
+        # it must be installed before the ondrej/php PPA is added.
+        sudo apt-get update
+        sudo apt-get install -y software-properties-common ca-certificates curl unzip
+        sudo add-apt-repository -y ppa:ondrej/php
         sudo apt-get update
 
-        EXTENSIONS_RAW="${{ inputs.php-extensions }}"
-        EXTENSIONS_CSV="$(echo "$EXTENSIONS_RAW" | tr -d '[:space:]')"
-        EXTENSION_PACKAGES=""
-        if [ -n "$EXTENSIONS_CSV" ]; then
-          IFS=',' read -ra EXTS <<< "$EXTENSIONS_CSV"
-          for ext in "${EXTS[@]}"; do
-            [ -n "$ext" ] || continue
-            case "$ext" in
-              sqlite)
-                EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-sqlite3"
-                ;;
-              pdo_mysql)
-                EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-mysql"
-                ;;
-              mysql)
-                EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-mysql"
-        EXTENSIONS_RAW="${{ inputs.php-extensions }}"
-        EXTENSIONS_CSV="$(echo "$EXTENSIONS_RAW" | tr -d '[:space:]')"
-        EXTENSION_PACKAGES=""
-        if [ -n "$EXTENSIONS_CSV" ]; then
-          IFS=',' read -ra EXTS <<< "$EXTENSIONS_CSV"
-          for ext in "${EXTS[@]}"; do
-            [ -n "$ext" ] || continue
-            # Map extension names to apt package names
-            case "$ext" in
-              sqlite) pkg="sqlite3" ;;
-              pdo_mysql) pkg="mysql" ;;
-              pdo_pgsql) pkg="pgsql" ;;
-              pdo_sqlite) pkg="sqlite3" ;;
-              json|ctype|fileinfo|pdo) continue ;;  # Built into PHP 8+ or php-common
-              dom) pkg="xml" ;;
-              *) pkg="$ext" ;;
+        # Map requested PHP extension names to their apt package names.
+        # A few extensions are built into PHP 8+ / php-common and need no
+        # package of their own; a few others are packaged under a name
+        # that differs from the PHP extension name.
+        extension_packages=()
+        extensions_csv="$(tr -d '[:space:]' <<< "${{ inputs.php-extensions }}")"
+        if [ -n "$extensions_csv" ]; then
+          IFS=',' read -ra requested_extensions <<< "$extensions_csv"
+          for extension in "${requested_extensions[@]}"; do
+            [ -n "$extension" ] || continue
+            case "$extension" in
+              json|ctype|fileinfo|pdo) continue ;;
+              sqlite|pdo_sqlite) package='sqlite3' ;;
+              mysql|pdo_mysql) package='mysql' ;;
+              pdo_pgsql) package='pgsql' ;;
+              dom) package='xml' ;;
+              *) package="$extension" ;;
             esac
-            EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-${pkg}"
+            extension_packages+=("php${php_version}-${package}")
           done
         fi
 
-        sudo apt-get install -y software-properties-common ca-certificates curl unzip \
-          php${PHP_MAJOR_MINOR} php${PHP_MAJOR_MINOR}-cli php${PHP_MAJOR_MINOR}-common \
-          php${PHP_MAJOR_MINOR}-mbstring php${PHP_MAJOR_MINOR}-xml php${PHP_MAJOR_MINOR}-curl \
-          php${PHP_MAJOR_MINOR}-zip php${PHP_MAJOR_MINOR}-mysql php${PHP_MAJOR_MINOR}-sqlite3 \
-          php${PHP_MAJOR_MINOR}-bcmath php${PHP_MAJOR_MINOR}-intl php${PHP_MAJOR_MINOR}-gd \
-          ${EXTENSION_PACKAGES}
+        sudo apt-get install -y \
+          "php${php_version}" "php${php_version}-cli" "php${php_version}-common" \
+          "${extension_packages[@]}"
 
-        sudo update-alternatives --set php /usr/bin/php${PHP_MAJOR_MINOR}
+        sudo update-alternatives --set php "/usr/bin/php${php_version}"
         php -v
 
     - name: Install Composer
       shell: bash
       run: |
         set -euo pipefail
-        EXPECTED_SIGNATURE=$(curl -s https://composer.github.io/installer.sig)
+
+        expected_signature="$(curl -sS https://composer.github.io/installer.sig)"
         php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-        ACTUAL_SIGNATURE=$(php -r "echo hash_file('sha384', 'composer-setup.php');")
-        if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]; then
+        actual_signature="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+        if [ "$expected_signature" != "$actual_signature" ]; then
           echo 'ERROR: Invalid Composer installer signature' >&2
-          rm composer-setup.php
+          rm -f composer-setup.php
           exit 1
         fi
+
         php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
-        rm composer-setup.php
+        rm -f composer-setup.php
         composer --version
 
-    - name: Get Composer Cache Directory
+    - name: Get Composer cache directory
       id: composer-cache
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
     - name: Cache Composer dependencies
       uses: actions/cache@v4
@@ -119,6 +109,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
+        set -euo pipefail
+
         if [ "${{ inputs.skip-composer-install }}" = "true" ]; then
           echo "Skipping composer install as requested."
         elif [ -n "${{ inputs.composer-args }}" ]; then

--- a/.github/actions/setup-php-composer/action.yml
+++ b/.github/actions/setup-php-composer/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Working directory for composer commands'
     required: false
     default: '.'
+  skip-composer-install:
+    description: 'Skip running composer install (useful when only PHP setup is needed)'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -41,7 +45,23 @@ runs:
           IFS=',' read -ra EXTS <<< "$EXTENSIONS_CSV"
           for ext in "${EXTS[@]}"; do
             [ -n "$ext" ] || continue
-            EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-${ext}"
+            case "$ext" in
+              sqlite)
+                EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-sqlite3"
+                ;;
+              pdo_mysql)
+                EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-mysql"
+                ;;
+              mysql)
+                EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-mysql"
+                ;;
+              pdo|json|ctype|dom|fileinfo)
+                # Built-in or provided by other packages, skip
+                ;;
+              *)
+                EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-${ext}"
+                ;;
+            esac
           done
         fi
 
@@ -89,7 +109,9 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        if [ -n "${{ inputs.composer-args }}" ]; then
+        if [ "${{ inputs.skip-composer-install }}" = "true" ]; then
+          echo "Skipping composer install as requested."
+        elif [ -n "${{ inputs.composer-args }}" ]; then
           composer install ${{ inputs.composer-args }}
         else
           composer install ${{ inputs.composer-flags }}

--- a/.github/actions/setup-php-composer/action.yml
+++ b/.github/actions/setup-php-composer/action.yml
@@ -54,14 +54,24 @@ runs:
                 ;;
               mysql)
                 EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-mysql"
-                ;;
-              pdo|json|ctype|dom|fileinfo)
-                # Built-in or provided by other packages, skip
-                ;;
-              *)
-                EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-${ext}"
-                ;;
+        EXTENSIONS_RAW="${{ inputs.php-extensions }}"
+        EXTENSIONS_CSV="$(echo "$EXTENSIONS_RAW" | tr -d '[:space:]')"
+        EXTENSION_PACKAGES=""
+        if [ -n "$EXTENSIONS_CSV" ]; then
+          IFS=',' read -ra EXTS <<< "$EXTENSIONS_CSV"
+          for ext in "${EXTS[@]}"; do
+            [ -n "$ext" ] || continue
+            # Map extension names to apt package names
+            case "$ext" in
+              sqlite) pkg="sqlite3" ;;
+              pdo_mysql) pkg="mysql" ;;
+              pdo_pgsql) pkg="pgsql" ;;
+              pdo_sqlite) pkg="sqlite3" ;;
+              json|ctype|fileinfo|pdo) continue ;;  # Built into PHP 8+ or php-common
+              dom) pkg="xml" ;;
+              *) pkg="$ext" ;;
             esac
+            EXTENSION_PACKAGES+=" php${PHP_MAJOR_MINOR}-${pkg}"
           done
         fi
 

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -21,11 +21,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
-          coverage: none
+      - name: Install PHP 8.2
+        run: |
+          sudo add-apt-repository ppa:ondrej/php -y
+          sudo apt-get update
+          sudo apt-get install -y php8.2 php8.2-cli
+          sudo update-alternatives --set php /usr/bin/php8.2
+          php -v
 
       - name: Run php -l on all PHP files
         run: |

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -21,13 +21,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install PHP 8.2
-        run: |
-          sudo add-apt-repository ppa:ondrej/php -y
-          sudo apt-get update
-          sudo apt-get install -y php8.2 php8.2-cli
-          sudo update-alternatives --set php /usr/bin/php8.2
-          php -v
+      - name: Set up PHP and Composer
+        uses: ./.github/actions/setup-php-composer
+        with:
+          php-version: '8.2'
+          composer-args: --no-interaction --no-install
 
       - name: Run php -l on all PHP files
         run: |

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/setup-php-composer
         with:
           php-version: '8.2'
-          composer-args: --no-interaction --no-install
+          skip-composer-install: 'true'
 
       - name: Run php -l on all PHP files
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,12 +80,12 @@ jobs:
           echo "✓ Translations structure validated" | tee -a "$LOG_FILE"
 
       # Step 3: Set up PHP and Composer (before frontend build)
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+      - name: Set up PHP and Composer
+        uses: ./.github/actions/setup-php-composer
         with:
           php-version: '8.4'
-          extensions: gd, bcmath, dom, intl, xml, zip, mbstring, pdo_mysql
-          coverage: none
+          php-extensions: gd, bcmath, dom, intl, xml, zip, mbstring, pdo_mysql
+          composer-args: --no-dev --optimize-autoloader --no-interaction --prefer-dist
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         uses: ./.github/actions/setup-php-composer
         with:
           php-version: '8.4'
-          php-extensions: gd, bcmath, dom, intl, xml, zip, mbstring, pdo_mysql
+          php-extensions: gd, bcmath, intl, xml, zip, mbstring, pdo_mysql, curl
           composer-args: --no-dev --optimize-autoloader --no-interaction --prefer-dist
 
       # Step 4: Set up Node.js for frontend build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,30 +87,6 @@ jobs:
           php-extensions: gd, bcmath, dom, intl, xml, zip, mbstring, pdo_mysql
           composer-args: --no-dev --optimize-autoloader --no-interaction --prefer-dist
 
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Install Composer dependencies (production)
-        run: |
-          set -e
-          set -o pipefail
-          
-          LOG_FILE="${{ env.LOG_DIR }}/composer-install.log"
-          
-          echo "Installing Composer dependencies (production mode)..." | tee -a "$LOG_FILE"
-          composer install --no-dev --optimize-autoloader \
-            --no-interaction --prefer-dist 2>&1 | tee -a "$LOG_FILE"
-          echo "✓ Composer dependencies installed" | tee -a "$LOG_FILE"
-
       # Step 4: Set up Node.js for frontend build
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
### Motivation
- Organization policy requires actions to be owned by InvoicePlane or GitHub, and `shivammathur/setup-php@v2` is blocked, causing CI failures.
- Ensure CI workflows continue to set up PHP and Composer without relying on disallowed third-party actions.

### Description
- Replaced `shivammathur/setup-php@v2` with a local composite action (`.github/actions/setup-php-composer/action.yml`) that installs PHP + extensions via `apt` and installs Composer using the official installer with signature verification.
- `php-lint.yml` and `release.yml` now use the local composite action instead of the blocked one.

### Fix-up (this update)
The composite action's extension-mapping step had a leftover unclosed `case`/`for`/`if` block duplicated ahead of the working one — the first step was an unterminated bash `case` statement (no matching `esac`) that silently swallowed every later command in the script (including the actual `apt-get install` and `php -v`). It never surfaced in CI because `php-lint.yml`/`release.yml` only trigger on `**.php` changes, so the action itself was never actually exercised by CI.

Also cleaned up:
- `software-properties-common` (which provides `add-apt-repository`) is now installed *before* the PPA is added, instead of after.
- `php-lint.yml` now uses the action's `skip-composer-install: true` input instead of the invalid `composer install --no-install` flag.
- `release.yml`'s extension list drops the redundant `dom` (already covered by `xml`) and adds `curl`, which was previously always installed unconditionally and would otherwise have been silently dropped.

Verified with `bash -n` on every extracted script block and `yaml.safe_load` on all three files. Live end-to-end verification via a real Actions run wasn't possible in this environment (workflow runs complete in ~3-5s with no retrievable logs), so this has not been confirmed against a real runner — worth a sanity-check re-run once merged.

## Summary by CodeRabbit

* **Chores**
  * Refactored PHP and Composer setup infrastructure across CI/CD workflows to use a unified custom composite action.
  * Added cryptographic signature verification for Composer installer downloads to enhance security.
  * Updated lint and release workflows to leverage the new setup action, improving consistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated PHP/Composer setup to use a shared local workflow step across linting and release processes.
  * Added an option to skip Composer installation when it isn’t needed.
  * Improved Composer installation validation and caching behavior.
  * Adjusted release workflow settings for the PHP version and extension set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->