### PR TITLE
Secure logo removal with CSRF protection and POST-only requests

### DIFF
--- a/application/modules/settings/controllers/Settings.php
+++ b/application/modules/settings/controllers/Settings.php
@@ -215,12 +215,16 @@ class Settings extends Admin_Controller
      * Remove a logo file with security validation.
      *
      * Security: Validates that the logo file path is safe and within the uploads directory
-     * to prevent arbitrary file deletion attacks.
+     * to prevent arbitrary file deletion attacks. Requires POST request and valid CSRF token.
      *
      * @param string $type Logo type ('invoice' or 'login')
      */
     public function remove_logo(string $type)
     {
+        if ( ! $this->ensure_valid_post_request('settings')) {
+            return;
+        }
+
         // Security: Validate type parameter against allowed values
         $allowed_types = ['invoice', 'login'];
         if ( ! in_array($type, $allowed_types, true)) {

--- a/application/modules/settings/views/partial_settings_general.php
+++ b/application/modules/settings/views/partial_settings_general.php
@@ -406,15 +406,26 @@
                                     ?>
                                 <br/>
                                 <div class="alert alert-danger">
-                                    <strong><?php _trans('warning'); ?>:</strong> 
-                                    <?php _trans('svg_logo_blocked_security'); ?> 
-                                    <?php echo anchor('settings/remove_logo/login', trans('remove_logo')); ?>
+                                    <strong><?php _trans('warning'); ?>:</strong>
+                                    <?php _trans('svg_logo_blocked_security'); ?>
+                                    <form method="post" action="<?php echo base_url(); ?>settings/remove_logo/login" style="display:inline;">
+                                        <?php _csrf_field(); ?>
+                                        <button type="submit" class="btn btn-link" style="padding:0; border:0; background:none; text-decoration:underline; cursor:pointer;">
+                                            <?php _trans('remove_logo'); ?>
+                                        </button>
+                                    </form>
                                 </div>
                             <?php } else { ?>
                                 <br/>
                                 <img class="personal_logo"
                                     src="<?php echo base_url(); ?>uploads/<?php echo htmlsc($login_logo_file); ?>"><br>
-                                <?php echo anchor('settings/remove_logo/login', trans('remove_logo')); ?><br/>
+                                <form method="post" action="<?php echo base_url(); ?>settings/remove_logo/login" style="display:inline;">
+                                    <?php _csrf_field(); ?>
+                                    <button type="submit" class="btn btn-link" style="padding:0; border:0; background:none; text-decoration:underline; cursor:pointer;">
+                                        <?php _trans('remove_logo'); ?>
+                                    </button>
+                                </form>
+                                <br/>
                             <?php }
                             } ?>
                             <input type="file" name="login_logo" id="login_logo" class="form-control"/>

--- a/application/modules/settings/views/partial_settings_invoices.php
+++ b/application/modules/settings/views/partial_settings_invoices.php
@@ -169,9 +169,14 @@ if (get_setting('invoice_logo')) {
         ?>
                                 <br/>
                                 <div class="alert alert-danger">
-                                    <strong><?php _trans('warning'); ?>:</strong> 
-                                    <?php _trans('svg_logo_blocked_security'); ?> 
-                                    <?php echo anchor('settings/remove_logo/invoice', trans('remove_logo')); ?>
+                                    <strong><?php _trans('warning'); ?>:</strong>
+                                    <?php _trans('svg_logo_blocked_security'); ?>
+                                    <form method="post" action="<?php echo base_url(); ?>settings/remove_logo/invoice" style="display:inline;">
+                                        <?php _csrf_field(); ?>
+                                        <button type="submit" class="btn btn-link" style="padding:0; border:0; background:none; text-decoration:underline; cursor:pointer;">
+                                            <?php _trans('remove_logo'); ?>
+                                        </button>
+                                    </form>
                                 </div>
 <?php
     } else {
@@ -180,7 +185,13 @@ if (get_setting('invoice_logo')) {
                                 <img class="personal_logo"
                                      src="<?php echo base_url(); ?>uploads/<?php echo htmlsc($invoice_logo_file); ?>">
                                 <br>
-                                <?php echo anchor('settings/remove_logo/invoice', trans('remove_logo')); ?><br/>
+                                <form method="post" action="<?php echo base_url(); ?>settings/remove_logo/invoice" style="display:inline;">
+                                    <?php _csrf_field(); ?>
+                                    <button type="submit" class="btn btn-link" style="padding:0; border:0; background:none; text-decoration:underline; cursor:pointer;">
+                                        <?php _trans('remove_logo'); ?>
+                                    </button>
+                                </form>
+                                <br/>
 <?php
     }
 }


### PR DESCRIPTION
# Pull Request Checklist

- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.
- [ ] I included relevant documentation updates if necessary.
- [ ] I have an accompanying issue ID for this pull request.

---

## Description

This PR enhances the security of the logo removal functionality by:

1. **Converting anchor links to POST forms**: Replaced `anchor()` helper calls with explicit `<form method="post">` elements in both the general settings and invoice settings views. This prevents accidental logo deletion via GET requests (e.g., from prefetching, link previews, or CSRF attacks).

2. **Adding CSRF token validation**: All logo removal forms now include `<?php _csrf_field(); ?>` to generate and validate CSRF tokens.

3. **Enforcing POST-only requests**: Updated the `remove_logo()` controller method to call `ensure_valid_post_request('settings')` at the start, rejecting any non-POST requests.

4. **Improved documentation**: Updated the docblock for `remove_logo()` to clarify that CSRF token validation is now required.

These changes follow InvoicePlane's non-negotiable security rule: **every state-changing POST form must include a CSRF token and the controller must validate it**.

---

## Related Issue(s)

N/A

---

## Motivation and Context

Logo removal is a state-changing operation that should not be triggered by GET requests. Using anchor links (`<a href="...">`) creates a security vulnerability where:
- Browser prefetching could accidentally delete logos
- Link previews in chat/email could trigger deletion
- CSRF attacks could exploit the GET endpoint

Converting to POST-only requests with CSRF token validation ensures that logo removal is intentional and authenticated.

---

## Issue Type

- [x] Bugfix
- [x] Improvement of an existing feature
- [ ] New feature

---

## Test Plan

- Verify that clicking "Remove Logo" buttons in both general and invoice settings displays a form submission (not a direct link navigation).
- Confirm that logo removal succeeds when the CSRF token is valid.
- Verify that direct GET requests to `settings/remove_logo/*` are rejected by the controller.
- Existing functionality for logo upload and display remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated logo removal actions to use secure form submissions with CSRF protection.
  * Added server-side validation so logo removal only proceeds on valid POST requests.
  * Improved the settings UI for both general and invoice logos to match the new secure removal flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->