### PR TITLE
Fix Upload::delete_file() failing on already-deleted files

### DIFF
--- a/application/modules/upload/controllers/Upload.php
+++ b/application/modules/upload/controllers/Upload.php
@@ -103,7 +103,16 @@ class Upload extends Admin_Controller
 
         $finalPath = $this->targetPath . $url_key . '_' . $filename;
 
-        if (validate_file_in_directory($finalPath, $this->targetPath) && ( ! file_exists($finalPath) || @unlink($finalPath))) {
+        // Security: realpath() (used by validate_file_in_directory()) returns false for a
+        // nonexistent path, so an already-deleted file must be handled before that check -
+        // $filename was already rejected above by sanitize_file_name() if it contained any
+        // path separator or traversal sequence, so $finalPath cannot escape $this->targetPath.
+        if ( ! file_exists($finalPath)) {
+            $this->mdl_uploads->delete_file($url_key, $filename);
+            respond_file_message(200, 'upload_file_deleted_successfully', $filename);
+        }
+
+        if (validate_file_in_directory($finalPath, $this->targetPath) && @unlink($finalPath)) {
             $this->mdl_uploads->delete_file($url_key, $filename);
             respond_file_message(200, 'upload_file_deleted_successfully', $filename);
         }


### PR DESCRIPTION
## Summary
- `Upload::delete_file()` validated the target path with `validate_file_in_directory()`, which resolves paths via `realpath()`; `realpath()` returns `false` for a file that no longer exists, so deleting an already-removed file (stale DB metadata, retry, race condition) always fell through to the generic "delete failed" response instead of clearing the record.
- The nonexistent-file case is now handled first and treated as a successful delete (metadata cleared), before the path-containment check runs against files that do exist. `$filename` is still rejected earlier in the method by `sanitize_file_name()` if it contains any path separator or traversal sequence, so `$finalPath` can't escape `$this->targetPath` either way.

Found during a follow-up review pass on #1664 (already merged) — this is a separate, small correctness fix, not part of that PR.

## Test plan
- [x] `php -l application/modules/upload/controllers/Upload.php`
- [x] `vendor/bin/pint --test application/modules/upload/controllers/Upload.php`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting files that are already missing now completes successfully.
  * Associated file metadata is removed even when the physical file is no longer present.
  * Existing files continue to be validated and deleted normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->