### PR TITLE
Verify template-LFI report as duplicate; credit @FelipeSilvany

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -18,6 +18,10 @@ record *why* and *how*.
 
 - **Horizontal privilege escalation via email takeover:** PR #1638 fixed password-change authorization (IDOR), but left the email field unprotected. A secondary administrator (`user_type=1`, `user_id != 1`) could edit the primary administrator's email address through the user form, then use password recovery to take over the account. `Users::form()` now validates that only the primary administrator can edit `user_id=1`, and `user_email` is added to `PROTECTED_FIELDS` (defense-in-depth). Thanks to [@0xMoError-22](https://github.com/0xMoError-22) for the responsible disclosure.
 
+### Duplicate reports (already remediated — no code change)
+
+- **Path traversal / LFI in invoice & quote template resolution (`pdf_template` / `guest_template`):** a report against `Mdl_templates.php` and the `generate_pdf` controllers was reviewed and confirmed **already fixed**. The `directory_map()` filesystem scan the report targets no longer exists — template lists come from the static `ALLOWED_INVOICE_TEMPLATES` / `ALLOWED_QUOTE_TEMPLATES` allowlists — and every request-supplied template name passes `validate_template_name()` (path-traversal rejection via `validate_safe_filename()`, strict static-allowlist membership, and an `^[a-zA-Z0-9_\- ]+$` character allowlist) at each sink: `validate_pdf_template()` in `Invoices`/`Quotes` (admin + guest) and again in `generate_invoice_pdf()` / `generate_quote_pdf()` "regardless of source", with `get_validated_template_path()` guarding the guest public view. A `../../../uploads/...` payload is rejected and falls back to the built-in `InvoicePlane` template. Original fixes: **LFI in PDF template handling** ([#1433](https://github.com/InvoicePlane/InvoicePlane/issues/1433), 1.7.0) and **RCE via template filesystem scan** ([GHSA-v735-2x3r-gwpp](https://github.com/InvoicePlane/InvoicePlane/security/advisories/GHSA-v735-2x3r-gwpp), 1.7.2). Thanks to [@FelipeSilvany](https://github.com/FelipeSilvany) for the responsible disclosure.
+
 ---
 
 ## [1.7.2] - 2026-07-17


### PR DESCRIPTION
## Verification result: **DUPLICATE — not exploitable on current code**

A report claims a path-traversal → LFI/RCE in `Mdl_templates.php` template
resolution via `pdf_template` / `guest_template`, with the sink
`$this->load->view('invoice_templates/pdf/' . $invoice_template, ...)` and the
discovery call `directory_map('./application/views/invoice_templates/pdf', 1)`.

### The quoted code no longer exists

- **`application/modules/invoices/models/Mdl_templates.php`** was rewritten. No
  `directory_map()`. `get_invoice_templates()` / `get_quote_templates()` return
  the hardcoded `ALLOWED_INVOICE_TEMPLATES` / `ALLOWED_QUOTE_TEMPLATES` static
  allowlists; the filesystem is never scanned. Custom templates come only from
  explicit `CUSTOM_*_TEMPLATES_*` ipconfig constants, each `preg_match`-validated.
- **No controller concatenates a raw parameter into a view path.** Every
  `generate_pdf` entrypoint the report names calls
  `validate_pdf_template($template, $type)` first:
  `invoices/controllers/Invoices.php:290`, `quotes/controllers/Quotes.php:238`,
  `guest/controllers/Invoices.php:134` (+`generate_sumex_pdf:158`),
  `guest/controllers/Quotes.php:133`.
- **The render sinks re-validate.** `pdf_helper.php` `generate_invoice_pdf()`
  (L88) and `generate_quote_pdf()` (L325) call `validate_template_name()`
  "regardless of source", falling back to the literal `'InvoicePlane'`.
- **Guest public view** (`guest/controllers/View.php`) uses
  `get_setting('public_invoice_template')` — not a request parameter — through
  `get_validated_template_path()`, which also runs `validate_file_in_directory()`.

### `validate_template_name()` already implements the report's own remediation

The report suggests `basename()` + `array_key_exists()` allowlist. Present, stricter:
Layer 2 `validate_safe_filename()` (rejects `../`, `..\`, null bytes, absolute
paths); Layer 6 `in_array($name, $static_whitelist, true)`; Layer 7
`preg_match('/^[a-zA-Z0-9_\- ]+$/', $name)`. Payload
`../../../../uploads/customer_files/shell` fails layers 2, 6 and 7 → replaced with
`InvoicePlane`.

### Prior art

- **[1.7.0] Security:** *"Critical — Local File Inclusion (LFI) in PDF template
  handling ([#1433]): invoice and quote template parameters are now validated
  before use, blocking directory traversal through template selection."*
- **[1.7.2]:** *"RCE via template filesystem scan"* —
  [GHSA-v735-2x3r-gwpp](https://github.com/InvoicePlane/InvoicePlane/security/advisories/GHSA-v735-2x3r-gwpp)
  (@Vijay-raghav7, #1505/#1506); `### Removed`: *"Dynamic filesystem scanning for
  template discovery — replaced with static allowlist constants."*

The report targets "v1.7.2 and prior", but v1.7.2 already ships both fixes.

## Change in this PR

CHANGELOG only — a "Duplicate reports (already remediated — no code change)"
note under `[1.7.3]` crediting [@FelipeSilvany](https://github.com/FelipeSilvany)
for the responsible disclosure. No source changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for previously addressed security protections, including template path traversal, local file inclusion, and static template allowlisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->