### PR TITLE
Fix MariaDB 1066 duplicate join on guest Payments page

### DIFF
--- a/application/modules/guest/controllers/Payments.php
+++ b/application/modules/guest/controllers/Payments.php
@@ -31,15 +31,10 @@ class Payments extends Guest_Controller
      */
     public function index($page = 0)
     {
-        // Security: Use a single join query instead of a two-step PHP-level prefetch.
-        // Joining on ip_invoices avoids fetching potentially large invoice-ID lists
-        // into PHP and removes the risk of hitting SQL IN-list limits.
         if ( ! empty($this->user_clients)) {
             $this->mdl_payments
-                ->join('ip_invoices', 'ip_invoices.invoice_id = ip_payments.invoice_id', 'inner')
                 ->where_in('ip_invoices.client_id', $this->user_clients);
         } else {
-            // No client access for this user — return an empty result set.
             $this->mdl_payments->where('1=0');
         }
 


### PR DESCRIPTION
Remove the explicit ip_invoices join from Guest Payments::index(); Mdl_Payments::default_join() already adds it, causing a "Not unique table/alias" error at SQL parse time for every guest user.

https://claude.ai/code/session_013YQWaezKeMcaUziJdMaS6e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized payment query processing for improved efficiency. No changes to end-user functionality or display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->