### PR TITLE
Prevent authentication for inactive user accounts

### DIFF
--- a/application/modules/sessions/models/Mdl_sessions.php
+++ b/application/modules/sessions/models/Mdl_sessions.php
@@ -68,6 +68,11 @@ class Mdl_Sessions extends CI_Model
 
             // Modern path: verify against the salted password hash.
             if ($this->crypt->check_password($user->user_password, $password)) {
+                // Verify the account is active before granting authentication.
+                if ((int) $user->user_active !== 1) {
+                    return false;
+                }
+
                 $session_data = [
                     'user_type'     => $user->user_type,
                     'user_id'       => $user->user_id,


### PR DESCRIPTION
# Pull Request Checklist

Please check the following steps before submitting your PR. If any items are incomplete, consider marking it as `[WIP]` (Work in Progress).

## Checklist
- [ ] My code follows the code formatting guidelines.
- [ ] I have tested my changes locally.
- [ ] I selected the appropriate branch for this PR.
- [ ] I have rebased my changes on top of the selected branch.
- [ ] I included relevant documentation updates if necessary.
- [ ] I have an accompanying issue ID for this pull request.

---

## Description

Added a validation check in the `auth()` method of `Mdl_sessions` to verify that a user account is active (`user_active = 1`) before granting authentication. Previously, the method would authenticate users with valid credentials regardless of their active status, allowing deactivated accounts to log in.

The check is performed immediately after password verification and before session data is created, ensuring that only active accounts can establish authenticated sessions.

---

## Related Issue(s)

Fixes # (issue number)

---

## Motivation and Context

User account deactivation should prevent login access. This change ensures that administrators can effectively disable user accounts by setting `user_active` to `0`, and those accounts will be unable to authenticate even with correct credentials.

---

## Issue Type (Check one or more)
- [x] Bugfix
- [ ] Improvement of an existing feature
- [ ] New feature

---

## Screenshots (If Applicable)

N/A

---

*Thank you for your contribution to InvoicePlane! We appreciate your time and effort.*

## Summary by CodeRabbit

* **Bug Fixes**
  * Login now requires the user account to be active before access is granted.
  * Inactive accounts are no longer able to start a session or sign in.