### PR TITLE
Enforce password-reset token expiry on POST and ship the expiry column migration

### DIFF
--- a/.github/improvements.md
+++ b/.github/improvements.md
@@ -882,7 +882,7 @@ through another vector, an attacker could use it at any time to take over the ac
 ### What Was Improved
 
 A `user_passwordreset_token_expiry DATETIME` column was added to `ip_users` (migration
-`044_1.7.3.sql`). Tokens now expire after a configurable duration (default: 15 minutes).
+`043_1.7.2.sql`). Tokens now expire after a configurable duration (default: 15 minutes).
 
 ```php
 // Token validation now checks expiry

--- a/application/modules/sessions/controllers/Sessions.php
+++ b/application/modules/sessions/controllers/Sessions.php
@@ -129,36 +129,8 @@ class Sessions extends Base_Controller
                 redirect('sessions/passwordreset');
             }
 
-            // Check if token has expired
-            if ( ! empty($user->user_passwordreset_token_expiry)) {
-                try {
-                    // Initialize UTC timezone if not already done
-                    if ( ! isset(self::$utc_timezone)) {
-                        self::$utc_timezone = new DateTimeZone('UTC');
-                    }
-
-                    // Use UTC timezone for consistent timestamp comparison
-                    $expiry_time  = new DateTime($user->user_passwordreset_token_expiry, self::$utc_timezone);
-                    $current_time = new DateTime('now', self::$utc_timezone);
-
-                    if ($current_time > $expiry_time) {
-                        // Token has expired, clear it from database
-                        $this->_clear_password_reset_token($user->user_id);
-
-                        $this->load->helper('file_security');
-                        log_message('info', 'Expired password reset token used for user ID: ' . sanitize_for_logging($user->user_id));
-                        $this->session->set_flashdata('alert_error', trans('password_reset_token_expired'));
-                        redirect('sessions/passwordreset');
-                    }
-                } catch (Exception $e) {
-                    // Invalid datetime format in database, clear the token for safety
-                    $this->load->helper('file_security');
-                    log_message('error', 'Invalid password reset token expiry format for user ID: ' . sanitize_for_logging($user->user_id));
-                    $this->_clear_password_reset_token($user->user_id);
-                    $this->session->set_flashdata('alert_error', trans('wrong_passwordreset_token'));
-                    redirect('sessions/passwordreset');
-                }
-            }
+            // Reject (and clear) the token if it has expired
+            $this->_reject_expired_password_reset_token($user);
 
             //if token is valid, delete the failure attempt from
             //the login_log table
@@ -196,6 +168,10 @@ class Sessions extends Base_Controller
                 $this->session->set_flashdata('alert_error', trans('loginalert_wrong_auth_code'));
                 redirect($this->_get_safe_referer());
             }
+
+            // Enforce token expiry on the password-change POST as well, otherwise an expired
+            // token that is still stored on the user row could be used to change the password.
+            $this->_reject_expired_password_reset_token($user);
 
             // Call the save_change_password() function from users model
             $this->mdl_users->save_change_password(
@@ -612,6 +588,51 @@ class Sessions extends Base_Controller
     private function _login_log_reset($username)
     {
         $this->db->delete('ip_login_log', ['login_name' => $username]);
+    }
+
+    /**
+     * Rejects an expired (or malformed) password reset token.
+     *
+     * Shared by the token-link (GET) and password-change (POST) flows so both enforce the
+     * same lifetime. When the token has expired or its stored expiry cannot be parsed, the
+     * token is cleared and the request is redirected back to the reset page. When the token
+     * is still valid this returns and execution continues.
+     *
+     * @param object $user The user row (must expose user_id and user_passwordreset_token_expiry)
+     */
+    private function _reject_expired_password_reset_token($user): void
+    {
+        if (empty($user->user_passwordreset_token_expiry)) {
+            return;
+        }
+
+        try {
+            // Initialize UTC timezone if not already done
+            if ( ! isset(self::$utc_timezone)) {
+                self::$utc_timezone = new DateTimeZone('UTC');
+            }
+
+            // Use UTC timezone for consistent timestamp comparison
+            $expiry_time  = new DateTime($user->user_passwordreset_token_expiry, self::$utc_timezone);
+            $current_time = new DateTime('now', self::$utc_timezone);
+
+            if ($current_time > $expiry_time) {
+                // Token has expired, clear it from database
+                $this->_clear_password_reset_token($user->user_id);
+
+                $this->load->helper('file_security');
+                log_message('info', 'Expired password reset token used for user ID: ' . sanitize_for_logging($user->user_id));
+                $this->session->set_flashdata('alert_error', trans('password_reset_token_expired'));
+                redirect('sessions/passwordreset');
+            }
+        } catch (Exception $e) {
+            // Invalid datetime format in database, clear the token for safety
+            $this->load->helper('file_security');
+            log_message('error', 'Invalid password reset token expiry format for user ID: ' . sanitize_for_logging($user->user_id));
+            $this->_clear_password_reset_token($user->user_id);
+            $this->session->set_flashdata('alert_error', trans('wrong_passwordreset_token'));
+            redirect('sessions/passwordreset');
+        }
     }
 
     /**

--- a/application/modules/setup/sql/043_1.7.2.sql
+++ b/application/modules/setup/sql/043_1.7.2.sql
@@ -11,3 +11,8 @@ MODIFY `client_birthdate` DATE NULL DEFAULT NULL;
 -- the application ENCRYPTION_KEY. Existing plaintext values remain readable
 -- (the application falls back to returning them as-is on decrypt failure) and
 -- are transparently re-encrypted the next time each record is saved.
+
+-- Add the password reset token expiry column used to enforce reset-token lifetime.
+ALTER TABLE `ip_users`
+ADD COLUMN `user_passwordreset_token_expiry` DATETIME NULL DEFAULT NULL
+AFTER `user_passwordreset_token`;

--- a/ipconfig.php.example
+++ b/ipconfig.php.example
@@ -86,7 +86,7 @@ PASSWORD_RESET_EMAIL_MAX_ATTEMPTS=3
 # Time window in hours for email-based rate limiting
 PASSWORD_RESET_EMAIL_WINDOW_HOURS=1
 
-# Password reset token expiration (since v1.7.3)
+# Password reset token expiration (since v1.7.2)
 # Time in minutes before a password reset token expires (default: 15 minutes)
 # This prevents indefinite token validity and reduces account takeover risk
 PASSWORD_RESET_TOKEN_EXPIRY_MINUTES=15


### PR DESCRIPTION
The 1.7.2 password-reset token-expiry fix only checked
user_passwordreset_token_expiry when the reset link was opened (GET). The
password-change POST (btn_new_password) validated only that the submitted token
matched the stored token, so an expired-but-still-stored token could be used to
change the password. It also shipped no migration for the
user_passwordreset_token_expiry column the controller reads and writes, so on
the stock release schema the expiry could not be enforced and token issuance /
clearing failed against the missing column.

- Extract the GET-side expiry/parse check into
  _reject_expired_password_reset_token() and call it from both the token-link
  (GET) and password-change (POST) flows so both enforce the same lifetime.
- Add the user_passwordreset_token_expiry column to the 043_1.7.2.sql migration
  (one migration per version), so fresh installs and 1.7.1 -> 1.7.2 upgrades
  create it.
- Point the docs at the 1.7.2 migration (improvements.md, ipconfig.php.example).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password-reset token expiration tracking.
  * Expired, missing, or invalid reset tokens are rejected when opening reset links or submitting new passwords.
  * Invalid tokens are cleared and users receive an appropriate error message.

* **Documentation**
  * Updated migration and configuration references to version 1.7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->