### PR TITLE
Fix @param tags that do not match the signatures

### DIFF
--- a/application/helpers/e-invoice_helper.php
+++ b/application/helpers/e-invoice_helper.php
@@ -133,7 +133,7 @@ function get_xml_template_files(): array
  * Set the calculation mode for Quote/Invoice view & many more (tricks)
  * Returns the XML template (UBL/CII) fullname of a given client_e-invoice_version value.
  *
- * @param $xml_Id
+ * @param $xml_id
  *
  * @used in get_einvoice_usage
  *
@@ -182,7 +182,6 @@ function get_admin_active_users($user_id = ''): array
  *
  * @param object $client
  * @param int    $user_id : get result only with it (or all if null)
- * @param bool   $vat     : check vat user field(s) are filled
  *
  * @return object $req_fields
  */

--- a/application/helpers/template_helper.php
+++ b/application/helpers/template_helper.php
@@ -57,7 +57,6 @@ function render_template_view(string $template_subpath, array $data, bool $retur
  *
  * @param $object
  * @param $body
- * @param $model_id
  *
  * @return mixed
  */
@@ -208,7 +207,7 @@ function parse_template($object, $body)
 /**
  * Returns the translated invoice status.
  *
- * @param $invoice->invoice_status_id
+ * @param $id
  *
  * @return string
  */

--- a/application/modules/custom_fields/models/Mdl_custom_fields.php
+++ b/application/modules/custom_fields/models/Mdl_custom_fields.php
@@ -327,7 +327,7 @@ class Mdl_Custom_Fields extends MY_Model
     /**
      * @param int    $field_id
      * @param string $custom_field_model
-     * @param int    $model_id
+     * @param object $object
      *
      * @return string
      */

--- a/application/modules/sessions/controllers/Sessions.php
+++ b/application/modules/sessions/controllers/Sessions.php
@@ -427,9 +427,6 @@ class Sessions extends Base_Controller
     /**
      * Check if IP address has exceeded rate limit for password resets.
      *
-     * @param int $max_attempts   Maximum attempts allowed per hour
-     * @param int $window_minutes Time window in minutes
-     *
      * @return bool True if rate limited, false otherwise
      */
     private function _is_ip_rate_limited_password_reset()
@@ -465,9 +462,7 @@ class Sessions extends Base_Controller
     /**
      * Check if email-based rate limit exceeded for password resets.
      *
-     * @param string $email        Email address to check
-     * @param int    $max_attempts Maximum attempts allowed
-     * @param int    $window_hours Time window in hours
+     * @param string $email Email address to check
      *
      * @return bool True if rate limited, false otherwise
      */


### PR DESCRIPTION
### The problem

Seven functions carry `@param` tags for parameters they do not take, so editor
tooltips and static analysis describe a signature that does not exist.

| Where | Documented | Actual |
|---|---|---|
| `application/modules/sessions/controllers/Sessions.php:427` | `$max_attempts`, `$window_minutes` | `_is_ip_rate_limited_password_reset()` takes nothing; both are locals read from `env()` in the body |
| `application/modules/sessions/controllers/Sessions.php:465` | `$max_attempts`, `$window_hours` | `_is_email_rate_limited_password_reset($email)` takes only `$email`; both are locals read from `env()` |
| `application/helpers/template_helper.php:55` | `$model_id` | `parse_template($object, $body)` — not a parameter, and not used in the body |
| `application/helpers/template_helper.php:208` | `$invoice->invoice_status_id` | `get_invoice_status($id)` — the tag holds a property access rather than the parameter name |
| `application/helpers/e-invoice_helper.php:132` | `$xml_Id` | `get_xml_full_name(string $xml_id)` — differs in case |
| `application/helpers/e-invoice_helper.php:180` | `$vat` | `get_req_fields_einvoice($client, $user_id)` — no such parameter |
| `application/modules/custom_fields/models/Mdl_custom_fields.php:327` | `int $model_id` | `get_value_for_field($field_id, $custom_field_model, $object)` — the third parameter is `$object`, and the body uses it as one: `$object->{$cf_model_name . '_id'}` |

The two rate-limit helpers look like the clearest case: they used to take the
limits as arguments and now read them from `env()`, and the tags stayed behind.

### The change

Dropped the tags for parameters that do not exist, and corrected the names where
the parameter was renamed. For `get_value_for_field` the type went to `object`
too, since the body dereferences it.

Comments only. No signature, call site, or behaviour is touched.

### Checked

Every one of these was opened in the file and read against the signature and the
body before changing it — including the neighbouring `@param` blocks in the same
files, which are correct and were left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected and clarified developer documentation for e-invoice, template, custom field, and session-related methods.
  * Removed outdated parameter references and aligned annotations with current method inputs.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->