### PR TITLE
Fix SSRF in report PDF date rendering

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -123,7 +123,7 @@ and [@PatrickGTR](https://github.com/PatrickGTR) (quote public-template fix).
 | Guest invoice/quote access keys and CRON authentication key generated with non-cryptographic PRNG | Medium | [Guest invoice/quote access keys and the CRON authentication key are generated with a non-cryptographic PRNG](https://github.com/InvoicePlane/InvoicePlane/security/advisories/GHSA-chqc-v432-8pj8) | [@alham-rizvi](https://github.com/alham-rizvi) | [#1651](https://github.com/InvoicePlane/InvoicePlane/pull/1651) |
 | Password reset token compared with non-constant-time operator | Medium | [Password reset token is compared with a non-constant-time operator instead of hash_equals()](https://github.com/InvoicePlane/InvoicePlane/security/advisories/GHSA-wcqc-qqv5-65ph) | [@alham-rizvi](https://github.com/alham-rizvi) | [#1651](https://github.com/InvoicePlane/InvoicePlane/pull/1651) |
 | Sensitive user fields exposed through email-template placeholders | Medium | — | [@Char0n1507](https://github.com/Char0n1507) | [#1660](https://github.com/InvoicePlane/InvoicePlane/pull/1660) |
-| SSRF via unescaped report PDF date parameters | Medium | — | [@Char0n1507](https://github.com/Char0n1507) | — |
+| SSRF via unescaped report PDF date parameters | Medium | — | [@Char0n1507](https://github.com/Char0n1507) | [#1661](https://github.com/InvoicePlane/InvoicePlane/pull/1661) |
 
 ### Security fixes
 
@@ -161,7 +161,7 @@ and [@PatrickGTR](https://github.com/PatrickGTR) (quote public-template fix).
 - [#1636](https://github.com/InvoicePlane/InvoicePlane/pull/1636) — **CSRF:** add POST + CSRF-token validation to `Recurring::stop()`, previously reachable via a bare GET request.
 - [#1651](https://github.com/InvoicePlane/InvoicePlane/pull/1651) — **Token hardening:** generate guest invoice/quote access keys and the CRON authentication key with a CSPRNG, and compare password-reset tokens with `hash_equals()`.
 - [#1660](https://github.com/InvoicePlane/InvoicePlane/pull/1660) — **Email template data exposure:** `parse_template()` now substitutes only documented invoice, quote, client, user, SUMEX, and custom-field tags; unknown placeholders render empty instead of reflecting arbitrary properties from the selected database row. Invoice and quote queries also select explicit public `ip_users` columns, excluding password hashes, salts, and password-reset tokens. Thanks to [@Char0n1507](https://github.com/Char0n1507) for the responsible disclosure.
-- **SSRF:** report PDFs now pass normalized date labels to their templates and escape those labels before mPDF rendering, preventing injected HTML resources in date fields from triggering server-side HTTP requests. Thanks to [@Char0n1507](https://github.com/Char0n1507) for the responsible disclosure.
+- [#1661](https://github.com/InvoicePlane/InvoicePlane/pull/1661) — **SSRF:** report PDFs now pass normalized date labels to their templates and escape those labels before mPDF rendering, preventing injected HTML resources in date fields from triggering server-side HTTP requests. Thanks to [@Char0n1507](https://github.com/Char0n1507) for the responsible disclosure.
 
 ### Added
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -123,6 +123,7 @@ and [@PatrickGTR](https://github.com/PatrickGTR) (quote public-template fix).
 | Guest invoice/quote access keys and CRON authentication key generated with non-cryptographic PRNG | Medium | [Guest invoice/quote access keys and the CRON authentication key are generated with a non-cryptographic PRNG](https://github.com/InvoicePlane/InvoicePlane/security/advisories/GHSA-chqc-v432-8pj8) | [@alham-rizvi](https://github.com/alham-rizvi) | [#1651](https://github.com/InvoicePlane/InvoicePlane/pull/1651) |
 | Password reset token compared with non-constant-time operator | Medium | [Password reset token is compared with a non-constant-time operator instead of hash_equals()](https://github.com/InvoicePlane/InvoicePlane/security/advisories/GHSA-wcqc-qqv5-65ph) | [@alham-rizvi](https://github.com/alham-rizvi) | [#1651](https://github.com/InvoicePlane/InvoicePlane/pull/1651) |
 | Sensitive user fields exposed through email-template placeholders | Medium | — | [@Char0n1507](https://github.com/Char0n1507) | [#1660](https://github.com/InvoicePlane/InvoicePlane/pull/1660) |
+| SSRF via unescaped report PDF date parameters | Medium | — | [@Char0n1507](https://github.com/Char0n1507) | — |
 
 ### Security fixes
 
@@ -160,6 +161,7 @@ and [@PatrickGTR](https://github.com/PatrickGTR) (quote public-template fix).
 - [#1636](https://github.com/InvoicePlane/InvoicePlane/pull/1636) — **CSRF:** add POST + CSRF-token validation to `Recurring::stop()`, previously reachable via a bare GET request.
 - [#1651](https://github.com/InvoicePlane/InvoicePlane/pull/1651) — **Token hardening:** generate guest invoice/quote access keys and the CRON authentication key with a CSPRNG, and compare password-reset tokens with `hash_equals()`.
 - [#1660](https://github.com/InvoicePlane/InvoicePlane/pull/1660) — **Email template data exposure:** `parse_template()` now substitutes only documented invoice, quote, client, user, SUMEX, and custom-field tags; unknown placeholders render empty instead of reflecting arbitrary properties from the selected database row. Invoice and quote queries also select explicit public `ip_users` columns, excluding password hashes, salts, and password-reset tokens. Thanks to [@Char0n1507](https://github.com/Char0n1507) for the responsible disclosure.
+- **SSRF:** report PDFs now pass normalized date labels to their templates and escape those labels before mPDF rendering, preventing injected HTML resources in date fields from triggering server-side HTTP requests. Thanks to [@Char0n1507](https://github.com/Char0n1507) for the responsible disclosure.
 
 ### Added
 

--- a/application/modules/reports/controllers/Reports.php
+++ b/application/modules/reports/controllers/Reports.php
@@ -29,10 +29,15 @@ class Reports extends Admin_Controller
     public function sales_by_client()
     {
         if ($this->input->post('btn_submit')) {
+            $posted_from_date = $this->input->post('from_date');
+            $posted_to_date   = $this->input->post('to_date');
+            $from_date        = date_to_mysql($posted_from_date);
+            $to_date          = date_to_mysql($posted_to_date);
+
             $data = [
-                'results'   => $this->mdl_reports->sales_by_client($this->input->post('from_date'), $this->input->post('to_date')),
-                'from_date' => $this->input->post('from_date'),
-                'to_date'   => $this->input->post('to_date'),
+                'results'   => $this->mdl_reports->sales_by_client($posted_from_date, $posted_to_date),
+                'from_date' => date_from_mysql($from_date, true),
+                'to_date'   => date_from_mysql($to_date, true),
             ];
 
             $html = $this->load->view('reports/sales_by_client', $data, true);
@@ -48,10 +53,15 @@ class Reports extends Admin_Controller
     public function invoices_per_client()
     {
         if ($this->input->post('btn_submit')) {
+            $posted_from_date = $this->input->post('from_date');
+            $posted_to_date   = $this->input->post('to_date');
+            $from_date        = date_to_mysql($posted_from_date);
+            $to_date          = date_to_mysql($posted_to_date);
+
             $data = [
-                'results'   => $this->mdl_reports->invoices_per_client($this->input->post('from_date'), $this->input->post('to_date')),
-                'from_date' => $this->input->post('from_date'),
-                'to_date'   => $this->input->post('to_date'),
+                'results'   => $this->mdl_reports->invoices_per_client($posted_from_date, $posted_to_date),
+                'from_date' => date_from_mysql($from_date, true),
+                'to_date'   => date_from_mysql($to_date, true),
             ];
 
             $html = $this->load->view('reports/invoices_per_client', $data, true);
@@ -67,10 +77,15 @@ class Reports extends Admin_Controller
     public function payment_history()
     {
         if ($this->input->post('btn_submit')) {
+            $posted_from_date = $this->input->post('from_date');
+            $posted_to_date   = $this->input->post('to_date');
+            $from_date        = date_to_mysql($posted_from_date);
+            $to_date          = date_to_mysql($posted_to_date);
+
             $data = [
-                'results'   => $this->mdl_reports->payment_history($this->input->post('from_date'), $this->input->post('to_date')),
-                'from_date' => $this->input->post('from_date'),
-                'to_date'   => $this->input->post('to_date'),
+                'results'   => $this->mdl_reports->payment_history($posted_from_date, $posted_to_date),
+                'from_date' => date_from_mysql($from_date, true),
+                'to_date'   => date_from_mysql($to_date, true),
             ];
 
             $html = $this->load->view('reports/payment_history', $data, true);
@@ -103,10 +118,15 @@ class Reports extends Admin_Controller
     public function sales_by_year()
     {
         if ($this->input->post('btn_submit')) {
+            $posted_from_date = $this->input->post('from_date');
+            $posted_to_date   = $this->input->post('to_date');
+            $from_date        = date_to_mysql($posted_from_date);
+            $to_date          = date_to_mysql($posted_to_date);
+
             $data = [
-                'results'   => $this->mdl_reports->sales_by_year($this->input->post('from_date'), $this->input->post('to_date'), $this->input->post('minQuantity'), $this->input->post('maxQuantity'), $this->input->post('checkboxTax')),
-                'from_date' => $this->input->post('from_date'),
-                'to_date'   => $this->input->post('to_date'),
+                'results'   => $this->mdl_reports->sales_by_year($posted_from_date, $posted_to_date, $this->input->post('minQuantity'), $this->input->post('maxQuantity'), $this->input->post('checkboxTax')),
+                'from_date' => date_from_mysql($from_date, true),
+                'to_date'   => date_from_mysql($to_date, true),
             ];
 
             $html = $this->load->view('reports/sales_by_year', $data, true);

--- a/application/views/reports/invoices_per_client.php
+++ b/application/views/reports/invoices_per_client.php
@@ -6,7 +6,7 @@
 </head>
 <body>
 
-    <h3 class="report_title"><?php _trans('invoices_per_client'); ?><br><small><?php echo $from_date . ' - ' . $to_date ?></small></h3>
+    <h3 class="report_title"><?php _trans('invoices_per_client'); ?><br><small><?php echo htmlsc($from_date) . ' - ' . htmlsc($to_date); ?></small></h3>
 
     <table>
 <?php

--- a/application/views/reports/payment_history.php
+++ b/application/views/reports/payment_history.php
@@ -6,7 +6,7 @@
 </head>
 <body>
 
-    <h3 class="report_title"><?php _trans('payment_history'); ?><br><small><?php echo $from_date . ' - ' . $to_date ?></small></h3>
+    <h3 class="report_title"><?php _trans('payment_history'); ?><br><small><?php echo htmlsc($from_date) . ' - ' . htmlsc($to_date); ?></small></h3>
 
     <table>
         <tr>

--- a/application/views/reports/sales_by_client.php
+++ b/application/views/reports/sales_by_client.php
@@ -6,7 +6,7 @@
 </head>
 <body>
 
-    <h3 class="report_title"><?php _trans('sales_by_client'); ?><br><small><?php echo $from_date . ' - ' . $to_date ?></small></h3>
+    <h3 class="report_title"><?php _trans('sales_by_client'); ?><br><small><?php echo htmlsc($from_date) . ' - ' . htmlsc($to_date); ?></small></h3>
 
     <table>
         <tr>

--- a/application/views/reports/sales_by_year.php
+++ b/application/views/reports/sales_by_year.php
@@ -6,7 +6,7 @@
 </head>
 
 <body>
-    <h3 class="report_title"><?php _trans('sales_by_date'); ?><br><small><?php echo $from_date . ' - ' . $to_date ?></small></h3>
+    <h3 class="report_title"><?php _trans('sales_by_date'); ?><br><small><?php echo htmlsc($from_date) . ' - ' . htmlsc($to_date); ?></small></h3>
 
     <table>
 


### PR DESCRIPTION
## Summary
- normalize report date labels before passing them into PDF views
- escape report date labels in all affected report PDF templates
- credit @Char0n1507 in the changelog for the responsible disclosure

## Verification
- php -l application/modules/reports/controllers/Reports.php
- php -l application/views/reports/sales_by_client.php
- php -l application/views/reports/payment_history.php
- php -l application/views/reports/invoices_per_client.php
- php -l application/views/reports/sales_by_year.php
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security when generating and displaying reports with date ranges.
  - Date values are now consistently formatted for report processing and presentation.
  - Report titles and payment history date ranges are safely escaped before display.
  - Added security documentation covering the report date-range issue and its remediation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->