### PR TITLE
Allow selecting service when copying documents

### DIFF
--- a/application/modules/invoices/controllers/Ajax.php
+++ b/application/modules/invoices/controllers/Ajax.php
@@ -310,6 +310,7 @@ class Ajax extends Admin_Controller
             'invoice_groups/mdl_invoice_groups',
             'tax_rates/mdl_tax_rates',
             'clients/mdl_clients',
+            'services/mdl_services',
         ]);
 
         $data = [
@@ -318,7 +319,13 @@ class Ajax extends Admin_Controller
             'invoice_id'     => $this->security->xss_clean($this->input->post('invoice_id')),
             'invoice'        => $this->mdl_invoices->where('ip_invoices.invoice_id', $this->security->xss_clean($this->input->post('invoice_id')))->get()->row(),
             'client'         => $this->mdl_clients->get_by_id($this->input->post('client_id')),
+            'service_id'     => $this->security->xss_clean($this->input->post('service_id')),
+            'services'       => $this->mdl_services->get()->result_array(),
         ];
+
+        if ($data['service_id'] === null || $data['service_id'] === '') {
+            $data['service_id'] = $data['invoice']->service_id;
+        }
 
         $this->layout->load_view('invoices/modal_copy_invoice', $data);
     }
@@ -341,7 +348,7 @@ class Ajax extends Admin_Controller
             $target_id = $this->mdl_invoices->save();
             $source_id = $this->security->xss_clean($this->input->post('invoice_id'));
 
-            $this->mdl_invoices->copy_invoice($source_id, $target_id);
+            $this->mdl_invoices->copy_invoice($source_id, $target_id, false, $this->security->xss_clean($this->input->post('service_id')));
 
             $response = [
                 'success'    => 1,

--- a/application/modules/invoices/models/Mdl_invoices.php
+++ b/application/modules/invoices/models/Mdl_invoices.php
@@ -280,7 +280,7 @@ class Mdl_Invoices extends Response_Model
      * @param int  $target_id
      * @param bool $copy_recurring_items_only
      */
-    public function copy_invoice($source_id, $target_id, $copy_recurring_items_only = false): void
+    public function copy_invoice($source_id, $target_id, $copy_recurring_items_only = false, $service_id = null): void
     {
         $this->load->model('invoices/mdl_items');
         $this->load->model('invoices/mdl_invoice_tax_rates');
@@ -292,7 +292,7 @@ class Mdl_Invoices extends Response_Model
             'percent'        => $invoice->invoice_discount_percent,
             'item'           => 0.0, // Updated by ref (Need for invoice_item_subtotal calculation in Mdl_invoice_amounts)
             'items_subtotal' => $this->mdl_items->get_items_subtotal($source_id),
-            'service'        => $invoice->service_id,
+            'service'        => $service_id ?? $invoice->service_id,
         ];
         unset($invoice); // Free memory
 

--- a/application/modules/invoices/views/modal_copy_invoice.php
+++ b/application/modules/invoices/views/modal_copy_invoice.php
@@ -15,6 +15,7 @@
                     legacy_calculation: legacy_calculation, // Automatic. From meta (see script)
                     invoice_id: <?php echo $invoice_id; ?>,
                     client_id: $('#client_id').val(),
+                    service_id: $('#copy_invoice_service_id').val(),
                     user_id: $('#user_id').val(),
                     invoice_date_created: $('#invoice_date_created_modal').val(),
                     invoice_group_id: $('#invoice_group_id').val(),
@@ -82,6 +83,25 @@
                     </span>
                 </div>
             </div>
+
+<?php if (get_setting('enable_services') == 1) : ?>
+            <div class="form-group has-feedback">
+                <label for="copy_invoice_service_id"><?php _trans('service'); ?></label>
+                <select name="service_id" id="copy_invoice_service_id" class="form-control simple-select" style="width: 100%;">
+                    <option value="0"><?php _trans('select_service'); ?></option>
+<?php foreach ($services as $service) : ?>
+<?php if ( ! empty($service['service_name'])) : ?>
+                    <option value="<?php echo html_escape($service['service_id']); ?>"
+                        <?php echo (int) $service['service_id'] === (int) $service_id ? 'selected' : ''; ?>>
+                        <?php echo html_escape($service['service_name']); ?>
+                    </option>
+<?php endif; ?>
+<?php endforeach; ?>
+                </select>
+            </div>
+<?php else : ?>
+            <input type="hidden" name="service_id" id="copy_invoice_service_id" value="0">
+<?php endif; ?>
 
             <div class="form-group">
                 <label for="invoice_password"><?php _trans('invoice_password'); ?></label>

--- a/application/modules/quotes/controllers/Ajax.php
+++ b/application/modules/quotes/controllers/Ajax.php
@@ -250,16 +250,21 @@ class Ajax extends Admin_Controller
         ]);
 
         $services = $this->mdl_services->get()->result_array();
