### PR TITLE
Fix stored XSS in mailer views via unescaped client_email (CWE-79)

### DIFF
--- a/application/modules/clients/models/Mdl_clients.php
+++ b/application/modules/clients/models/Mdl_clients.php
@@ -92,6 +92,8 @@ class Mdl_Clients extends Response_Model
             ],
             'client_email' => [
                 'field' => 'client_email',
+                'label' => trans('email_address'),
+                'rules' => 'trim|valid_email',
             ],
             'client_web' => [
                 'field' => 'client_web',

--- a/application/modules/mailer/views/invoice.php
+++ b/application/modules/mailer/views/invoice.php
@@ -76,7 +76,7 @@ if (($invoice->client_einvoicing_version ?? '') != '' && ($invoice->client_einvo
                 <div class="form-group">
                     <label for="to_email"><?php _trans('to_email'); ?></label>
                     <input type="email" multiple name="to_email" id="to_email" class="form-control" required
-                           value="<?php echo $invoice->client_email; ?>">
+                           value="<?php echo htmlsc($invoice->client_email); ?>">
                 </div>
 
                 <hr>

--- a/application/modules/mailer/views/quote.php
+++ b/application/modules/mailer/views/quote.php
@@ -59,7 +59,7 @@
                 <div class="form-group">
                     <label for="to_email"><?php _trans('to_email'); ?></label>
                     <input type="email" multiple name="to_email" id="to_email" class="form-control" required
-                           value="<?php echo $quote->client_email; ?>">
+                           value="<?php echo htmlsc($quote->client_email); ?>">
                 </div>
 
                 <hr>


### PR DESCRIPTION
The invoice and quote mailer pages rendered `client_email` directly
inside a double-quoted HTML attribute without escaping. The global POST
XSS filter strips HTML tags but does not encode attribute-breaking
characters such as `"`, allowing an attacker who can create/edit a
client to break out of the `value` attribute and inject event handlers
(e.g. `" autofocus onfocus="...`) that execute in the victim admin's
authenticated session when the mailer page is opened.

- Escape `client_email` with `htmlsc()` (ENT_QUOTES) in the invoice and
  quote mailer views — the definitive attribute-context fix.
- Add `trim|valid_email` validation on `client_email` in Mdl_Clients as
  defense-in-depth. CI3 skips rules on empty non-required fields, so
  optional emails are preserved.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DTPPyH26S6HdTuqNXHeG5o

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure client email addresses are properly formatted.
  * Improved invoice and quote email forms by safely handling prefilled recipient addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->