### PR TITLE
Fix stored XSS via CSV import (CWE-79)

### DIFF
--- a/application/modules/guest/views/invoices_view.php
+++ b/application/modules/guest/views/invoices_view.php
@@ -3,7 +3,7 @@ $global_discount = $invoice->invoice_discount_percent > 0 ? format_amount($invoi
 if ($invoice_tax_rates) {
     $global_taxes = [];
     foreach ($invoice_tax_rates as $invoice_tax_rate) {
-        $global_taxes[] = $invoice_tax_rate->invoice_tax_rate_name . ' (' . format_amount($invoice_tax_rate->invoice_tax_rate_percent) . '%): '
+        $global_taxes[] = htmlsc($invoice_tax_rate->invoice_tax_rate_name) . ' (' . format_amount($invoice_tax_rate->invoice_tax_rate_percent) . '%): '
                           . format_currency($invoice_tax_rate->invoice_tax_rate_amount);
     }
     $global_taxes = implode('<br>', $global_taxes);

--- a/application/modules/guest/views/payments_index.php
+++ b/application/modules/guest/views/payments_index.php
@@ -35,7 +35,7 @@
                             </a>
                         </td>
                         <td><?php echo format_currency($payment->payment_amount); ?></td>
-                        <td><?php echo $payment->payment_method_name; ?></td>
+                        <td><?php echo htmlsc($payment->payment_method_name); ?></td>
                         <td><?php _htmlsc($payment->payment_note); ?></td>
                     </tr>
                 <?php } ?>

--- a/application/modules/guest/views/quotes_view.php
+++ b/application/modules/guest/views/quotes_view.php
@@ -3,7 +3,7 @@ $global_discount = $quote->quote_discount_percent > 0 ? format_amount($quote->qu
 if ($quote_tax_rates) {
     $global_taxes = [];
     foreach ($quote_tax_rates as $quote_tax_rate) {
-        $global_taxes[] = $quote_tax_rate->quote_tax_rate_name . ' (' . format_amount($quote_tax_rate->quote_tax_rate_percent) . '%): '
+        $global_taxes[] = htmlsc($quote_tax_rate->quote_tax_rate_name) . ' (' . format_amount($quote_tax_rate->quote_tax_rate_percent) . '%): '
                           . format_currency($quote_tax_rate->quote_tax_rate_amount);
     }
     $global_taxes = implode('<br>', $global_taxes);

--- a/application/modules/import/models/Mdl_import.php
+++ b/application/modules/import/models/Mdl_import.php
@@ -292,7 +292,7 @@ class Mdl_Import extends Response_Model
                                 $data[$key] = $tax_rate->row()->tax_rate_id;
                             } else {
                                 $this->db->insert('ip_tax_rates', [
-                                    'tax_rate_name'    => $data[$key],
+                                    'tax_rate_name'    => strip_tags($this->security->xss_clean($data[$key])),
                                     'tax_rate_percent' => $data[$key],
                                 ]);
                                 $data[$key] = $this->db->insert_id();
@@ -368,7 +368,7 @@ class Mdl_Import extends Response_Model
                             if ($payment_method->num_rows()) {
                                 $data[$key] = $payment_method->row()->payment_method_id;
                             } else {
-                                $this->db->insert('ip_payment_methods', ['payment_method_name' => $data[$key]]);
+                                $this->db->insert('ip_payment_methods', ['payment_method_name' => strip_tags($this->security->xss_clean($data[$key]))]);
                                 $data[$key] = $this->db->insert_id();
                             }
                         } else {

--- a/application/modules/invoices/views/view.php
+++ b/application/modules/invoices/views/view.php
@@ -563,7 +563,7 @@ foreach ($payment_methods as $payment_method) {
     ?>
                                         <option <?php check_select($invoice->payment_method, $payment_method->payment_method_id) ?>
                                             value="<?php echo $payment_method->payment_method_id; ?>">
-                                            <?php echo $payment_method->payment_method_name; ?>
+                                            <?php echo htmlsc($payment_method->payment_method_name); ?>
                                         </option>
 <?php
 } // End foreach

--- a/application/modules/invoices/views/view_sumex.php
+++ b/application/modules/invoices/views/view_sumex.php
@@ -597,7 +597,7 @@ foreach ($payment_methods as $payment_method) {
     ?>
                                         <option <?php check_select($invoice->payment_method, $payment_method->payment_method_id) ?>
                                             value="<?php echo $payment_method->payment_method_id; ?>">
-                                            <?php echo $payment_method->payment_method_name; ?>
+                                            <?php echo htmlsc($payment_method->payment_method_name); ?>
                                         </option>
 <?php
 } // End foreach


### PR DESCRIPTION
CSV import wrote payment method names and tax rate names directly to the
database without sanitization, bypassing the POST-only filter_input().
Several views then echoed those values without HTML encoding, allowing a
crafted CSV to store JavaScript that executed in an admin browser when
opening any invoice for editing.

Fix layer 1 (source): sanitize payment_method_name and tax_rate_name
with xss_clean()+strip_tags() before the DB insert in Mdl_import.php,
consistent with what filter_input() does for normal form POST fields.

Fix layer 2 (sinks): wrap the bare echo calls in htmlsc() in:
- invoices/views/view.php (payment method dropdown)
- invoices/views/view_sumex.php (payment method dropdown)
- guest/views/payments_index.php (client portal payment list)
- guest/views/invoices_view.php (global tax rate name in summary row)
- guest/views/quotes_view.php (same pattern for quotes)

https://claude.ai/code/session_01MtzNFUgssHqD1FkLX7xxtu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by properly escaping tax rate names and payment method names displayed across invoices, payments, and quotes
  * Added sanitization for imported tax rate names and payment method names during data import to prevent potential security issues
  * Applied consistent security measures across all relevant display and import areas

<!-- end of auto-generated comment: release notes by coderabbit.ai -->