+        $quote    = $this->mdl_quotes->where('ip_quotes.quote_id', $this->input->post('quote_id'))->get()->row();
 
         $data = [
             'invoice_groups' => $this->mdl_invoice_groups->get()->result(),
             'tax_rates'      => $this->mdl_tax_rates->get()->result(),
             'quote_id'       => $this->security->xss_clean($this->input->post('quote_id')),
-            'quote'          => $this->mdl_quotes->where('ip_quotes.quote_id', $this->input->post('quote_id'))->get()->row(),
+            'quote'          => $quote,
             'client'         => $this->mdl_clients->get_by_id($this->input->post('client_id')),
             'service_id'     => $this->security->xss_clean($this->input->post('service_id')),
             'services'       => $services,
         ];
+
+        if ($data['service_id'] === null || $data['service_id'] === '') {
+            $data['service_id'] = $quote->service_id;
+        }
 
         $this->layout->load_view('quotes/modal_copy_quote', $data);
     }
@@ -282,7 +287,7 @@ class Ajax extends Admin_Controller
             $target_id = $this->mdl_quotes->save();
             $source_id = $this->input->post('quote_id');
 
-            $this->mdl_quotes->copy_quote($source_id, $target_id);
+            $this->mdl_quotes->copy_quote($source_id, $target_id, $this->security->xss_clean($this->input->post('service_id')));
 
             $response = [
                 'success'  => 1,

--- a/application/modules/quotes/models/Mdl_quotes.php
+++ b/application/modules/quotes/models/Mdl_quotes.php
@@ -253,7 +253,7 @@ class Mdl_Quotes extends Response_Model
      * @param int $source_id
      * @param int $target_id
      */
-    public function copy_quote($source_id, $target_id)
+    public function copy_quote($source_id, $target_id, $service_id = null)
     {
         $this->load->model('quotes/mdl_quote_items');
 
@@ -264,7 +264,7 @@ class Mdl_Quotes extends Response_Model
             'percent'        => $quote->quote_discount_percent,
             'item'           => 0.0, // Updated by ref (Need for quote_item_subtotal calculation in Mdl_quote_amounts)
             'items_subtotal' => $this->mdl_quote_items->get_items_subtotal($source_id),
-            'service'        => $quote->service_id,
+            'service'        => $service_id ?? $quote->service_id,
         ];
         unset($quote); // Free memory
 

--- a/application/modules/quotes/views/modal_copy_quote.php
+++ b/application/modules/quotes/views/modal_copy_quote.php
@@ -15,6 +15,7 @@
                     legacy_calculation: legacy_calculation, // Automatic. From meta (see script)
                     quote_id: <?php echo $quote_id; ?>,
                     client_id: $('#client_id').val(),
+                    service_id: $('#copy_quote_service_id').val(),
                     user_id: $('#user_id').val(),
                     quote_date_created: $('#quote_date_created_modal').val(),
                     invoice_group_id: $('#invoice_group_id').val(),
@@ -78,6 +79,25 @@
                     </span>
                 </div>
             </div>
+
+<?php if (get_setting('enable_services') == 1) : ?>
+            <div class="form-group has-feedback">
+                <label for="copy_quote_service_id"><?php _trans('service'); ?></label>
+                <select name="service_id" id="copy_quote_service_id" class="form-control simple-select" style="width: 100%;">
+                    <option value="0"><?php _trans('select_service'); ?></option>
+<?php foreach ($services as $service) : ?>
+<?php if ( ! empty($service['service_name'])) : ?>
+                    <option value="<?php echo html_escape($service['service_id']); ?>"
+                        <?php echo (int) $service['service_id'] === (int) $service_id ? 'selected' : ''; ?>>
+                        <?php echo html_escape($service['service_name']); ?>
+                    </option>
+<?php endif; ?>
+<?php endforeach; ?>
+                </select>
+            </div>
+<?php else : ?>
+            <input type="hidden" name="service_id" id="copy_quote_service_id" value="0">
+<?php endif; ?>
 
             <div class="form-group">
                 <label for="invoice_group_id"><?php _trans('invoice_group'); ?></label>


### PR DESCRIPTION
  # Pull Request Checklist

  ## Checklist
  - [x] My code follows the code formatting guidelines.
  - [x] I have tested my changes locally.
  - [ ] I selected the appropriate branch for this PR.
  - [ ] I have rebased my changes on top of the selected branch.
  - [x] I included relevant documentation updates if necessary.
  - [ ] I have an accompanying issue ID for this pull request.

  ---

  ## Description

  Added service selection to the copy invoice and copy quote popups.

  The selected service is now correctly sent and saved when creating the copied document.

 
  ---

  ## Motivation and Context

  The copy invoice and copy quote popups did not allow users to select a service.

  The service field has been added to both popups, with the current service selected by default. The selected value is now preserved when the new invoice or quote is created.

  The service selector also uses a unique HTML identifier to avoid conflicts with the service field already present on the document page.

  ---

  ## Issue Type (Check one or more)
  - [x] Bugfix
  - [x] Improvement of an existing feature
  - [ ] New feature

---

*Thank you for your contribution to InvoicePlane! We appreciate your time and effort.*
