### PR TITLE
fix(security): escape invoice_number in payment gateway flash messages

### DIFF
--- a/application/modules/guest/controllers/gateways/Paypal.php
+++ b/application/modules/guest/controllers/gateways/Paypal.php
@@ -218,7 +218,7 @@ class Paypal extends Base_Controller
                             'payment_external_id' => $capture_id,
                         ]);
 
-                        $this->session->set_flashdata('alert_success', sprintf(trans('online_payment_payment_successful'), $invoice->invoice_number));
+                        $this->session->set_flashdata('alert_success', sprintf(trans('online_payment_payment_successful'), htmlsc($invoice->invoice_number)));
                         $this->session->keep_flashdata('alert_success');
                     }
                 }

--- a/application/modules/guest/controllers/gateways/Stripe.php
+++ b/application/modules/guest/controllers/gateways/Stripe.php
@@ -166,7 +166,7 @@ class Stripe extends Base_Controller
                                 . ', session ID: ' . $session->id                                   // Unique identifier for the object.
                                 : ($session->cancel ? $session->cancellation_reason : $session->last_payment_error); // Cancelled
             // User (& error) message
-            $user_msg = $paid ? sprintf(trans('online_payment_successful'), '#' . $invoice->invoice_number)
+            $user_msg = $paid ? sprintf(trans('online_payment_successful'), '#' . htmlsc($invoice->invoice_number))
                               : trans('online_payment_failed') . '<br>' . sprintf(trans('online_payment_incomplete'), __CLASS__, $session->payment_status);
         } catch (Error|Exception|ErrorException $e) {
             $user_msg = trans('online_payment_error') . (empty($user_msg) ? '' : '<br>' . $user_msg);


### PR DESCRIPTION
`alerts.php` echoes flashdata raw. Both the Stripe and PayPal callback
controllers interpolated the admin-controlled `invoice_number` field
directly into the success flash message via sprintf() without htmlsc(),
allowing a stored XSS payload to fire in the browser of any client who
completes (or is redirected through) a payment flow.

Apply htmlsc() to $invoice->invoice_number at the sprintf() call site in
both gateways so the HTML in the flash string is safe before it reaches
the unescaped output in alerts.php.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed how invoice numbers are displayed in payment confirmation messages for PayPal and Stripe gateways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->