### PR TITLE
Fix arbitrary local file read vulnerability (CWE-73/CWE-116)

### DIFF
--- a/application/helpers/mpdf_helper.php
+++ b/application/helpers/mpdf_helper.php
@@ -110,6 +110,7 @@ function pdf_create(
     // mPDF loading
     $mpdf = new \Mpdf\Mpdf([
         'tempDir' => UPLOADS_TEMP_MPDF_FOLDER,
+        'whitelistStreamWrappers' => ['http', 'https'],
     ]);
 
     // mPDF configuration

--- a/application/modules/import/models/Mdl_import.php
+++ b/application/modules/import/models/Mdl_import.php
@@ -134,7 +134,14 @@ class Mdl_Import extends Response_Model
                 $db_array = [];
                 // Loop through each of the values in the row
                 foreach ($headers as $header) {
-                    $db_array[$header] = ($data[array_keys($fileheaders, $header)[0]] != null) ? $data[array_keys($fileheaders, $header)[0]] : '';
+                    $value = ($data[array_keys($fileheaders, $header)[0]] != null) ? $data[array_keys($fileheaders, $header)[0]] : '';
+
+                    // Sanitize CSV client data to prevent injection attacks
+                    if ($file == 'clients.csv') {
+                        $value = strip_tags($this->security->xss_clean($value));
+                    }
+
+                    $db_array[$header] = $value;
                 }
 
                 // Create a couple of default values if file is clients.csv

--- a/application/views/reports/sales_by_year.php
+++ b/application/views/reports/sales_by_year.php
@@ -55,7 +55,7 @@ foreach ($results as $result) {
     ?>
 
         <tr>
-            <td style="border-bottom: none;text-align:center;"><?php echo $result->VAT_ID; ?></td>
+            <td style="border-bottom: none;text-align:center;"><?php _htmlsc($result->VAT_ID); ?></td>
             <td style="border-bottom: none;text-align:center;" rowspan="<?php echo $numRows; ?>"
                 valign="top"><?php _htmlsc($result->Name); ?></td>
             <td style="border-bottom: none;text-align:center;"><?php _trans('annual'); ?></td>


### PR DESCRIPTION
- Escape VAT_ID output in sales_by_year report with _htmlsc() to prevent HTML injection into PDF
- Restrict mPDF stream wrapper whitelist to http/https, removing file:// protocol access
- Sanitize CSV client import data with strip_tags() and xss_clean() to prevent injection at ingress

This prevents the stored XSS vulnerability where an attacker could plant a malicious VAT_ID through CSV import that would read arbitrary server files when the report PDF is generated, exfiltrating the content into a downloadable document.

Defense in depth approach:
- Template output escaping (VAT_ID field)
- Renderer-level protocol restriction (mPDF configuration)
- Input sanitization (CSV import)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF generation security by restricting allowed web-based content sources during rendering.
  * Imported client data is now cleaned more consistently, reducing the risk of unexpected HTML appearing in records.
  * Sales reports now display VAT IDs safely, preventing stray markup from showing in report output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->