### PR TITLE
fix(security): atomic gateway payment recording — TOCTOU race in Stripe/PayPal callbacks

### DIFF
--- a/application/modules/guest/controllers/gateways/Paypal.php
+++ b/application/modules/guest/controllers/gateways/Paypal.php
@@ -224,7 +224,11 @@ class Paypal extends Base_Controller
                             // If the payment status is pending, set a note accordingly.
                             $payment_note = ($capture_status === 'PENDING') ? trans('online_payment_pending') : '';
 
-                            $this->mdl_payments->save(null, [
+                            // Record the payment atomically: the balance guard
+                            // and the insert are one conditional UPDATE, so a
+                            // concurrent capture with a different capture_id
+                            // cannot also pass a stale balance and double-credit.
+                            $recorded = $this->mdl_payments->record_external_payment([
                                 'invoice_id'          => $invoice_id,
                                 'payment_date'        => date('Y-m-d'),
                                 'payment_amount'      => $amount,
@@ -233,8 +237,13 @@ class Paypal extends Base_Controller
                                 'payment_external_id' => $capture_id,
                             ]);
 
-                            $this->session->set_flashdata('alert_success', sprintf(trans('online_payment_payment_successful'), htmlsc($invoice->invoice_number)));
+                            if ($recorded) {
+                                $this->session->set_flashdata('alert_success', sprintf(trans('online_payment_payment_successful'), htmlsc($invoice->invoice_number)));
+                            } else {
+                                $this->session->set_flashdata('alert_info', trans('online_payment_already_processed'));
+                            }
                             $this->session->keep_flashdata('alert_success');
+                            $this->session->keep_flashdata('alert_info');
                         }
                     }
                 }

--- a/application/modules/guest/controllers/gateways/Stripe.php
+++ b/application/modules/guest/controllers/gateways/Stripe.php
@@ -160,8 +160,11 @@ class Stripe extends Base_Controller
                         $paid     = false;
                         $user_msg = trans('online_payment_payment_failed');
                     } else {
-                        // Save the payment (visible in guest user)
-                        $this->mdl_payments->save(null, [
+                        // Record the payment atomically: the balance guard and
+                        // the insert are one conditional UPDATE, so a concurrent
+                        // callback with a different payment_intent cannot also
+                        // pass a stale balance and double-credit the invoice.
+                        $recorded = $this->mdl_payments->record_external_payment([
                             'invoice_id'          => $invoice->invoice_id,
                             'payment_date'        => date('Y-m-d'),
                             'payment_amount'      => $capture_amount,
@@ -169,6 +172,11 @@ class Stripe extends Base_Controller
                             'payment_note'        => trans('online_payment_intent_id') . ': ' . $payment_intent,
                             'payment_external_id' => $payment_intent,
                         ]);
+
+                        if ( ! $recorded) {
+                            $paid     = false;
+                            $user_msg = trans('online_payment_already_processed');
+                        }
                     }
                 }
             }

