### PR TITLE
Fix 7 pre-beta bugs found in security-hardening review

### DIFF
--- a/application/core/Password_Encryption_Trait.php
+++ b/application/core/Password_Encryption_Trait.php
@@ -1,0 +1,63 @@
+<?php
+
+if ( ! defined('BASEPATH')) {
+    exit('No direct script access allowed');
+}
+
+/*
+ * InvoicePlane
+ *
+ * @author      InvoicePlane Developers & Contributors
+ * @copyright   Copyright (c) 2012 - 2018 InvoicePlane.com
+ * @license     https://invoiceplane.com/license.txt
+ * @link        https://invoiceplane.com
+ */
+
+/**
+ * Password Encryption Trait.
+ *
+ * Shared encrypt/decrypt logic for models that store PDF passwords at rest.
+ * Used by Mdl_Invoices and Mdl_Quotes.
+ */
+trait Password_Encryption_Trait
+{
+    /**
+     * Encrypt a PDF password for storage. Returns null for empty input.
+     */
+    protected function encrypt_password(?string $password): ?string
+    {
+        if ($password === null || $password === '') {
+            return null;
+        }
+
+        $this->load->library('crypt');
+
+        return $this->crypt->encode($password);
+    }
+
+    /**
+     * Decrypt a stored PDF password.
+     *
+     * Falls back to returning the raw value when decryption fails so that
+     * invoices created before at-rest encryption was introduced continue to
+     * work until they are next saved (at which point save() encrypts them).
+     */
+    protected function decrypt_password(?string $password): string
+    {
+        if ($password === null || $password === '') {
+            return '';
+        }
+
+        $this->load->library('crypt');
+
+        try {
+            $decoded = $this->crypt->decode($password);
+
+            return is_string($decoded) ? $decoded : '';
+        } catch (\Exception $e) {
+            // Value is likely plaintext from before at-rest encryption was
+            // added; return as-is so existing invoices stay accessible.
+            return $password;
+        }
+    }
+}

