### PR TITLE
fullpage-loader: move loader-error.svg in loader-error-message

### DIFF
--- a/application/modules/layout/views/includes/fullpage-loader.php
+++ b/application/modules/layout/views/includes/fullpage-loader.php
@@ -1,10 +1,10 @@
 <div id="fullpage-loader" style="display: none">
     <div class="loader-content">
         <i id="loader-icon" class="fa fa-cog fa-spin"></i>
-        <img id="loader-error-icon" src="<?php echo base_url('assets/core/img/loader-error.svg'); ?>" 
-             alt="<?php echo html_escape(trans('loading_error')); ?>">
         <div id="loader-error" class="loader-error-message" style="display: none">
             <div class="alert alert-danger">
+                <img id="loader-error-icon" src="<?php echo base_url('assets/core/img/loader-error.svg'); ?>"
+                     alt="<?php echo html_escape(trans('loading_error')); ?>">
                 <strong><i class="fa fa-exclamation-triangle"></i> <?php _trans('loading_error'); ?></strong>
                 <div class="loader-error-actions">
                     <a href="https://wiki.invoiceplane.com/<?php _trans('cldr'); ?>/1.0/general/faq"


### PR DESCRIPTION
# Pull Request Checklist

## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.

---

## Description
Just move new error svg image to error message

---

## Motivation and Context
IMHO this is really where it placed

---

## Issue Type (Check one or more)
- [x] Bugfix (maybe)
- [ ] Improvement of an existing feature
- [ ] New feature

---

## Screenshots

[edit] Before:

<img width="640" height="483" alt="image" src="https://github.com/user-attachments/assets/36515f84-f755-4bcc-a9d6-627b0b13d6b4" />

After (svg appear only on error timeout):

<img width="640" height="483" alt="Screenshot 2026-07-02 at 21-58-59 InvoicePlane-error-new" src="https://github.com/user-attachments/assets/61f4963a-c8fa-4517-9207-2c9015712abc" />

---

*Thank you for your contribution to InvoicePlane! We appreciate your time and effort.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the loader error display so the error message container appears before the error icon, helping the full-page loading error render more consistently.
  * Updated the error icon text handling and markup formatting for better display of loading-related error content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->