### PR TITLE
Use strict expiry parsing before comparing password-reset token timestamps

### DIFF
--- a/application/modules/sessions/controllers/Sessions.php
+++ b/application/modules/sessions/controllers/Sessions.php
@@ -124,8 +124,10 @@ class Sessions extends Base_Controller
             $user = $user->row();
 
             if (empty($user)) {
-                // Redirect back to the login screen with an alert
-                $this->session->set_flashdata('alert_error', trans('wrong_passwordreset_token'));
+                // Unknown token: show the same generic "expired, request a new one" message as
+                // the expiry paths so the response never reveals whether the token matched a
+                // user, was malformed, or had expired.
+                $this->session->set_flashdata('alert_error', trans('password_reset_token_expired'));
                 redirect('sessions/passwordreset');
             }
 

--- a/application/modules/sessions/controllers/Sessions.php
+++ b/application/modules/sessions/controllers/Sessions.php
@@ -618,17 +618,17 @@ class Sessions extends Base_Controller
             }
 
             // Use UTC timezone for consistent timestamp comparison. Parse strictly:
-            // new DateTime() accepts out-of-range values such as "25:99:99" and would let a
-            // malformed-but-"non-expired" token continue, so parse the exact format and reject
-            // any parser warning or error before the elapsed-time check.
-            $expiry_time = DateTime::createFromFormat(
-                '!Y-m-d H:i:s',
-                (string) $user->user_passwordreset_token_expiry,
-                self::$utc_timezone
-            );
+            // new DateTime() accepts out-of-range values such as "25:99:99", and
+            // createFromFormat() silently normalizes non-canonical strings such as
+            // "2026-8-10 9:05:07" (single-digit fields) without a warning. The stored expiry is
+            // always written canonically as Y-m-d H:i:s, so require that exact anchored shape,
+            // then reject any parser warning or error before the elapsed-time check.
+            $raw_expiry   = (string) $user->user_passwordreset_token_expiry;
+            $expiry_time  = DateTime::createFromFormat('!Y-m-d H:i:s', $raw_expiry, self::$utc_timezone);
             $parse_errors = DateTime::getLastErrors();
             if (
-                $expiry_time === false
+                ! preg_match('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $raw_expiry)
+                || $expiry_time === false
                 || ($parse_errors !== false
                     && ($parse_errors['warning_count'] > 0 || $parse_errors['error_count'] > 0))
             ) {

--- a/application/modules/sessions/controllers/Sessions.php
+++ b/application/modules/sessions/controllers/Sessions.php
@@ -612,8 +612,23 @@ class Sessions extends Base_Controller
                 self::$utc_timezone = new DateTimeZone('UTC');
             }
 
-            // Use UTC timezone for consistent timestamp comparison
-            $expiry_time  = new DateTime($user->user_passwordreset_token_expiry, self::$utc_timezone);
+            // Use UTC timezone for consistent timestamp comparison. Parse strictly:
+            // new DateTime() accepts out-of-range values such as "25:99:99" and would let a
+            // malformed-but-"non-expired" token continue, so parse the exact format and reject
+            // any parser warning or error before the elapsed-time check.
+            $expiry_time = DateTime::createFromFormat(
+                '!Y-m-d H:i:s',
+                (string) $user->user_passwordreset_token_expiry,
+                self::$utc_timezone
+            );
+            $parse_errors = DateTime::getLastErrors();
+            if (
+                $expiry_time === false
+                || ($parse_errors !== false
+                    && ($parse_errors['warning_count'] > 0 || $parse_errors['error_count'] > 0))
+            ) {
+                throw new Exception('Invalid password reset token expiry');
+            }
             $current_time = new DateTime('now', self::$utc_timezone);
 
             if ($current_time > $expiry_time) {

--- a/application/modules/sessions/controllers/Sessions.php
+++ b/application/modules/sessions/controllers/Sessions.php
@@ -641,11 +641,14 @@ class Sessions extends Base_Controller
                 redirect('sessions/passwordreset');
             }
         } catch (Exception $e) {
-            // Invalid datetime format in database, clear the token for safety
+            // Invalid or malformed expiry: clear the token for safety. Log the specifics
+            // server-side, but show the user the same generic "expired, request a new one"
+            // message as the normal expiry path so the response never reveals which internal
+            // check failed (malformed vs. expired vs. unknown token).
             $this->load->helper('file_security');
             log_message('error', 'Invalid password reset token expiry format for user ID: ' . sanitize_for_logging($user->user_id));
             $this->_clear_password_reset_token($user->user_id);
-            $this->session->set_flashdata('alert_error', trans('wrong_passwordreset_token'));
+            $this->session->set_flashdata('alert_error', trans('password_reset_token_expired'));
             redirect('sessions/passwordreset');
         }
     }