--- a/application/modules/guest/controllers/View.php
+++ b/application/modules/guest/controllers/View.php
@@ -14,7 +14,7 @@ if ( ! defined('BASEPATH')) {
  */
 
 #[AllowDynamicProperties]
-class View extends Guest_Controller
+class View extends Base_Controller
 {
     /**
      * Constructor - load file security helper for validation.
@@ -36,7 +36,7 @@ class View extends Guest_Controller
 
         $this->load->model('invoices/mdl_invoices');
 
-        $invoice = $this->mdl_invoices->guest_visible()->where('invoice_url_key', $invoice_url_key)->where_in('client_id', $this->user_clients)->get();
+        $invoice = $this->mdl_invoices->guest_visible()->where('invoice_url_key', $invoice_url_key)->get();
 
         if ($invoice->num_rows() != 1) {
             show_404();
@@ -111,7 +111,7 @@ class View extends Guest_Controller
     {
         $this->load->model('invoices/mdl_invoices');
 
-        $invoice = $this->mdl_invoices->guest_visible()->where('invoice_url_key', $invoice_url_key)->where_in('client_id', $this->user_clients)->get();
+        $invoice = $this->mdl_invoices->guest_visible()->where('invoice_url_key', $invoice_url_key)->get();
 
         if ($invoice->num_rows() == 1) {
             $invoice = $invoice->row();
@@ -138,7 +138,7 @@ class View extends Guest_Controller
     {
         $this->load->model('invoices/mdl_invoices');
 
-        $invoice = $this->mdl_invoices->guest_visible()->where('invoice_url_key', $invoice_url_key)->where_in('client_id', $this->user_clients)->get();
+        $invoice = $this->mdl_invoices->guest_visible()->where('invoice_url_key', $invoice_url_key)->get();
 
         if ($invoice->num_rows() == 1) {
             $invoice = $invoice->row();
@@ -168,7 +168,7 @@ class View extends Guest_Controller
 
         $this->load->model('quotes/mdl_quotes');
 
-        $quote = $this->mdl_quotes->guest_visible()->where('quote_url_key', $quote_url_key)->where_in('client_id', $this->user_clients)->get();
+        $quote = $this->mdl_quotes->guest_visible()->where('quote_url_key', $quote_url_key)->get();
 
         if ($quote->num_rows() != 1) {
             show_404();
@@ -228,7 +228,7 @@ class View extends Guest_Controller
     {
         $this->load->model('quotes/mdl_quotes');
 
-        $quote = $this->mdl_quotes->guest_visible()->where('quote_url_key', $quote_url_key)->where_in('client_id', $this->user_clients)->get()->row();
+        $quote = $this->mdl_quotes->guest_visible()->where('quote_url_key', $quote_url_key)->get()->row();
 
         if ( ! $quote) {
             show_404();

--- a/application/modules/invoices/models/Mdl_invoices.php
+++ b/application/modules/invoices/models/Mdl_invoices.php
@@ -16,6 +16,8 @@ if ( ! defined('BASEPATH')) {
 #[AllowDynamicProperties]
 class Mdl_Invoices extends Response_Model
 {
+    use Password_Encryption_Trait;
+
     public $table = 'ip_invoices';
 
     public $primary_key = 'ip_invoices.invoice_id';
@@ -75,8 +77,12 @@ class Mdl_Invoices extends Response_Model
 
     public function save($id = null, $db_array = null)
     {
-        if (is_array($db_array) && array_key_exists('invoice_password', $db_array)) {
-            $db_array['invoice_password'] = $this->encrypt_invoice_password($db_array['invoice_password']);
+        if ($db_array === null) {
+            $db_array = $this->db_array();
+        }
+
+        if (array_key_exists('invoice_password', $db_array)) {
+            $db_array['invoice_password'] = $this->encrypt_password($db_array['invoice_password']);
         }
 
         return parent::save($id, $db_array);
@@ -84,25 +90,12 @@ class Mdl_Invoices extends Response_Model
 
     public function encrypt_invoice_password($password): ?string
     {
-        if ($password === null || $password === '') {
-            return null;
-        }
-
-        $this->load->library('crypt');
-
-        return $this->crypt->encode((string) $password);
+        return $this->encrypt_password($password);
     }
 
     public function decrypt_invoice_password($password): string
     {
-        if ($password === null || $password === '') {
-            return '';
-        }
-
-        $this->load->library('crypt');
-        $decoded = $this->crypt->decode($password);
-
-        return is_string($decoded) ? $decoded : '';
+        return $this->decrypt_password($password);
     }
 
     public function default_order_by()
@@ -197,6 +190,14 @@ class Mdl_Invoices extends Response_Model
      */
     public function create($db_array = null, $include_invoice_tax_rates = true)
     {
+        if ($db_array === null) {
+            $db_array = $this->db_array();
+        }
+
+        if (array_key_exists('invoice_password', $db_array)) {
+            $db_array['invoice_password'] = $this->encrypt_password($db_array['invoice_password']);
+        }
+
         $invoice_id = parent::save(null, $db_array);
 
         $inv           = $this->where('ip_invoices.invoice_id', $invoice_id)->get()->row();

--- a/application/modules/quotes/controllers/Ajax.php
+++ b/application/modules/quotes/controllers/Ajax.php
@@ -118,7 +118,7 @@ class Ajax extends Admin_Controller
                 'quote_status_id'        => $quote_status_id,
                 'quote_date_created'     => date_to_mysql($this->input->post('quote_date_created')),
                 'quote_date_expires'     => date_to_mysql($this->input->post('quote_date_expires')),
-                'quote_password'         => $this->input->post('quote_password'),
+                'quote_password'         => $this->security->xss_clean($this->input->post('quote_password')),
                 'notes'                  => $this->input->post('notes'),
                 'quote_discount_amount'  => standardize_amount($quote_discount_amount),
                 'quote_discount_percent' => standardize_amount($quote_discount_percent),

--- a/application/modules/quotes/controllers/Quotes.php
+++ b/application/modules/quotes/controllers/Quotes.php
@@ -193,6 +193,14 @@ class Quotes extends Admin_Controller
             return;
         }
 
+        $quote = $this->mdl_quotes->get_by_id($quote_id);
+
+        if ( ! $quote) {
+            show_404();
+
+            return;
+        }
+
         // Delete the quote
         $this->mdl_quotes->delete($quote_id);
 

--- a/application/modules/quotes/models/Mdl_quotes.php
+++ b/application/modules/quotes/models/Mdl_quotes.php
@@ -16,6 +16,8 @@ if ( ! defined('BASEPATH')) {
 #[AllowDynamicProperties]
 class Mdl_Quotes extends Response_Model
 {
+    use Password_Encryption_Trait;
+
     public $table = 'ip_quotes';
 
     public $primary_key = 'ip_quotes.quote_id';
@@ -78,8 +80,12 @@ class Mdl_Quotes extends Response_Model
 
     public function save($id = null, $db_array = null)
     {
-        if (is_array($db_array) && array_key_exists('quote_password', $db_array)) {
-            $db_array['quote_password'] = $this->encrypt_quote_password($db_array['quote_password']);
+        if ($db_array === null) {
+            $db_array = $this->db_array();
+        }
+
+        if (array_key_exists('quote_password', $db_array)) {
+            $db_array['quote_password'] = $this->encrypt_password($db_array['quote_password']);
         }
 
         return parent::save($id, $db_array);
@@ -87,25 +93,12 @@ class Mdl_Quotes extends Response_Model
 
     public function encrypt_quote_password($password): ?string
     {
-        if ($password === null || $password === '') {
-            return null;
-        }
-
-        $this->load->library('crypt');
-
-        return $this->crypt->encode((string) $password);
+        return $this->encrypt_password($password);
     }
 
     public function decrypt_quote_password($password): string
     {
-        if ($password === null || $password === '') {
-            return '';
-        }
-
-        $this->load->library('crypt');
-        $decoded = $this->crypt->decode($password);
-
-        return is_string($decoded) ? $decoded : '';
+        return $this->decrypt_password($password);
     }
 
     public function default_order_by()
@@ -187,6 +180,14 @@ class Mdl_Quotes extends Response_Model
      */
     public function create($db_array = null)
     {
+        if ($db_array === null) {
+            $db_array = $this->db_array();
+        }
+
+        if (array_key_exists('quote_password', $db_array)) {
+            $db_array['quote_password'] = $this->encrypt_password($db_array['quote_password']);
+        }
+
         $quote_id = parent::save(null, $db_array);
 
         // Create an quote amount record

--- a/application/modules/setup/sql/043_1.7.2.sql
+++ b/application/modules/setup/sql/043_1.7.2.sql
@@ -6,3 +6,8 @@ WHERE `client_birthdate` = '0000-00-00';
 
 ALTER TABLE `ip_clients`
 MODIFY `client_birthdate` DATE NULL DEFAULT NULL;
+
+-- NOTE: invoice_password and quote_password are now encrypted at rest using
+-- the application ENCRYPTION_KEY. Existing plaintext values remain readable
+-- (the application falls back to returning them as-is on decrypt failure) and
+-- are transparently re-encrypted the next time each record is saved.


### PR DESCRIPTION
1. CRITICAL — Revert guest/View to Base_Controller; remove where_in guards that
   required login to view invoices/quotes by URL key, breaking all emailed links
   and payment-gateway success redirects.

2. HIGH — Fix create() in Mdl_Invoices/Mdl_Quotes bypassing the save() encryption
   override (parent::save vs $this->save dispatch). New records now encrypt
   invoice_password / quote_password on creation.

3. HIGH — Add try/catch to decrypt_password() in new Password_Encryption_Trait so
   that legacy plaintext passwords (stored before at-rest encryption landed) do not
   throw an uncaught Cryptor exception, crashing the admin view and PDF generation.
   Values migrate transparently on next save.

4. HIGH — Fix save() null-path: when called with no explicit db_array, populate
   from db_array() before encrypting so the password field is never written
   unencrypted via the no-arg path.

5. HIGH — Add get_by_id null-check to Quotes::delete(), matching the guard already
   present in Invoices::delete().

6. MEDIUM — Add xss_clean() to quote_password in quotes Ajax controller, matching
   the existing sanitization on invoice_password.

7. CLEANUP — Extract shared encrypt/decrypt logic to Password_Encryption_Trait,
   eliminating the verbatim duplication between Mdl_Invoices and Mdl_Quotes.

https://claude.ai/code/session_01WaPtptKZ2DgixiVmfyrWZK