### PR TITLE
docs: add php -l pre-push requirement to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,13 +63,17 @@ These are documented fully in `AGENTS.md` and `.junie/guidelines.md`. Short form
 - Method names: `snake_case`; test methods: `it_<snake_case>` with `#[Test]`.
 - No comments unless the *why* is non-obvious.
 
-## Testing
+## Testing & Code Quality
 
+Before pushing:
 ```bash
-vendor/bin/phpunit          # run all tests
-vendor/bin/pint             # fix code style
-vendor/bin/phpstan analyse  # static analysis
+php -l application/**/*.php   # Syntax check (finds parse errors)
+vendor/bin/phpunit            # run all tests
+vendor/bin/pint               # fix code style
+vendor/bin/phpstan analyse    # static analysis
 ```
+
+**CRITICAL:** `php -l` must be run before any push to prevent parse errors in GitHub Actions. The workflow `.github/workflows/php-lint.yml` will block commits with syntax errors, so catch them locally first. This catches issues like embedded `<?php` tags in comments that confuse the lexer.
 
 Tests live in `tests/`. Use plain `\PHPUnit\Framework\TestCase` — no Laravel `TestCase`.
 


### PR DESCRIPTION
Document the critical requirement to run 'php -l' before pushing to catch
PHP parse errors early, preventing CI failures. Includes guidance on common
issues like embedded <?php tags in comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the testing guidance to include a fuller local quality-check checklist.
  * Added a required PHP syntax check before pushing to help prevent CI failures.
  * Renamed the section to better reflect both testing and code quality steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->