--- a/application/modules/payments/models/Mdl_payments.php
+++ b/application/modules/payments/models/Mdl_payments.php
@@ -117,6 +117,89 @@ class Mdl_Payments extends Response_Model
     }
 
     /**
+     * Atomically record a payment received from an online gateway callback.
+     *
+     * The "is there still a balance owed" check and the payment insert must be
+     * a single atomic operation. Two concurrent gateway callbacks for the same
+     * invoice carrying distinct external references (so idx_payment_external_id
+     * does not catch them) would otherwise both pass a separate balance check
+     * and both insert, over-crediting the invoice and driving the balance
+     * negative (CWE-362 / CWE-367).
+     *
+     * A single conditional UPDATE on ip_invoice_amounts is the gate: InnoDB
+     * serialises it, so the second caller sees a balance that is no longer
+     * outstanding and is refused before it can insert. calculate() then
+     * reconciles the stored figures from the real payment rows.
+     *
+     * @param array $db_array invoice_id, payment_date, payment_amount,
+     *                        payment_method_id, payment_note, payment_external_id
+     *
+     * @return bool true when the payment was recorded; false when the invoice
+     *              balance no longer covered it (already paid or a concurrent
+     *              callback won) or the external id was a replay
+     */
+    public function record_external_payment(array $db_array): bool
+    {
+        $this->load->model('invoices/mdl_invoice_amounts');
+
+        $invoice_id  = (int) $db_array['invoice_id'];
+        $amount      = (float) standardize_amount($db_array['payment_amount']);
+        $external_id = isset($db_array['payment_external_id']) && $db_array['payment_external_id'] !== ''
+            ? (string) $db_array['payment_external_id']
+            : null;
+
+        // Atomic gate: claim the outstanding balance in one statement.
+        $this->db->set('invoice_paid', sprintf('invoice_paid + %F', $amount), false);
+        $this->db->set('invoice_balance', sprintf('invoice_balance - %F', $amount), false);
+        $this->db->where('invoice_id', $invoice_id);
+        $this->db->where('invoice_balance >', 0);
+        $this->db->update('ip_invoice_amounts');
+
+        if ($this->db->affected_rows() < 1) {
+            log_message('warning', __CLASS__ . '::' . __FUNCTION__ . ' - Refused gateway payment for invoice ' . sanitize_for_logging($invoice_id) . ': balance no longer outstanding (concurrent callback or already paid).');
+
+            return false;
+        }
+
+        // Claim held. Insert the payment; INSERT IGNORE so an external id that
+        // raced past a wider balance is dropped by idx_payment_external_id
+        // rather than raising a duplicate-key error.
+        $this->db->set([
+            'invoice_id'          => $invoice_id,
+            'payment_date'        => date_to_mysql($db_array['payment_date']),
+            'payment_amount'      => $amount,
+            'payment_method_id'   => $db_array['payment_method_id'] ?: 0,
+            'payment_note'        => (string) ($db_array['payment_note'] ?? ''),
+            'payment_external_id' => $external_id,
+        ]);
+        $insert_sql = preg_replace('/^INSERT INTO/i', 'INSERT IGNORE INTO', $this->db->get_compiled_insert('ip_payments'), 1);
+        $this->db->query($insert_sql);
+        $recorded = $this->db->affected_rows() > 0;
+
+        if ( ! $recorded) {
+            log_message('warning', __CLASS__ . '::' . __FUNCTION__ . ' - Duplicate external payment id for invoice ' . sanitize_for_logging($invoice_id) . '; gate claim rolled back by recalculation.');
+        }
+
+        // calculate() recomputes invoice_paid = SUM(payment_amount) and the
+        // balance from the real rows, correcting the gate arithmetic whether
+        // the insert landed or was ignored.
+        $global_discount['item'] = $this->mdl_invoice_amounts->get_global_discount($invoice_id);
+        $this->mdl_invoice_amounts->calculate($invoice_id, $global_discount);
+
+        $amounts = $this->db->where('invoice_id', $invoice_id)->get('ip_invoice_amounts')->row();
+
+        if ($amounts !== null && (float) $amounts->invoice_paid >= (float) $amounts->invoice_total) {
+            $this->db->where('invoice_id', $invoice_id);
+            $this->db->set('invoice_status_id', 4);
+            $this->db->update('ip_invoices');
+
+            $this->mdl_invoice_amounts->calculate($invoice_id, $global_discount);
+        }
+
+        return $recorded;
+    }
+
+    /**
      * @return bool|int|null
      */
     public function save($id = null, $db_array = null)

--- a/application/modules/setup/sql/044_1.7.3.sql
+++ b/application/modules/setup/sql/044_1.7.3.sql
@@ -1,4 +1,27 @@
--- Add payment_external_id column for gateway deduplication (Stripe/PayPal callbacks)
+-- Add payment_external_id for gateway deduplication (Stripe/PayPal callbacks).
+--
+-- The index is UNIQUE: Mdl_Payments::record_external_payment() relies on the
+-- database itself rejecting a duplicate external reference, so two concurrent
+-- callbacks cannot both record a payment for the same invoice. A NULL value
+-- (every manually entered payment) is exempt — MariaDB/MySQL allow unlimited
+-- NULLs in a UNIQUE index.
 
-ALTER TABLE `ip_payments` ADD COLUMN `payment_external_id` VARCHAR(255) NULL AFTER `payment_id`;
-ALTER TABLE `ip_payments` ADD INDEX `idx_payment_external_id` (`payment_external_id`);
+ALTER TABLE `ip_payments`
+    ADD COLUMN `payment_external_id` VARCHAR(255) NULL AFTER `payment_id`;
+
+-- If duplicate gateway payments were recorded before the index was made unique,
+-- keep the earliest row's reference intact and suffix the others with
+-- "-dup<payment_id>" so ADD UNIQUE INDEX cannot fail. No rows are deleted: the
+-- payment history is preserved and the renamed rows stay greppable for an
+-- operator to reconcile. NULLs are untouched; on a fresh install this matches
+-- nothing. Gateway references (Stripe payment_intent, PayPal capture id) are far
+-- shorter than 255, so the suffix never overflows the column.
+UPDATE `ip_payments` AS `dup`
+INNER JOIN `ip_payments` AS `keep`
+        ON `dup`.`payment_external_id` = `keep`.`payment_external_id`
+       AND `dup`.`payment_external_id` IS NOT NULL
+       AND `dup`.`payment_id` > `keep`.`payment_id`
+   SET `dup`.`payment_external_id` = CONCAT(`dup`.`payment_external_id`, '-dup', `dup`.`payment_id`);
+
+ALTER TABLE `ip_payments`
+    ADD UNIQUE INDEX `idx_payment_external_id` (`payment_external_id`);


