### PR TITLE
fix(projects): use POST + CSRF for project delete on detail page

### DIFF
--- a/application/modules/projects/views/view.php
+++ b/application/modules/projects/views/view.php
@@ -9,11 +9,14 @@
             <a href="<?php echo site_url('projects/form/' . $project->project_id); ?>" class="btn btn-default">
                 <i class="fa fa-edit"></i> <?php _trans('edit'); ?>
             </a>
-            <a class="btn btn-danger"
-               href="<?php echo site_url('projects/delete/' . $project->project_id); ?>"
-               onclick="return confirm('<?php _trans('delete_record_warning'); ?>');">
-                <i class="fa fa-trash-o"></i> <?php _trans('delete'); ?>
-            </a>
+            <form action="<?php echo site_url('projects/delete/' . $project->project_id); ?>"
+                  method="post" style="display:inline-block;">
+                <?php _csrf_field(); ?>
+                <button type="submit" class="btn btn-danger"
+                        onclick="return confirm('<?php _trans('delete_record_warning'); ?>');">
+                    <i class="fa fa-trash-o"></i> <?php _trans('delete'); ?>
+                </button>
+            </form>
         </div>
     </div>
 </div>


### PR DESCRIPTION
The delete button on the project detail page (`application/modules/projects/views/view.php`) uses a GET `<a>` link. `Base_Controller` rejects any non-POST request whose URL contains "delete" with `show_404()` (the CSRF/prefetch guard), so deleting a project from its detail page returns a 404 instead of deleting it.

This converts the link to a POST form with `_csrf_field()`, matching the delete-hardening already applied elsewhere in the module (`partial_projects_table.php`, the projects list table). The list-table delete and all other deletes were already POST + CSRF; this detail-page link was the remaining GET link.

## Test plan
- Project detail page -> Delete -> confirm: project is deleted and redirects to the list (previously 404).
- Projects list-table delete still works unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the project delete action to use a safer form submission instead of a direct link.
  * Added protection against unauthorized requests and kept the confirmation prompt before deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->