### PR TITLE
Add user_siren field for French e-invoicing support

### DIFF
--- a/application/language/english/ip_lang.php
+++ b/application/language/english/ip_lang.php
@@ -187,6 +187,7 @@ $lang = [
     'drop_files_here'                               => 'Drop files here!',
     'due_date'                                      => 'Due Date',
     'edit'                                          => 'Edit',
+    'einvoice_siren'                                => 'SIREN',
     'einvoicing_enable'                             => 'Enable e-invoice',
     'einvoicing_enable_help'                        => 'This option activates the electronic invoice system to be sent to the customer. Examples to adapt to your needs are available in this repository:',
     'einvoicing_how_enable_hint'                    => 'Electronic invoicing deactivated. No configuration and model found in dedicated folders. To activate this feature, please consult the documentation or see this repository:',

--- a/application/modules/setup/sql/044_1.7.3.sql
+++ b/application/modules/setup/sql/044_1.7.3.sql
@@ -1,0 +1,4 @@
+# Added for versioning
+-- Add user_siren column for French e-invoicing (Factur-X / EN16931 / PDP) support.
+ALTER TABLE `ip_users`
+ADD COLUMN `user_siren` VARCHAR(9) NULL DEFAULT NULL AFTER `user_company`;

--- a/application/modules/users/controllers/Users.php
+++ b/application/modules/users/controllers/Users.php
@@ -69,6 +69,7 @@ class Users extends Admin_Controller
                     'user_name'     => $new_details->user_name,
                     'user_email'    => $new_details->user_email,
                     'user_company'  => $new_details->user_company,
+                    'user_siren'    => $new_details->user_siren,
                     'user_language' => $new_details->user_language ?? 'system',
                 ];
 

--- a/application/modules/users/models/Mdl_users.php
+++ b/application/modules/users/models/Mdl_users.php
@@ -86,6 +86,8 @@ class Mdl_Users extends Response_Model
             ],
             'user_siren' => [
                 'field' => 'user_siren',
+                'label' => trans('einvoice_siren'),
+                'rules' => 'trim|regex_match[/^[0-9]{9}$/]',
             ],
             'user_address_1' => [
                 'field' => 'user_address_1',
@@ -202,10 +204,12 @@ class Mdl_Users extends Response_Model
             ],
             'user_siren' => [
                 'field' => 'user_siren',
+                'label' => trans('einvoice_siren'),
+                'rules' => 'trim|regex_match[/^[0-9]{9}$/]',
             ],
             'user_address_1' => [
                 'field' => 'user_address_1',
-            ],
+
             'user_address_2' => [
                 'field' => 'user_address_2',
             ],

--- a/application/modules/users/models/Mdl_users.php
+++ b/application/modules/users/models/Mdl_users.php
@@ -84,6 +84,9 @@ class Mdl_Users extends Response_Model
             'user_company' => [
                 'field' => 'user_company',
             ],
+            'user_siren' => [
+                'field' => 'user_siren',
+            ],
             'user_address_1' => [
                 'field' => 'user_address_1',
             ],
@@ -196,6 +199,9 @@ class Mdl_Users extends Response_Model
             ],
             'user_company' => [
                 'field' => 'user_company',
+            ],
+            'user_siren' => [
+                'field' => 'user_siren',
             ],
             'user_address_1' => [
                 'field' => 'user_address_1',

--- a/application/modules/users/views/form.php
+++ b/application/modules/users/views/form.php
@@ -76,7 +76,7 @@ $einvoicingOpt = $einvoicing ? $einvoicingTip . trans('optional') . ')"' : '';
                             <div class="form-group"<?php echo $itsCompany ? $einvoicingB2B : $einvoicingOpt; ?>>
                                 <label for="user_siren">SIREN (<?php _trans($itsCompany ? 'required_field' : 'optional'); ?>)</label><?php echo $qr_code_info; ?>
                                 <input type="text" name="user_siren" id="user_siren" class="form-control"
-                                       value="<?php echo $this->mdl_users->form_value('user_siren'); ?>">
+                                       value="<?php echo $this->mdl_users->form_value('user_siren', true); ?>">
                             </div>
 
                             <div class="form-group">

--- a/application/modules/users/views/form.php
+++ b/application/modules/users/views/form.php
@@ -73,6 +73,12 @@ $einvoicingOpt = $einvoicing ? $einvoicingTip . trans('optional') . ')"' : '';
                                        value="<?php echo $this->mdl_users->form_value('user_company', true); ?>">
                             </div>
 
+                            <div class="form-group"<?php echo $itsCompany ? $einvoicingB2B : $einvoicingOpt; ?>>
+                                <label for="user_siren">SIREN (<?php _trans($itsCompany ? 'required_field' : 'optional'); ?>)</label><?php echo $qr_code_info; ?>
+                                <input type="text" name="user_siren" id="user_siren" class="form-control"
+                                       value="<?php echo $this->mdl_users->form_value('user_siren'); ?>">
+                            </div>
+
                             <div class="form-group">
                                 <label for="user_email"><?php _trans('email_address'); ?></label>
                                 <input type="text" name="user_email" id="user_email" class="form-control"


### PR DESCRIPTION
# Pull Request Checklist

---

## Motivation and Context
This change was necessary to improve Factur-X compatibility with the French e-invoicing requirements and PDP validators.

The current generated XML could be accepted by some generic Factur-X validators, but it failed validation with French PDP-oriented validators such as SuperPDP and FactPulse.

This PR improves the generated Factur-X XML by:

* adding support for the seller SIREN through a new `user_siren` field
* using the buyer SIREN for electronic routing
* improving EN16931 profile compatibility
* adding required French legal notes
* sanitizing invoice references according to French validation rules
* preventing invalid payment blocks when no IBAN or account identifier is available

This helps InvoicePlane generate invoices that are better aligned with French PDP / EN16931 validation requirements and reduces the risk of invoice rejection by French e-invoicing platforms.

Validated with:

* SuperPDP
* FactPulse

Related issue: [`<link-to-issue>`](https://github.com/InvoicePlane/InvoicePlane-e-invoices/issues/11)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SIREN field to user account settings, displayed in the account information panel.
  * The SIREN field is pre-filled from existing data and validated (format: 9 digits) during submission.
  * When users edit their own account, the updated SIREN value is reflected in the session right away.
* **Documentation**
  * Added the “SIREN” label to the English language resources.
* **Chores**
  * Introduced a database column to store the new SIREN value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->