### PR TITLE
fix(setup): fail loudly when a migration SQL file cannot be read

### DIFF
--- a/application/modules/setup/models/Mdl_setup.php
+++ b/application/modules/setup/models/Mdl_setup.php
@@ -25,7 +25,7 @@ class Mdl_Setup extends CI_Model
     {
         $file_contents = file_get_contents(APPPATH . 'modules/setup/sql/000_1.0.0.sql');
 
-        $this->execute_contents($file_contents);
+        $this->execute_contents($file_contents, '000_1.0.0.sql');
 
         $this->save_version('000_1.0.0.sql');
 
@@ -90,7 +90,7 @@ class Mdl_Setup extends CI_Model
             }
 
             $file_contents = file_get_contents(APPPATH . 'modules/setup/sql/' . $sql_file);
-            $this->execute_contents($file_contents);
+            $this->execute_contents($file_contents, $sql_file);
             $this->save_version($sql_file);
 
             $upgrade_method = 'upgrade_' . str_replace('.', '_', mb_substr($sql_file, 0, -4));
@@ -368,9 +368,13 @@ class Mdl_Setup extends CI_Model
     /**
      * @param string $contents
      */
-    private function execute_contents(string|bool $contents)
+    private function execute_contents(string|bool $contents, string $source = '')
     {
         if ( ! is_string($contents)) {
+            $this->errors[] = 'Setup aborted: could not read migration SQL'
+                . ($source !== '' ? " '" . $source . "'" : '')
+                . ' (file_get_contents() returned ' . gettype($contents) . ' instead of a string).';
+
             return;
         }
 


### PR DESCRIPTION
## Problem

Follow-up to #1617. That PR added a type guard to `Mdl_Setup::execute_contents()`:

```php
if ( ! is_string($contents)) {
    return;
}
```

But it returns **silently**. `execute_contents()` is fed `file_get_contents()`
results from `install_tables()` and `upgrade_tables()`; when a migration file is
missing or unreadable, `file_get_contents()` returns `false`, and this branch
skips the migration and lets setup continue — reporting success on a partial
install, with no indication anything was skipped.

## Fix

- Record an error (instead of returning silently) when `$contents` is not a
  string. The existing `if ($this->errors) { return false; }` guards in
  `install_tables()` / `upgrade_tables()` then halt the flow and surface the
  failure.
- Pass the source filename from both callers so the message names the exact
  unreadable file, e.g.:
  `Setup aborted: could not read migration SQL '044_1.8.0.sql' (file_get_contents() returned boolean instead of a string).`

Minimal change: one new optional `$source` parameter and the two call sites.

## Verification

Invoked `execute_contents(false, '044_1.8.0.sql')` via reflection: exactly one
error is recorded and it names the file, so `install_tables()`/`upgrade_tables()`
now return `false` instead of silently succeeding. `php -l` clean.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup and upgrade error reporting so failed migration steps now include the relevant file name.
  * Added clearer diagnostics when a migration file cannot be read, making it easier to identify the source of the problem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->