### PR TITLE
fix(templates): define the custom template allowlist constants

### DIFF
--- a/index.php
+++ b/index.php
@@ -308,6 +308,12 @@ $_custom_tpl = env('CUSTOM_TEMPLATES_FOLDER');
 define('CUSTOM_TEMPLATES_FOLDER', $_custom_tpl ? rtrim($_custom_tpl, '/\\') . DIRECTORY_SEPARATOR : null);
 unset($_custom_tpl);
 
+// Explicit allowlists of custom template names, consumed by Mdl_Templates
+define('CUSTOM_INVOICE_TEMPLATES_PDF', env('CUSTOM_INVOICE_TEMPLATES_PDF'));
+define('CUSTOM_INVOICE_TEMPLATES_PUBLIC', env('CUSTOM_INVOICE_TEMPLATES_PUBLIC'));
+define('CUSTOM_QUOTE_TEMPLATES_PDF', env('CUSTOM_QUOTE_TEMPLATES_PDF'));
+define('CUSTOM_QUOTE_TEMPLATES_PUBLIC', env('CUSTOM_QUOTE_TEMPLATES_PUBLIC'));
+
 // Ensure storage temp directory exists
 if ( ! is_dir(STORAGE_TEMP_FOLDER)) {
     @mkdir(STORAGE_TEMP_FOLDER, 0755, true);


### PR DESCRIPTION
`Mdl_Templates::_merge_custom()` reads the four `CUSTOM_*_TEMPLATES_*` allowlists with `defined()` / `constant()`, but nothing defines them. `index.php` defines `CUSTOM_TEMPLATES_FOLDER` only. The allowlist is always empty, so no custom template can be selected or rendered.

## Problem

Set `CUSTOM_TEMPLATES_FOLDER` and `CUSTOM_INVOICE_TEMPLATES_PDF` as documented, and the template still does not appear in Settings. Documents whose saved template setting names it render from the built-in `InvoicePlane` template, and the app logs:

```
Template validation failed: Template not in static whitelist: MyTemplate (type: invoice, scope: pdf)
Invalid PDF invoice template from settings: MyTemplate, using default
```

Nothing surfaces in the UI. The request returns 200 with a valid PDF, built from the wrong template. Installs that upgrade to 1.7.2 with a custom template already selected keep issuing documents in the default design.

Containers are affected too. `resources/docker/entrypoint.sh` writes all five keys into `ipconfig.php`, so they reach `$_ENV` and are likewise never defined as constants.

## Fix

Define the four constants from their `ipconfig.php` keys, next to `CUSTOM_TEMPLATES_FOLDER`. `env()` returns `null` when a key is unset, which `_merge_custom()` already treats as empty, so installs without custom templates behave as before.

`_merge_custom()` could read `env()` directly instead, dropping the constants. I kept constants because its docblock names them and `CUSTOM_TEMPLATES_FOLDER` is already one.

## Test plan

- No custom templates configured: unchanged, built-ins only. Null, empty and undefined constants give the same result, with no deprecation under `E_ALL`.
- Configured: the names appear in Settings, and invoice, paid, overdue and quote documents all render from the custom files.
- `../../evil` and `evil.php` are still rejected, so the allowlist's protection is unchanged.
- Run in production on two 1.7.2-rc-1 installs, upgraded from 1.6.3 and 1.7.0. Documents that rendered from the built-in template before the change now render byte-identically to the same documents from before the upgrade.

## Not in this PR

`.github/docs/UPGRADE.md` section 3 says templates in `CUSTOM_TEMPLATES_FOLDER` are "discovered" and that sub-directories there "are ignored". Neither matches the code, which reads names only from config and requires the `invoice_templates/pdf/` layout that `CUSTOM_TEMPLATES.md` documents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable allowlists for custom invoice and quote templates in PDF and public views.
  * Template options can now be controlled separately through environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->