--- a/application/modules/sessions/controllers/Sessions.php
+++ b/application/modules/sessions/controllers/Sessions.php
@@ -103,6 +103,11 @@ class Sessions extends Base_Controller
      */
     public function passwordreset($token = null)
     {
+        // Shared, XSS/open-redirect-safe referer + CSRF helpers (not autoloaded).
+        if ( ! function_exists('get_safe_referer')) {
+            $this->load->helper('security');
+        }
+
         // Check if a token was provided
         if ($token) {
             if (preg_match("/[^[:alnum:]\-_]/", $token)) {
@@ -113,7 +118,7 @@ class Sessions extends Base_Controller
             //prevent brute force attacks by counting times a token is used
             $login_log_check = $this->_login_log_check($token);
             if ( ! empty($login_log_check) && $login_log_check->log_count > 10) {
-                redirect($this->_get_safe_referer());
+                redirect(get_safe_referer('', 'sessions/passwordreset'));
             } else {
                 //the use of a token counts as a failure
                 $this->_login_log_addfailure($token);
@@ -148,12 +153,20 @@ class Sessions extends Base_Controller
 
         // Check if the form for a new password was used
         if ($this->input->post('btn_new_password')) {
+            // Validate the CSRF token before any state change. The new-password form emits
+            // _csrf_field(); this mirrors Admin_Controller::ensure_valid_post_request(), which
+            // Sessions (a Base_Controller, not an Admin_Controller) cannot call.
+            if ( ! verify_csrf_token()) {
+                $this->session->set_flashdata('alert_error', trans('invalid_request'));
+                redirect(get_safe_referer('', 'sessions/passwordreset'));
+            }
+
             $new_password = $this->input->post('new_password', true);
             $user_id      = $this->input->post('user_id', true);
 
             if (empty($user_id) || empty($new_password)) {
                 $this->session->set_flashdata('alert_error', trans('loginalert_no_password'));
-                redirect($this->_get_safe_referer());
+                redirect(get_safe_referer('', 'sessions/passwordreset'));
             }
 
             $this->load->model('users/mdl_users');
@@ -166,12 +179,12 @@ class Sessions extends Base_Controller
             // return the same generic reset message used by the token-link flow.
             if (empty($user)) {
                 $this->session->set_flashdata('alert_error', trans('password_reset_token_expired'));
-                redirect($this->_get_safe_referer());
+                redirect(get_safe_referer('', 'sessions/passwordreset'));
             }
 
             if (empty($user->user_passwordreset_token) || ! hash_equals((string) $user->user_passwordreset_token, (string) $this->input->post('token'))) {
                 $this->session->set_flashdata('alert_error', trans('password_reset_token_expired'));
-                redirect($this->_get_safe_referer());
+                redirect(get_safe_referer('', 'sessions/passwordreset'));
             }
 
             // Enforce token expiry on the password-change POST as well, otherwise an expired
@@ -674,43 +687,5 @@ class Sessions extends Base_Controller
             'user_passwordreset_token'        => '',
             'user_passwordreset_token_expiry' => null,
         ]);
-    }
-
-    /**
-     * Validates that a referer URL is from the same domain
-     * to prevent open redirect vulnerabilities.
-     *
-     * @param string $referer
-     *
-     * @return string Safe redirect URL
-     */
-    private function _get_safe_referer($referer = '')
-    {
-        $default = 'sessions/passwordreset';
-
-        $referer = empty($referer) ? ($_SERVER['HTTP_REFERER'] ?? '') : $referer;
-
-        if (empty($referer)) {
-            return $default;
-        }
-
-        $base_url = base_url();
-
-        // If base_url is not configured, str_starts_with($referer, '') is always true
-        // and any external URL would pass. Reject to be safe.
-        if (empty($base_url)) {
-            return $default;
-        }
-
-        // Compare parsed hosts rather than string prefixes to resist
-        // bypass attempts such as https://example.com.evil.com/...
-        $referer_host = parse_url($referer, PHP_URL_HOST);
-        $base_host    = parse_url($base_url, PHP_URL_HOST);
-
-        if ( ! $referer_host || ! $base_host || $referer_host !== $base_host) {
-            return $default;
-        }
-
-        return $referer;
     }
 }

--- a/application/modules/sessions/controllers/Sessions.php
+++ b/application/modules/sessions/controllers/Sessions.php
@@ -161,13 +161,16 @@ class Sessions extends Base_Controller
             // Check for the reset token
             $user = $this->mdl_users->get_by_id($user_id);
 
+            // Unknown user_id and a wrong token must be indistinguishable, otherwise the
+            // differing messages let an attacker enumerate valid user_ids on this POST. Both
+            // return the same generic reset message used by the token-link flow.
             if (empty($user)) {
-                $this->session->set_flashdata('alert_error', trans('loginalert_user_not_found'));
+                $this->session->set_flashdata('alert_error', trans('password_reset_token_expired'));
                 redirect($this->_get_safe_referer());
             }
 
             if (empty($user->user_passwordreset_token) || ! hash_equals((string) $user->user_passwordreset_token, (string) $this->input->post('token'))) {
-                $this->session->set_flashdata('alert_error', trans('loginalert_wrong_auth_code'));
+                $this->session->set_flashdata('alert_error', trans('password_reset_token_expired'));
                 redirect($this->_get_safe_referer());
             }
 


### PR DESCRIPTION
## Checklist
- [x] My code follows the code formatting guidelines.
- [x] I have tested my changes locally.
- [x] I selected the appropriate branch for this PR.
- [x] I have rebased my changes on top of the selected branch.
- [ ] I included relevant documentation updates if necessary.
- [ ] I have an accompanying issue ID for this pull request.

---

## Description
Harden the password-reset token expiry check in `Sessions::_reject_expired_password_reset_token()` to parse the stored expiry timestamp **strictly** before comparing it against the current time.

```diff
- $expiry_time  = new DateTime($user->user_passwordreset_token_expiry, self::$utc_timezone);
+ $expiry_time = DateTime::createFromFormat(
+     '!Y-m-d H:i:s',
+     (string) $user->user_passwordreset_token_expiry,
+     self::$utc_timezone
+ );
+ $parse_errors = DateTime::getLastErrors();
+ if (
+     $expiry_time === false
+     || ($parse_errors !== false
+         && ($parse_errors['warning_count'] > 0 || $parse_errors['error_count'] > 0))
+ ) {
+     throw new Exception('Invalid password reset token expiry');
+ }
  $current_time = new DateTime('now', self::$utc_timezone);
```

The thrown `Exception` is handled by the existing `catch` block in the same method, which clears the token and rejects the request — so a malformed expiry is treated as an invalid token rather than being silently accepted.

---

## Related Issue(s)
Follow-up hardening on the password-reset token expiry flow.

---

## Motivation and Context
`new DateTime()` throws for clearly malformed strings, but invalid `Y-m-d H:i:s` values such as `25:99:99` can still produce a valid `DateTime` object (with overflow rollover). That allows the password-reset flow to continue with a malformed but supposedly non-expired token. Using `DateTime::createFromFormat('!Y-m-d H:i:s', ...)` and rejecting both parser warnings and errors before the elapsed-time check closes that gap.

Verified locally:

| Input | Result |
|---|---|
| `2020-01-01 12:00:00` | accepted |
| `25:99:99` | rejected |
| `2020-13-40 00:00:00` | rejected |
| `not-a-date` | rejected |

---

## Issue Type (Check one or more)
- [x] Bugfix
- [ ] Improvement of an existing feature
- [ ] New feature

---

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved password reset security by strictly validating token expiration timestamps.
  - Invalid or malformed expiration values are rejected, cleared, and handled with an appropriate error redirect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password reset validation by rejecting incorrectly formatted or invalid expiration timestamps.
  * Applied consistent token and expiry validation to reset links and password-change submissions.
  * Standardized messaging for unknown, expired, malformed, or invalid reset tokens.
  * Invalid or expired reset tokens continue to be cleared and handled safely through redirection.
  * Password reset failures now provide a consistent, generic message without revealing token or account details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->