### PR DESCRIPTION
## Summary

The guest Stripe (`callback`) and PayPal (`paypal_capture_payment`) endpoints record an
online payment in three separate, non-atomic steps: read `invoice_balance` → check it →
`INSERT` into `ip_payments` (followed by `Mdl_invoice_amounts::calculate()`).

Two callbacks that arrive **concurrently** for the same invoice, each carrying a **distinct**
gateway reference (distinct `payment_intent` / `capture_id`, so the `payment_external_id`
dedup added in #1496 matches neither), both pass the balance check before either commits.
Both then insert — recording two payments against one balance, marking the invoice paid, and
leaving `invoice_balance` negative.

- **Type:** TOCTOU race condition — CWE-362 / CWE-367
- **Access:** unauthenticated (the guest callback endpoints); needs two genuinely-paid
  gateway orders for the same invoice plus concurrent timing
- **Impact:** accounting integrity / double-credit; recoverable by the operator issuing a
  refund, no fund theft from third parties

This is the concurrent variant of the duplicate-payment issue behind #1496
([GHSA-6cpc-hr8h-xgr2](https://github.com/InvoicePlane/InvoicePlane/security/advisories/GHSA-6cpc-hr8h-xgr2)).
#1496 stops the *same* reference being replayed; it does not stop two *distinct* references
racing, and the `payment_external_id` index it relies on was added non-unique, so it does not
enforce dedup at the database level either.

## Changes

### `chore(setup): make payment_external_id unique (repair 044_1.7.3.sql)`

`044_1.7.3.sql` originally added `payment_external_id` with a plain, non-unique `INDEX`.
Since the column is new in that same migration and 1.7.3 is unreleased, the migration is
repaired in place rather than shipping a follow-up:

- the index is now `UNIQUE`, so the atomic path below can rely on the database rejecting a
  duplicate external reference;
- if any duplicate gateway payments were recorded during the non-unique window, the earliest
  row keeps its reference and the others are suffixed with `-dup<payment_id>` so `ADD UNIQUE
  INDEX` cannot fail. **No rows are deleted** — the payment history is preserved and the
  renamed rows stay greppable for an operator to reconcile. `NULL` rows (every manually
  entered payment) are untouched; on a fresh install it matches nothing.

`NULL` stays exempt: MariaDB/MySQL permit unlimited `NULL`s in a `UNIQUE` index, so the
payment form is unchanged.

### `fix(security): make gateway-callback payment recording atomic` — `Mdl_Payments::record_external_payment()`

Collapses the guard and the insert into one atomic operation:

- a single conditional
  `UPDATE ip_invoice_amounts SET invoice_paid = invoice_paid + :amt,
   invoice_balance = invoice_balance - :amt
   WHERE invoice_id = :id AND invoice_balance > 0` — InnoDB serialises it on the amounts row,
  so a second concurrent caller sees `invoice_balance <= 0`, gets `affected_rows() == 0`, and
  is refused before it can insert;
- the payment row then goes in as `INSERT IGNORE`, so an external id that raced past a wider
  balance is dropped by the unique `idx_payment_external_id` rather than raising a
  duplicate-key error;
- `Mdl_invoice_amounts::calculate()` then reconciles `invoice_paid` / `invoice_balance` /
  status from the real payment rows — the `UPDATE` arithmetic is only the lock.

Both callbacks now call `record_external_payment()` instead of `mdl_payments->save(null, …)`
and surface `online_payment_already_processed` when it returns `false`. Existing
single-payment, currency-mismatch, amount-short and already-paid behaviour is unchanged.

## Testing

`develop` has no PHPUnit harness, so no tests are included in this PR. The change was
developed test-first on a branch that does have one: a regression suite fires the two
callbacks as genuinely parallel request subprocesses over 8 rounds and asserts, each round,
at most one payment per invoice, `invoice_balance >= 0`, and `invoice_paid <= invoice_total`.

- pre-fix: the two distinct-reference race tests fail (2 payment rows recorded)
- post-fix: all pass; same-reference concurrent replay and a legitimate single full payment
  stay green

The repaired `044_1.7.3.sql` was verified against a scratch database seeded with triple and
double duplicates plus `NULL`s: all rows survive, the earliest reference per group is kept,
the rest become `<ref>-dup<id>`, `NULL`s are untouched, and the rebuilt index reports
`Non_unique = 0`.
