### PR TITLE
Display tax and Peppol identifiers in PDF templates

### DIFF
--- a/application/views/invoice_templates/pdf/InvoicePlane.php
+++ b/application/views/invoice_templates/pdf/InvoicePlane.php
@@ -60,7 +60,10 @@ if ($invoice->client_vat_id) {
     echo '<div>' . trans('vat_id_short') . ': ' . htmlsc($invoice->client_vat_id) . '</div>';
 }
 if ($invoice->client_tax_code) {
-    echo '<div>' . trans('tax_code_short') . ': ' . htmlsc($invoice->client_tax_code) . '</div>';
+    echo '<div>' . trans('tax_code') . ': ' . htmlsc($invoice->client_tax_code) . '</div>';
+}
+if ($invoice->client_peppol_id) {
+    echo '<div>' . trans('peppol_participant_id') . ': ' . htmlsc($invoice->client_peppol_id) . '</div>';
 }
 if ($invoice->client_address_1) {
     echo '<div>' . htmlsc($invoice->client_address_1) . '</div>';
@@ -106,7 +109,10 @@ if ($invoice->user_vat_id) {
     echo '<div>' . trans('vat_id_short') . ': ' . htmlsc($invoice->user_vat_id) . '</div>';
 }
 if ($invoice->user_tax_code) {
-    echo '<div>' . trans('tax_code_short') . ': ' . htmlsc($invoice->user_tax_code) . '</div>';
+    echo '<div>' . trans('tax_code') . ': ' . htmlsc($invoice->user_tax_code) . '</div>';
+}
+if ($invoice->user_einvoice_identifier) {
+    echo '<div>' . trans('peppol_participant_id') . ': ' . htmlsc($invoice->user_einvoice_identifier) . '</div>';
 }
 if ($invoice->user_address_1) {
     echo '<div>' . htmlsc($invoice->user_address_1) . '</div>';

--- a/application/views/quote_templates/pdf/InvoicePlane.php
+++ b/application/views/quote_templates/pdf/InvoicePlane.php
@@ -27,7 +27,10 @@ if ($quote->client_vat_id) {
     echo '<div>' . trans('vat_id_short') . ': ' . htmlsc($quote->client_vat_id) . '</div>';
 }
 if ($quote->client_tax_code) {
-    echo '<div>' . trans('tax_code_short') . ': ' . htmlsc($quote->client_tax_code) . '</div>';
+    echo '<div>' . trans('tax_code') . ': ' . htmlsc($quote->client_tax_code) . '</div>';
+}
+if ($quote->client_peppol_id) {
+    echo '<div>' . trans('peppol_participant_id') . ': ' . htmlsc($quote->client_peppol_id) . '</div>';
 }
 if ($quote->client_address_1) {
     echo '<div>' . htmlsc($quote->client_address_1) . '</div>';
@@ -72,7 +75,10 @@ if ($quote->user_vat_id) {
     echo '<div>' . trans('vat_id_short') . ': ' . htmlsc($quote->user_vat_id) . '</div>';
 }
 if ($quote->user_tax_code) {
-    echo '<div>' . trans('tax_code_short') . ': ' . htmlsc($quote->user_tax_code) . '</div>';
+    echo '<div>' . trans('tax_code') . ': ' . htmlsc($quote->user_tax_code) . '</div>';
+}
+if ($quote->user_einvoice_identifier) {
+    echo '<div>' . trans('peppol_participant_id') . ': ' . htmlsc($quote->user_einvoice_identifier) . '</div>';
 }
 if ($quote->user_address_1) {
     echo '<div>' . htmlsc($quote->user_address_1) . '</div>';


### PR DESCRIPTION
  # Pull Request Checklist

  ## Checklist
  - [x] My code follows the code formatting guidelines.
  - [x] I have tested my changes locally.
  - [ ] I selected the appropriate branch for this PR.
  - [ ] I have rebased my changes on top of the selected branch.
  - [x] I included relevant documentation updates if necessary.
  - [ ] I have an accompanying issue ID for this pull request.

  ---

  ## Description

  Updated the InvoicePlane PDF invoice and quote templates to:

  - Display the full `Tax Code` label.
  - Display the client's Peppol Participant ID when available.
  - Display the user's Peppol Participant ID when available.

  ---

  ## Motivation and Context

  The PDF invoice and quote templates previously used the shortened `Tax Code` translation and did not display Peppol identifiers.

  This change ensures that tax codes are labelled consistently and that Peppol Participant IDs are visible on generated PDF documents when configured.

  ---

  ## Issue Type (Check one or more)
  - [x] Bugfix
  - [x] Improvement of an existing feature
  - [ ] New feature

---

*Thank you for your contribution to InvoicePlane! We appreciate your time and effort.*
