### PR TITLE
Fix PayPal and Stripe payment forgery vulnerabilities

### DIFF
--- a/application/modules/guest/controllers/gateways/Paypal.php
+++ b/application/modules/guest/controllers/gateways/Paypal.php
@@ -206,20 +206,34 @@ class Paypal extends Base_Controller
                         $this->session->set_flashdata('alert_info', trans('invoice_already_paid'));
                         $this->session->keep_flashdata('alert_info');
                     } else {
-                        // If the payment status is pending, set a note accordingly.
-                        $payment_note = ($capture_status === 'PENDING') ? trans('online_payment_pending') : '';
+                        // Validate currency and amount before recording payment
+                        $expected_currency = mb_strtoupper((string) get_setting('gateway_paypal_currency'));
+                        $capture_currency  = mb_strtoupper((string) ($capture_data->amount->currency_code ?? ''));
 
-                        $this->mdl_payments->save(null, [
-                            'invoice_id'          => $invoice_id,
-                            'payment_date'        => date('Y-m-d'),
-                            'payment_amount'      => $amount,
-                            'payment_method_id'   => get_setting('gateway_paypal_payment_method'),
-                            'payment_note'        => $payment_note,
-                            'payment_external_id' => $capture_id,
-                        ]);
+                        if ($capture_currency !== $expected_currency) {
+                            log_message('error', __CLASS__ . '::' . __FUNCTION__ . ' - Rejected capture: currency mismatch for invoice ' . sanitize_for_logging($invoice_id) . '. Expected: ' . $expected_currency . ', received: ' . $capture_currency);
+                            $this->session->set_flashdata('alert_error', trans('online_payment_payment_failed'));
+                            $this->session->keep_flashdata('alert_error');
+                        } elseif ((float) $amount + 0.0001 < (float) $invoice->invoice_balance) {
+                            log_message('error', __CLASS__ . '::' . __FUNCTION__ . ' - Rejected capture: amount mismatch for invoice ' . sanitize_for_logging($invoice_id) . '. Expected: ' . sanitize_for_logging($invoice->invoice_balance) . ', received: ' . sanitize_for_logging($amount));
+                            $this->session->set_flashdata('alert_error', trans('online_payment_payment_failed'));
+                            $this->session->keep_flashdata('alert_error');
+                        } else {
+                            // If the payment status is pending, set a note accordingly.
+                            $payment_note = ($capture_status === 'PENDING') ? trans('online_payment_pending') : '';
 
-                        $this->session->set_flashdata('alert_success', sprintf(trans('online_payment_payment_successful'), htmlsc($invoice->invoice_number)));
-                        $this->session->keep_flashdata('alert_success');
+                            $this->mdl_payments->save(null, [
+                                'invoice_id'          => $invoice_id,
+                                'payment_date'        => date('Y-m-d'),
+                                'payment_amount'      => $amount,
+                                'payment_method_id'   => get_setting('gateway_paypal_payment_method'),
+                                'payment_note'        => $payment_note,
+                                'payment_external_id' => $capture_id,
+                            ]);
+
+                            $this->session->set_flashdata('alert_success', sprintf(trans('online_payment_payment_successful'), htmlsc($invoice->invoice_number)));
+                            $this->session->keep_flashdata('alert_success');
+                        }
                     }
                 }
 

--- a/application/modules/guest/controllers/gateways/Stripe.php
+++ b/application/modules/guest/controllers/gateways/Stripe.php
@@ -145,15 +145,30 @@ class Stripe extends Base_Controller
                     $paid     = false; // Mark as not paid to show info message instead of success
                     $user_msg = trans('invoice_already_paid');
                 } else {
-                    // Save the payment (visible in guest user)
-                    $this->mdl_payments->save(null, [
-                        'invoice_id'          => $invoice->invoice_id,
-                        'payment_date'        => date('Y-m-d'),
-                        'payment_amount'      => $session->amount_total / 100,
-                        'payment_method_id'   => get_setting('gateway_stripe_payment_method'),
-                        'payment_note'        => trans('online_payment_intent_id') . ': ' . $payment_intent,
-                        'payment_external_id' => $payment_intent,
-                    ]);
+                    // Validate currency and amount before recording payment
+                    $expected_currency = mb_strtoupper((string) get_setting('gateway_stripe_currency'));
+                    $capture_currency  = mb_strtoupper((string) ($session->currency ?? ''));
+                    $capture_amount    = $session->amount_total / 100;
+
+                    if ($capture_currency !== $expected_currency) {
+                        log_message('error', __CLASS__ . '::' . __FUNCTION__ . ' - Rejected capture: currency mismatch for invoice ' . sanitize_for_logging($invoice_key) . '. Expected: ' . $expected_currency . ', received: ' . $capture_currency);
+                        $paid     = false;
+                        $user_msg = trans('online_payment_payment_failed');
+                    } elseif ((float) $capture_amount + 0.0001 < (float) $invoice->invoice_balance) {
+                        log_message('error', __CLASS__ . '::' . __FUNCTION__ . ' - Rejected capture: amount mismatch for invoice ' . sanitize_for_logging($invoice_key) . '. Expected: ' . sanitize_for_logging($invoice->invoice_balance) . ', received: ' . sanitize_for_logging($capture_amount));
+                        $paid     = false;
+                        $user_msg = trans('online_payment_payment_failed');
+                    } else {
+                        // Save the payment (visible in guest user)
+                        $this->mdl_payments->save(null, [
+                            'invoice_id'          => $invoice->invoice_id,
+                            'payment_date'        => date('Y-m-d'),
+                            'payment_amount'      => $capture_amount,
+                            'payment_method_id'   => get_setting('gateway_stripe_payment_method'),
+                            'payment_note'        => trans('online_payment_intent_id') . ': ' . $payment_intent,
+                            'payment_external_id' => $payment_intent,
+                        ]);
+                    }
                 }
             }
 


### PR DESCRIPTION
Add currency and amount validation before recording payments:
- Validate captured currency matches configured gateway currency
- Validate captured amount is >= invoice balance
- Prevent payment forgery attacks where weak-currency orders (e.g., 100 VND)
  could mark invoices as fully paid

Applies to both PayPal (paypal_capture_payment) and Stripe (callback) handlers.
Logs rejected captures with sanitized details and shows user-friendly error messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment confirmation checks for PayPal and Stripe.
  * Payments are now rejected if the captured currency does not match the invoice currency.
  * Payments are also rejected if the captured amount is less than the invoice balance.
  * Successful payments continue to be recorded only after these validations pass, reducing failed or incorrect payment confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->