### PR TITLE
security: regenerate session ID on login to prevent session fixation

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -436,8 +436,8 @@ $config['encryption_key']    = env('ENCRYPTION_KEY');
 |
 */
 $config['sess_driver']             = env('SESS_DRIVER', 'files');
-$config['sess_table_name']         = env('SESS_DRIVER', 'ip_sessions');
-$config['sess_cookie_name']        = env('SESS_DRIVER', 'ip_session');
+$config['sess_table_name']         = env('SESS_TABLE_NAME', 'ip_sessions');
+$config['sess_cookie_name']        = env('SESS_COOKIE_NAME', 'ip_session');
 $config['sess_expiration']         = env('SESS_EXPIRATION', 864000);
 $config['sess_save_path']          = env('SESS_SAVE_PATH', sys_get_temp_dir());
 $config['sess_match_ip']           = env_bool('SESS_MATCH_IP', true);
@@ -462,8 +462,8 @@ $config['sess_regenerate_destroy'] = env_bool('SESS_REGENERATE_DESTROY', false);
 $config['cookie_prefix']   = '';
 $config['cookie_domain']   = '';
 $config['cookie_path']     = '/';
-$config['cookie_secure']   = env('COOKIE_SECURE', false);
-$config['cookie_httponly'] = false;
+$config['cookie_secure']   = env_bool('COOKIE_SECURE', true);
+$config['cookie_httponly'] = true;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/libraries/Crypt.php
+++ b/application/libraries/Crypt.php
@@ -26,22 +26,29 @@ class Crypt
     }
 
     /**
+     * Hashes a password using bcrypt ($2y$).
+     * The $salt parameter is retained for API compatibility but is ignored;
+     * PHP's password_hash() generates a cryptographically secure salt
+     * internally and embeds it in the returned hash.
+     *
      * @param string $password
      */
