### PR TITLE
Restrict direct access to uploads/import directory

### DIFF
--- a/uploads/import/.htaccess
+++ b/uploads/import/.htaccess
@@ -1,0 +1,1 @@
+Deny from all


### PR DESCRIPTION
# Pull Request Checklist

Please check the following steps before submitting your PR. If any items are incomplete, consider marking it as `[WIP]` (Work in Progress).

## Checklist
- [ ] My code follows the code formatting guidelines.
- [ ] I have tested my changes locally.
- [ ] I selected the appropriate branch for this PR.
- [ ] I have rebased my changes on top of the selected branch.
- [ ] I included relevant documentation updates if necessary.
- [ ] I have an accompanying issue ID for this pull request.

---

## Description
Add `.htaccess` file to the `uploads/import/` directory to deny direct HTTP access to all files in that location. This prevents users from directly browsing or accessing files in the import directory via the web server.

---

## Related Issue(s)
Fixes # (example)

---

## Motivation and Context
The `uploads/import/` directory is intended for temporary file storage during import operations and should not be directly accessible via HTTP requests. By adding a `Deny from all` directive in `.htaccess`, we prevent potential information disclosure and ensure that files in this directory can only be accessed through the application's controlled import logic.

This is a security hardening measure that follows Apache web server best practices for protecting sensitive upload directories.

---

## Issue Type (Check one or more)
- [x] Bugfix
- [x] Improvement of an existing feature

---

## Screenshots (If Applicable)
N/A

---

*Thank you for your contribution to InvoicePlane! We appreciate your time and effort.*

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted public access to the import uploads directory, helping prevent direct browser access to files stored there.