### PR TITLE
Fix second-order SQL injection via unvalidated custom_field_table identifier

### DIFF
--- a/application/modules/custom_fields/models/Mdl_custom_fields.php
+++ b/application/modules/custom_fields/models/Mdl_custom_fields.php
@@ -64,7 +64,7 @@ class Mdl_Custom_Fields extends MY_Model
             'custom_field_table' => [
                 'field' => 'custom_field_table',
                 'label' => trans('table'),
-                'rules' => 'required',
+                'rules' => 'required|in_list[ip_client_custom,ip_invoice_custom,ip_payment_custom,ip_quote_custom,ip_user_custom]',
             ],
             'custom_field_label' => [
                 'field' => 'custom_field_label',
@@ -221,7 +221,12 @@ class Mdl_Custom_Fields extends MY_Model
             return;
         }
 
-        $cf   = $this->get_by_id($id);
+        $cf = $this->get_by_id($id);
+
+        if ( ! in_array($cf->custom_field_table, array_keys($this->custom_tables()), true)) {
+            return $get ? [] : $this->db;
+        }
+
         $base = strtr($cf->custom_field_table, ['ip_' => '']) . '_field';
 
         $this->db->from($cf->custom_field_table)
@@ -239,6 +244,11 @@ class Mdl_Custom_Fields extends MY_Model
     {
         if ( ! $this->used($id)) {
             $custom_field = $this->get_by_id($id);
+
+            if ( ! in_array($custom_field->custom_field_table, array_keys($this->custom_tables()), true)) {
+                return false;
+            }
+
             // Remove MULTIPLE|SINGLE CHOICE values
             if (preg_match('/CHOICE/', $custom_field->custom_field_type)) {
                 $this->load->model('custom_values/mdl_custom_values');

--- a/application/modules/custom_fields/models/Mdl_custom_fields.php
+++ b/application/modules/custom_fields/models/Mdl_custom_fields.php
@@ -64,7 +64,7 @@ class Mdl_Custom_Fields extends MY_Model
             'custom_field_table' => [
                 'field' => 'custom_field_table',
                 'label' => trans('table'),
-                'rules' => 'required|in_list[ip_client_custom,ip_invoice_custom,ip_payment_custom,ip_quote_custom,ip_user_custom]',
+                'rules' => 'required|in_list[' . implode(',', array_keys($this->custom_tables())) . ']',
             ],
             'custom_field_label' => [
                 'field' => 'custom_field_label',

--- a/application/modules/custom_fields/models/Mdl_custom_fields.php
+++ b/application/modules/custom_fields/models/Mdl_custom_fields.php
@@ -223,6 +223,10 @@ class Mdl_Custom_Fields extends MY_Model
 
         $cf = $this->get_by_id($id);
 
+        if ($cf === null) {
+            return $get ? [] : $this->db;
+        }
+
         if ( ! in_array($cf->custom_field_table, array_keys($this->custom_tables()), true)) {
             return $get ? [] : $this->db;
         }
@@ -244,6 +248,10 @@ class Mdl_Custom_Fields extends MY_Model
     {
         if ( ! $this->used($id)) {
             $custom_field = $this->get_by_id($id);
+
+            if ($custom_field === null) {
+                return false;
+            }
 
             if ( ! in_array($custom_field->custom_field_table, array_keys($this->custom_tables()), true)) {
                 return false;

--- a/application/modules/custom_values/models/Mdl_custom_values.php
+++ b/application/modules/custom_values/models/Mdl_custom_values.php
@@ -113,6 +113,11 @@ class Mdl_Custom_Values extends MY_Model
         $cv = $this->get_by_id($id)->row();
         $cf = $this->mdl_custom_fields->get_by_id($cv->custom_values_field);
         unset($cv);
+
+        if ( ! in_array($cf->custom_field_table, array_keys($this->custom_tables()), true)) {
+            return $get ? [] : $this->db;
+        }
+
         $base = strtr($cf->custom_field_table, ['ip_' => '']) . '_fieldvalue';
 
         // Get values [SINGLE|MULTIPLE]-CHOICE

--- a/application/modules/custom_values/models/Mdl_custom_values.php
+++ b/application/modules/custom_values/models/Mdl_custom_values.php
@@ -111,8 +111,17 @@ class Mdl_Custom_Values extends MY_Model
 
         $this->load->model('custom_fields/mdl_custom_fields');
         $cv = $this->get_by_id($id)->row();
+
+        if ($cv === null) {
+            return $get ? [] : $this->db;
+        }
+
         $cf = $this->mdl_custom_fields->get_by_id($cv->custom_values_field);
         unset($cv);
+
+        if ($cf === null) {
+            return $get ? [] : $this->db;
+        }
 
         if ( ! in_array($cf->custom_field_table, array_keys($this->custom_tables()), true)) {
             return $get ? [] : $this->db;


### PR DESCRIPTION
## Summary

- **CWE-89 (second-order SQL injection):** `custom_field_table` was stored with only a `required` validation rule, so an attacker-supplied value was persisted verbatim. On the next page load (opening the edit form of the crafted custom field), the stored value was concatenated unescaped into the `FROM` table-name and `WHERE` column-name identifier positions of three Active Record queries — positions CodeIgniter never parameterizes.
- Affected sinks: `Mdl_custom_fields::used()`, `Mdl_custom_fields::delete()`, `Mdl_custom_values::used()`.
- Precondition: authenticated administrator. No victim interaction needed beyond the attacker opening the edit page of their own field.

## Changes

### Layer 1 — Input validation (`Mdl_custom_fields::validation_rules()`)

Added `in_list[ip_client_custom,ip_invoice_custom,ip_payment_custom,ip_quote_custom,ip_user_custom]` to the `custom_field_table` rule. Values outside this set are rejected at form-validation time before reaching the database.

### Layer 2 — Defense-in-depth at every identifier sink

Added `in_array($table, array_keys($this->custom_tables()), true)` guards in:
- `Mdl_custom_fields::used()` — returns `[]` for non-whitelisted table names
- `Mdl_custom_fields::delete()` — returns `false` for non-whitelisted table names
- `Mdl_custom_values::used()` — returns `[]` for non-whitelisted table names

This second layer protects against legacy rows written before the patch and ensures the identifier never reaches the query builder even if the validation layer is bypassed.

## Test plan

- [ ] Create a custom field with each of the five valid tables (`ip_client_custom`, `ip_invoice_custom`, `ip_payment_custom`, `ip_quote_custom`, `ip_user_custom`) — form should save and edit page should load normally.
- [ ] Attempt to submit the create form with a crafted `custom_field_table` value outside the whitelist (e.g. via direct POST) — request should be rejected with a validation error.
- [ ] Verify existing custom fields can still be edited and deleted without regression.
- [ ] Confirm `Mdl_custom_values::used()` correctly resolves usage for SINGLE-CHOICE and MULTIPLE-CHOICE fields.

https://claude.ai/code/session_018Z9obprsf6W8mVk7BsUb4M

---
_Generated by [Claude Code](https://claude.ai/code/session_018Z9obprsf6W8mVk7BsUb4M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation tightened for custom field configuration so only recognized custom table types are accepted.
  * Added safety checks across custom field/value operations (fetch, usage checks, and deletion) to return safe defaults or skip processing when a field or its table is missing or unrecognized, preventing unintended queries or deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->