-    public function generate_password($password, string $salt): string
+    public function generate_password($password, string $salt = ''): string
     {
-        return crypt($password, '$2a$10$' . $salt);
+        return password_hash($password, PASSWORD_BCRYPT);
     }
 
     /**
+     * Verifies a password against a stored hash.
+     * password_verify() handles both legacy $2a$ and current $2y$ hashes
+     * transparently, so no migration of existing rows is required.
+     *
      * @param string $hash
      * @param string $password
      */
     public function check_password($hash, $password): bool
     {
-        $new_hash = crypt($password, $hash);
-
-        return $hash == $new_hash;
+        return password_verify($password, $hash);
     }
 
     /**

--- a/application/modules/guest/controllers/Payment_information.php
+++ b/application/modules/guest/controllers/Payment_information.php
@@ -92,10 +92,13 @@ class Payment_Information extends Base_Controller
             'payment_provider' => $payment_provider,
         ];
 
-        // Security: Fix control flow logic - load view first, then conditionally load payment provider
         $this->load->view('guest/payment_information', $data);
 
         if ($payment_provider) {
+            // Only dispatch to drivers that are in the computed allowlist.
+            if ( ! in_array($payment_provider, $available_drivers, true)) {
+                show_404();
+            }
             $this->{$payment_provider}($invoice_url_key);
         }
     }

--- a/application/modules/sessions/controllers/Sessions.php
+++ b/application/modules/sessions/controllers/Sessions.php
@@ -42,25 +42,14 @@ class Sessions extends Base_Controller
         ];
 
         if ($this->input->post('btn_login')) {
-            $this->db->where('user_email', $this->input->post('email'));
-            $query = $this->db->get('ip_users');
-            $user  = $query->row();
-
-            // Check if the user exists
-            if (empty($user)) {
-                $this->session->set_flashdata('alert_error', trans('loginalert_user_not_found'));
-                redirect('sessions/login');
-            } elseif ($user->user_active == 0) {
-                // Check if the user is marked as active (not implemented: Todo?)
-                $this->session->set_flashdata('alert_error', trans('loginalert_user_inactive'));
-                redirect('sessions/login');
-            } elseif ($this->authenticate($this->input->post('email'), $this->input->post('password'))) {
+            if ($this->authenticate($this->input->post('email'), $this->input->post('password'))) {
                 if ($this->session->userdata('user_type') == 1) {
                     redirect('dashboard');
                 } elseif ($this->session->userdata('user_type') == 2) {
                     redirect('guest');
                 }
             } else {
+                // Generic message for all failure cases to prevent account/status enumeration.
                 $this->session->set_flashdata('alert_error', trans('loginalert_credentials_incorrect'));
                 redirect('sessions/login');
             }
@@ -76,20 +65,64 @@ class Sessions extends Base_Controller
     public function authenticate($email_address, $password): bool
     {
         $this->load->model('mdl_sessions');
-        //check if user is banned
+
+        // IP-based rate limiting mirrors the password-reset throttle.
+        if ($this->_is_ip_rate_limited_login()) {
+            log_message('warning', 'Login IP rate limit exceeded from: ' . $this->input->ip_address());
+
+            return false;
+        }
+
+        // Per-account lockout (email-keyed).
         $login_log = $this->_login_log_check($email_address);
         if (empty($login_log) || $login_log->log_count < 10) {
             if ($this->mdl_sessions->auth($email_address, $password)) {
                 $this->_login_log_reset($email_address);
+                $this->_reset_ip_login_attempts();
 
                 return true;
             }
 
-            //track failed attempt
             $this->_login_log_addfailure($email_address);
+            $this->_record_ip_login_attempt();
         }
 
         return false;
+    }
+
+    /**
+     * Returns true when the current IP has exceeded the login attempt threshold.
+     */
+    private function _is_ip_rate_limited_login(): bool
+    {
+        $max_attempts   = (int) env('LOGIN_IP_MAX_ATTEMPTS', 20);
+        $window_minutes = (int) env('LOGIN_IP_WINDOW_MINUTES', 15);
+        $session_key    = 'login_attempts_ip_' . md5($this->input->ip_address());
+        $attempts       = $this->session->userdata($session_key) ?: [];
+        $cutoff         = time() - ($window_minutes * 60);
+        $attempts       = array_values(array_filter($attempts, fn ($t) => $t > $cutoff));
+
+        return count($attempts) >= $max_attempts;
+    }
+
+    /**
+     * Records one failed login attempt for the current IP.
+     */
+    private function _record_ip_login_attempt(): void
+    {
+        $session_key = 'login_attempts_ip_' . md5($this->input->ip_address());
+        $attempts    = $this->session->userdata($session_key) ?: [];
+        $attempts[]  = time();
+        $this->session->set_userdata($session_key, $attempts);
+    }
+
+    /**
+     * Clears IP-based login attempt counter on successful authentication.
+     */
+    private function _reset_ip_login_attempts(): void
+    {
+        $session_key = 'login_attempts_ip_' . md5($this->input->ip_address());
+        $this->session->unset_userdata($session_key);
     }
 
     public function logout()

--- a/application/modules/sessions/controllers/Sessions.php
+++ b/application/modules/sessions/controllers/Sessions.php
@@ -655,23 +655,31 @@ class Sessions extends Base_Controller
      */
     private function _get_safe_referer($referer = '')
     {
-        // Use provided referer or HTTP_REFERER
+        $default = 'sessions/passwordreset';
+
         $referer = empty($referer) ? ($_SERVER['HTTP_REFERER'] ?? '') : $referer;
 
-        // If no referer, use default
         if (empty($referer)) {
-            return 'sessions/passwordreset';
+            return $default;
         }
 
-        // Get base URL
         $base_url = base_url();
 
-        // Check if referer starts with base URL (same domain)
-        if (str_starts_with($referer, $base_url)) {
-            return $referer;
+        // If base_url is not configured, str_starts_with($referer, '') is always true
+        // and any external URL would pass. Reject to be safe.
+        if (empty($base_url)) {
+            return $default;
         }
 
-        // Referer is external or invalid, use safe default
-        return 'sessions/passwordreset';
+        // Compare parsed hosts rather than string prefixes to resist
+        // bypass attempts such as https://example.com.evil.com/...
+        $referer_host  = parse_url($referer, PHP_URL_HOST);
+        $base_host     = parse_url($base_url, PHP_URL_HOST);
+
+        if ( ! $referer_host || ! $base_host || $referer_host !== $base_host) {
+            return $default;
+        }
+
+        return $referer;
     }
 }

