### PR TITLE
fix(setup): harden migration SQL runner against semicolons in strings/comments

### DIFF
--- a/application/helpers/sql_helper.php
+++ b/application/helpers/sql_helper.php
@@ -1,0 +1,142 @@
+<?php
+
+defined('BASEPATH') || exit('No direct script access allowed');
+
+if ( ! function_exists('split_sql_statements')) {
+    /**
+     * Split a SQL script into individual statements on the top-level `;`
+     * terminator only.
+     *
+     * A naive explode(';', $sql) breaks whenever a semicolon appears inside a
+     * string literal (e.g. COMMENT 'FK to x; NULL for legacy rows') or a
+     * comment, sending invalid fragments to the database. This walker tracks
+     * string literals ('...', "...", `...`), line comments (-- , #) and block
+     * comments (/* ... *\/) so semicolons inside them are never treated as
+     * statement terminators.
+     *
+     * @return string[] Trimmed statements, in order, with empty ones removed.
+     */
+    function split_sql_statements(string $sql): array
+    {
+        $statements = [];
+        $buffer     = '';
+        $length     = strlen($sql);
+
+        $in_single  = false; // '...'
+        $in_double  = false; // "..."
+        $in_ident   = false; // `...`
+        $in_line    = false; // -- or #  until end of line
+        $in_block   = false; // /* ... */
+
+        for ($i = 0; $i < $length; $i++) {
+            $ch   = $sql[$i];
+            $next = $i + 1 < $length ? $sql[$i + 1] : '';
+
+            if ($in_line) {
+                $buffer .= $ch;
+                if ($ch === "\n") {
+                    $in_line = false;
+                }
+                continue;
+            }
+
+            if ($in_block) {
+                $buffer .= $ch;
+                if ($ch === '*' && $next === '/') {
+                    $buffer .= $next;
+                    $i++;
+                    $in_block = false;
+                }
+                continue;
+            }
+
+            if ($in_single) {
+                $buffer .= $ch;
+                if ($ch === '\\' && $next !== '') {
+                    $buffer .= $next;
+                    $i++;
+                } elseif ($ch === "'" && $next === "'") { // doubled '' escape
+                    $buffer .= $next;
+                    $i++;
+                } elseif ($ch === "'") {
+                    $in_single = false;
+                }
+                continue;
+            }
+
+            if ($in_double) {
+                $buffer .= $ch;
+                if ($ch === '\\' && $next !== '') {
+                    $buffer .= $next;
+                    $i++;
+                } elseif ($ch === '"' && $next === '"') {
+                    $buffer .= $next;
+                    $i++;
+                } elseif ($ch === '"') {
+                    $in_double = false;
+                }
+                continue;
+            }
+
+            if ($in_ident) {
+                $buffer .= $ch;
+                if ($ch === '`') {
+                    $in_ident = false;
+                }
+                continue;
+            }
+
+            // Not inside any string/comment: detect openers and the terminator.
+            $after = $i + 2 < $length ? $sql[$i + 2] : '';
+
+            if ($ch === '-' && $next === '-' && ($after === '' || ctype_space($after))) {
+                $in_line = true;
+                $buffer .= $ch;
+                continue;
+            }
+            if ($ch === '#') {
+                $in_line = true;
+                $buffer .= $ch;
+                continue;
+            }
+            if ($ch === '/' && $next === '*') {
+                $in_block = true;
+                $buffer .= $ch . $next;
+                $i++;
+                continue;
+            }
+            if ($ch === "'") {
+                $in_single = true;
+                $buffer .= $ch;
+                continue;
+            }
+            if ($ch === '"') {
+                $in_double = true;
+                $buffer .= $ch;
+                continue;
+            }
+            if ($ch === '`') {
+                $in_ident = true;
+                $buffer .= $ch;
+                continue;
+            }
+            if ($ch === ';') {
+                $statement = trim($buffer);
+                if ($statement !== '') {
+                    $statements[] = $statement;
+                }
+                $buffer = '';
+                continue;
+            }
+
+            $buffer .= $ch;
+        }
+
+        $tail = trim($buffer);
+        if ($tail !== '') {
+            $statements[] = $tail;
+        }
+
+        return $statements;
+    }
+}

--- a/application/modules/setup/models/Mdl_setup.php
+++ b/application/modules/setup/models/Mdl_setup.php
@@ -370,16 +370,17 @@ class Mdl_Setup extends CI_Model
      */
     private function execute_contents(string|bool $contents)
     {
-        $commands = explode(';', $contents);
+        if ( ! is_string($contents)) {
+            return;
+        }
+
+        $this->load->helper('sql');
+        $commands = split_sql_statements($contents);
 
         foreach ($commands as $command) {
-            if ( ! mb_trim($command)) {
-                continue;
-            }
-
             $this->db->db_debug = IP_DEBUG;
 
-            $this->db->query(mb_trim($command) . ';');
+            $this->db->query($command . ';');
 
             $error = $this->db->error();
             if ($error['code'] !== 0) {


### PR DESCRIPTION
## Problem

`Mdl_Setup::execute_contents()` splits each migration file into statements with:

```php
$commands = explode(';', $contents);
```

That splits on **every** `;`, including semicolons inside a `COMMENT '…'` string
or a SQL comment. When that happens the statement is cut in half and two invalid
fragments are sent to MySQL/MariaDB, aborting the install/upgrade with
`You have an error in your SQL syntax …` messages.

This is a latent bug in `develop` — it trips as soon as any migration contains a
semicolon inside a string literal or comment.

## Fix

- Add `split_sql_statements()` (`application/helpers/sql_helper.php`): a small,
  dependency-free splitter that only breaks on a **top-level** `;`, while
  tracking `'…'`, `"…"` and `` `…` `` literals (incl. `''`/`""` doubling and
  backslash escapes) and `--` / `#` / `/* … */` comments.
- Use it in `execute_contents()` instead of `explode(';', …)`.

Behaviour is unchanged for every existing migration (they contain no semicolons
inside strings/comments); the runner is simply no longer fooled by ones that do.

## Verification

Ran the splitter over all 45 shipped `application/modules/setup/sql/*.sql` files:
every file split into complete statements with balanced string literals (0 broken
fragments). Against a migration that deliberately puts a semicolon in a `COMMENT`
string, `explode(';')` produces truncated fragments while `split_sql_statements()`
returns the correct, whole statements.

A unit test covering the splitter and scanning every migration accompanies this
change on the branches that carry the phpunit harness (develop has no test setup
yet, so it is not included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JAtryuRu4m7xe9xLn6kTr

---
_Generated by [Claude Code](https://claude.ai/code/session_011JAtryuRu4m7xe9xLn6kTr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of SQL script imports, including better support for semicolons inside strings and comments.
* **Bug Fixes**
  * Reduced the risk of SQL statements being split incorrectly during setup.
  * Added safer handling for unexpected non-text input during script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->