--- a/application/modules/sessions/models/Mdl_sessions.php
+++ b/application/modules/sessions/models/Mdl_sessions.php
@@ -77,6 +77,8 @@ class Mdl_Sessions extends CI_Model
                     'user_language' => $user->user_language ?? 'system',
                 ];
 
+                // Regenerate session ID on login to prevent session fixation attacks.
+                $this->session->sess_regenerate(true);
                 $this->session->set_userdata($session_data);
 
                 return true;

--- a/application/modules/users/controllers/Users.php
+++ b/application/modules/users/controllers/Users.php
@@ -54,7 +54,11 @@ class Users extends Admin_Controller
         }
 
         if ($this->mdl_users->run_validation(($id) ? 'validation_rules_existing' : 'validation_rules')) {
-            $id = $this->mdl_users->save($id);
+            // Build the db_array, then explicitly add the admin-authorized
+            // privilege field so it isn't silently mass-assigned from POST.
+            $db_array              = $this->mdl_users->db_array();
+            $db_array['user_type'] = (int) $this->input->post('user_type');
+            $id                    = $this->mdl_users->save($id, $db_array);
 
             $this->load->model('custom_fields/mdl_user_custom');
             $this->mdl_user_custom->save_custom($id, $this->input->post('custom'));

--- a/application/modules/users/models/Mdl_users.php
+++ b/application/modules/users/models/Mdl_users.php
@@ -282,11 +282,23 @@ class Mdl_Users extends Response_Model
     }
 
     /**
+     * Fields that must never be written from raw POST data regardless of
+     * validation rules. Controllers that legitimately need to set these
+     * must build and pass their own $db_array to save().
+     */
+    private const PROTECTED_FIELDS = ['user_type', 'user_active', 'user_psalt'];
+
+    /**
      * @return array
      */
     public function db_array()
     {
         $db_array = parent::db_array();
+
+        // Strip privilege-escalation fields from POST-sourced data.
+        foreach (self::PROTECTED_FIELDS as $field) {
+            unset($db_array[$field]);
+        }
 
         if (isset($db_array['user_password'])) {
             unset($db_array['user_passwordv']);

--- a/ipconfig.php.example
+++ b/ipconfig.php.example
@@ -36,6 +36,12 @@ DB_PORT=
 # the default is 10 days.
 SESS_EXPIRATION=864000
 SESS_MATCH_IP=true
+# Database table used to store sessions when SESS_DRIVER=database.
+# Only needed if you override the default table name.
+SESS_TABLE_NAME=ip_sessions
+# Name of the session cookie sent to the browser.
+# Only needed if you need to avoid a collision with another application on the same domain.
+SESS_COOKIE_NAME=ip_session
 
 # Default Global Amounts Calculation mode - Since 1.6.3
 # This change Taxes and discounts calcuation mode


### PR DESCRIPTION
Calls sess_regenerate(true) immediately before writing session data on
every successful authentication, invalidating the pre-login session ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected session and cookie configuration defaults (session table/cookie name now use the intended environment variables).
* **Security Improvements**
  * Upgraded password hashing to bcrypt and verification via `password_verify()`.
  * Added IP-based login rate limiting and improved login failure messaging.
  * Regenerated session IDs on successful login to reduce session fixation risk.
  * Hardened payment-provider dispatch with an allowlist and safer referer handling.
  * Prevented unintended persistence of sensitive user fields (e.g., type/active/credentials).
* **Documentation**
  * Updated `ipconfig.php.example` with session table and cookie name configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->